### PR TITLE
connbytes_kb, connbytes successor.

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/restore.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/restore.sh
@@ -149,6 +149,14 @@ if [ -n "$quotas_active" ] ; then
 else
 	uci del gargoyle.status.quotause 2>/dev/null
 fi
+
+for qos_gargoyle_connbytes_rule in $(uci show qos_gargoyle | sed "/^qos_gargoyle\..*\.connbytes=[0-9]*$/!d; s#=.*##g"); do
+	connbytes_value="$(uci get ${qos_gargoyle_connbytes_rule})"
+	connbytes_kb_value="$(( ${connbytes_value} * 1024 ))"
+	uci set ${qos_gargoyle_connbytes_rule}_kb=${connbytes_kb_value}
+	uci del ${qos_gargoyle_connbytes_rule}
+done; unset qos_gargoyle_connbytes_rule
+
 uci commit
 
 #deal with firewall include file path being swapped

--- a/package/gargoyle/files/www/js/qos.js
+++ b/package/gargoyle/files/www/js/qos.js
@@ -165,7 +165,7 @@ function saveChanges()
 			uci.set("qos_gargoyle", ruleId, "class", classId);
 			uci.set("qos_gargoyle", ruleId, "test_order", rulePriority);
 
-			optionList = ["source", "srcport", "destination", "dstport", "max_pkt_size","min_pkt_size",  "proto", "connbytes"];
+			optionList = ["source", "srcport", "destination", "dstport", "max_pkt_size","min_pkt_size",  "proto", "connbytes_kb"];
 
 			matchCriteria = parseRuleMatchCriteria(ruleData[ruleIndex][0]);
 			for(criteriaIndex = 0; criteriaIndex < optionList.length; criteriaIndex++)
@@ -411,8 +411,8 @@ function resetData()
 		rulePriorities.push(rulePriority + "," + ruleIndex);
 
 
-		optionList = ["source", "srcport", "destination", "dstport", "max_pkt_size", "min_pkt_size", "proto", "connbytes"];
-		displayOptionList = ["Source: $", "Source Port: $", "Destination: $", "Destination Port: $", "Maximum Packet Length: $ bytes", "Minimum Packet Length: $ bytes", "Transport Protocol: $", "Connection bytes: $ MBytes"];
+		optionList = ["source", "srcport", "destination", "dstport", "max_pkt_size", "min_pkt_size", "proto", "connbytes_kb"];
+		displayOptionList = ["Source: $", "Source Port: $", "Destination: $", "Destination Port: $", "Maximum Packet Length: $ bytes", "Minimum Packet Length: $ bytes", "Transport Protocol: $", "Connection bytes: $ kBytes"];
 
 		ruleText = "";
 		for (optionIndex = 0; optionIndex < optionList.length; optionIndex++)
