### PR TITLE
Use cookies to persist bandwidth usage page settings

### DIFF
--- a/package/gargoyle/files/etc/config/gargoyle
+++ b/package/gargoyle/files/etc/config/gargoyle
@@ -104,10 +104,10 @@ config 400 system
 config 500 logout
 
 config bandwidth_display bandwidth_display
-	option time_frame "15m"
-	option plot1_type "total"
-	option plot2_type "none"
-	option plot3_type "none"
+#	option time_frame "15m"
+#	option plot1_type "total"
+#	option plot2_type "none"
+#	option plot3_type "none"
 
 config help help
 	option ddns_1		1


### PR DESCRIPTION
Browser cookies seem to be more conventional place to store client-side presentation configuration. It saves flash write cycles (not a big concern, of course) and allows different clients to have different config.
