### PR TITLE
sed fix.

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/libgargoylehelper.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/libgargoylehelper.sh
@@ -18,7 +18,7 @@ service_enabled() {
 
 	if [ -f "/etc/init.d/$1" ]; then
 		# Get number of the first START= from initscript.
-		start_num="$(sed -r '1,/RE/{/^START=[0-9]+$/!d;}; s#START=##g' "/etc/init.d/$1")"
+		start_num="$(sed -r '/^START=[0-9]+$/!d; s#START=##g' "/etc/init.d/$1")"
 		if [ -s "/etc/rc.d/S${start_num}$1" ]; then
 			return 0
 		else


### PR DESCRIPTION
Simplification of sed to detect start_num. It supposed to print only first match but it does print first match and rest of file. Good that this changes only hit 1.5 branch which intend to be experimental one. 

The simpler sed will work unless someone will put another START variable in init file which shoudn't ever happen.