@@ -532,7 +532,7 @@ function qosQuotasExist()
 function setQosEnabled()
 {
 	enabled = document.getElementById("qos_enabled").checked;
-	controlIds = ["default_class", "source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes", "app_protocol", "use_source_ip", "use_source_port", "use_dest_ip", "use_dest_port", "use_max_pktsize", "use_min_pktsize", "use_transport_protocol", "use_connbytes", "use_app_protocol", "classification", "add_rule_button", "class_name", "percent_bandwidth", "min_radio1", "min_radio2", "min_bandwidth", "max_radio1", "max_radio2", "max_bandwidth", "add_class_button"];
+	controlIds = ["default_class", "source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes_kb", "app_protocol", "use_source_ip", "use_source_port", "use_dest_ip", "use_dest_port", "use_max_pktsize", "use_min_pktsize", "use_transport_protocol", "use_connbytes_kb", "use_app_protocol", "classification", "add_rule_button", "class_name", "percent_bandwidth", "min_radio1", "min_radio2", "min_bandwidth", "max_radio1", "max_radio2", "max_bandwidth", "add_class_button"];
 
 	setElementEnabled( document.getElementById("total_bandwidth"), enabled, uciOriginal.get("qos_gargoyle", direction, "total_bandwidth") );
 	for(controlIndex = 0; controlIndex < controlIds.length; controlIndex++)
@@ -572,8 +572,8 @@ function addClassificationRule()
 	else
 	{
 
-		addRuleMatchControls = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes", "app_protocol"];
-		displayList = ["Source: $", "Source Port: $", "Destination: $", "Destination Port: $","Maximum Packet Length: $ bytes", "Minimum Packet Length: $ bytes", "Transport Protocol: $", "Connection bytes: $ MBytes", "Application Protocol: $"];
+		addRuleMatchControls = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes_kb", "app_protocol"];
+		displayList = ["Source: $", "Source Port: $", "Destination: $", "Destination Port: $","Maximum Packet Length: $ bytes", "Minimum Packet Length: $ bytes", "Transport Protocol: $", "Connection bytes: $ kBytes", "Application Protocol: $"];
 
 		ruleText = ""
 		for (controlIndex = 0; controlIndex <addRuleMatchControls.length; controlIndex++)
@@ -606,7 +606,7 @@ function addClassificationRule()
 
 function proofreadClassificationRule(controlDocument)
 {
-	addRuleIds = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes", "app_protocol"];
+	addRuleIds = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes_kb", "app_protocol"];
 	validatePktSize = function(text){ return validateNumericRange(text, 1, 1500); };
 	validateCBSize = function(text){ return validateNumericRange(text, 0, 4194393); };
 	alwaysValid = function(text){return 0;};
@@ -634,7 +634,7 @@ function proofreadClassificationRule(controlDocument)
 
 function resetRuleControls()
 {
-	ruleControlIds = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol","connbytes", "app_protocol"];
+	ruleControlIds = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol","connbytes_kb", "app_protocol"];
 	document.getElementById("classification").selectedIndex = document.getElementById("default_class").selectedIndex;
 
 	for(ruleControlIndex=0; ruleControlIndex < ruleControlIds.length; ruleControlIndex++)
@@ -846,7 +846,7 @@ function editRuleTableRow()
 					addOptionToSelectElement("classification", serviceClassOptions[classIndex].text, serviceClassOptions[classIndex].text, null, editRuleWindow.document);
 				}
 
-				ruleControlIds = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes", "app_protocol"];
+				ruleControlIds = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes_kb", "app_protocol"];
 
 				criteria = parseRuleMatchCriteria(editRuleWindowRow.firstChild.firstChild.data);
 				for(ruleControlIndex=0; ruleControlIndex < ruleControlIds.length; ruleControlIndex++)
@@ -894,8 +894,8 @@ function editRuleTableRow()
 					}
 					else
 					{
-						addRuleMatchControls = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes", "app_protocol"];
-						displayList = ["Source: $", "Source Port: $", "Destination: $", "Destination Port: $",  "Maximum Packet Length: $ bytes", "Minimum Packet Length: $ bytes","Transport Protocol: $", "Connection bytes: $ MBytes", "Application Protocol: $"];
+						addRuleMatchControls = ["source_ip", "source_port", "dest_ip", "dest_port", "max_pktsize", "min_pktsize", "transport_protocol", "connbytes_kb", "app_protocol"];
+						displayList = ["Source: $", "Source Port: $", "Destination: $", "Destination Port: $",  "Maximum Packet Length: $ bytes", "Minimum Packet Length: $ bytes","Transport Protocol: $", "Connection bytes: $ kBytes", "Application Protocol: $"];
 						ruleText = ""
 						for (controlIndex = 0; controlIndex <addRuleMatchControls.length; controlIndex++)
 						{
@@ -1140,7 +1140,7 @@ function parseRuleMatchCriteria(matchText)
 	splitText = matchText.split(/[\t ]*,[\t ]*/);
 	criteria = [];
 
-	possibleCriteria = ["Source: (.*)", "Source Port: (.*)", "Destination: (.*)", "Destination Port: (.*)", "Maximum Packet Length: (.*) bytes", "Minimum Packet Length: (.*) bytes",  "Transport Protocol: (.*)", "Connection bytes: (.*) MBytes", "Application Protocol: (.*)"];
+	possibleCriteria = ["Source: (.*)", "Source Port: (.*)", "Destination: (.*)", "Destination Port: (.*)", "Maximum Packet Length: (.*) bytes", "Minimum Packet Length: (.*) bytes",  "Transport Protocol: (.*)", "Connection bytes: (.*) kBytes", "Application Protocol: (.*)"];
 
 	for(possibleCriteriaIndex=0; possibleCriteriaIndex < possibleCriteria.length; possibleCriteriaIndex++)
 	{

--- a/package/gargoyle/files/www/qos_download.sh
+++ b/package/gargoyle/files/www/qos_download.sh
@@ -150,11 +150,11 @@
 
 			<div>
 				<div class='leftcolumn'>
-					<input type='checkbox'  id='use_connbytes' onclick='enableAssociatedField(this,"connbytes", "")'  />
-					<label id="connbytes_label" for='connbytes'>Connection bytes reach:</label>
+					<input type='checkbox'  id='use_connbytes_kb' onclick='enableAssociatedField(this,"connbytes_kb", "")'  />
+					<label id="connbytes_kb_label" for='connbytes_kb'>Connection bytes reach:</label>
 				</div>
-				<input class='rightcolumn' type='text' id='connbytes' onkeyup='proofreadNumericRange(this,0,4194303)' size='17' maxlength='7' />
-				<em>MBytes</em>
+				<input class='rightcolumn' type='text' id='connbytes_kb' onkeyup='proofreadNumericRange(this,0,4194303)' size='17' maxlength='28' />
+				<em>kBytes</em>
 			</div>
 
 			<div>

--- a/package/gargoyle/files/www/qos_edit_rule.sh
+++ b/package/gargoyle/files/www/qos_edit_rule.sh
@@ -70,11 +70,11 @@
 	</div>
 	<div>
 		<div class='leftcolumn'>
-			<input type='checkbox'  id='use_connbytes' onclick='enableAssociatedField(this,"connbytes", "")'  />
-			<label id="connbytes_label" for='connbytes'>Connection bytes reach:</label>
+			<input type='checkbox'  id='use_connbytes_kb' onclick='enableAssociatedField(this,"connbytes_kb", "")'  />
+			<label id="connbytes_kb_label" for='connbytes_kb'>Connection bytes reach:</label>
 		</div>
-		<input class='rightcolumn' type='text' id='connbytes' onkeyup='proofreadNumeric(this)' size='17' maxlength='7' />
-		<em>MB</em>
+		<input class='rightcolumn' type='text' id='connbytes_kb' onkeyup='proofreadNumeric(this)' size='17' maxlength='28' />
+		<em>kBytes</em>
 	</div>
 	<div>
 		<div class='leftcolumn'>

--- a/package/gargoyle/files/www/qos_upload.sh
+++ b/package/gargoyle/files/www/qos_upload.sh
@@ -151,11 +151,11 @@
 
 			<div>
 				<div class='leftcolumn'>
-					<input type='checkbox'  id='use_connbytes' onclick='enableAssociatedField(this,"connbytes", "")'  />
-					<label id="connbytes_label" for='connbytes'>Connection bytes reach:</label>
+					<input type='checkbox'  id='use_connbytes_kb' onclick='enableAssociatedField(this,"connbytes_kb", "")'  />
+					<label id="connbytes_kb_label" for='connbytes_kb'>Connection bytes reach:</label>
 				</div>
-				<input class='rightcolumn' type='text' id='connbytes' onkeyup='proofreadNumericRange(this,0,4194303)' size='17' maxlength='7' />
-				<em>MBytes</em>
+				<input class='rightcolumn' type='text' id='connbytes_kb' onkeyup='proofreadNumericRange(this,0,4194303)' size='17' maxlength='28' />
+				<em>kBytes</em>
 			</div>
 
 			<div>

--- a/package/qos-gargoyle/files/qos_gargoyle.init
+++ b/package/qos-gargoyle/files/qos_gargoyle.init
@@ -47,8 +47,8 @@ load_all_config_options()
 		fi
 	}
 
-
 	config_load "$config_name"
+
 	for var in $ALL_OPTION_VARIABLES
 	do
 		config_get "$var" "$section_id" "$var"
@@ -150,6 +150,7 @@ apply_all_rules()
 		load_all_config_options "$config_file_name" "$rule"
 
 		for option in $ALL_OPTION_VARIABLES ; do
+
 			option_value=$(eval echo \$$option)
 			case "$option" in
 				source)
@@ -188,8 +189,8 @@ apply_all_rules()
 						match_str="$match_str -m layer7 --l7proto $option_value"
 					fi
 				;;
-				connbytes)
-					match_str="$match_str -m connbytes --connbytes $(($option_value*1048576)): --connbytes-dir both --connbytes-mode bytes"
+				connbytes_kb)
+					match_str="$match_str -m connbytes --connbytes $(($option_value*1024)): --connbytes-dir both --connbytes-mode bytes"
 				;;
 			esac
 		done


### PR DESCRIPTION
From now on you can use kilobytes instead of megabytes for 'Connection bytes' option. Much more fixable.
There is a hook in restore.sh to convert old 'connbytes' to new 'connbytes_kb'. Tested, work.

Because this is change in core of how QoS works I think it shouldn't hit 1.4 line.
