### PR TITLE
General usb_storage code simplification and fixes.

### DIFF
--- a/package/plugin-gargoyle-usb-storage/files/etc/init.d/usb_storage
+++ b/package/plugin-gargoyle-usb-storage/files/etc/init.d/usb_storage
@@ -89,15 +89,20 @@ do_start()
 			'Linux swap')
 				swapon "$d"
 			;;
-			'Ext4')
+			'Ext4'|'Ext3')
+				# disktype misdetect ext4 as ext3. Try mount as ext3 first then fallback to ext4.
+				# in some circumstances ext3 may be mounted as ext4 but if you write anything to it
+				# the filesystem will be no longer compatible with ext3.
 				mkdir -p "/tmp/usb_mount/$id"
-				umount "/tmp/usb_mount/$id" 2>/dev/null
-				mount -t ext4 -o noatime "$d" "/tmp/usb_mount/$id" || umount "/tmp/usb_mount/$id" 2> /dev/null
-			;;
-			'Ext3')
-				mkdir -p "/tmp/usb_mount/$id"
-				umount "/tmp/usb_mount/$id" 2>/dev/null
-				mount -t ext3 -o noatime "$d" "/tmp/usb_mount/$id" || umount "/tmp/usb_mount/$id" 2> /dev/null
+				umount "/tmp/usb_mount/$id" 2>/dev/null					
+				if mount -t ext3 -o noatime "$d" "/tmp/usb_mount/$id"; then
+					type='ext3'
+				elif mount -t ext4 -o noatime "$d" "/tmp/usb_mount/$id"; then
+					type='ext4'
+				else
+					# Something went wrong.
+					umount "/tmp/usb_mount/$id"
+				fi
 			;;
 			'Ext2')
 				mkdir -p "/tmp/usb_mount/$id"


### PR DESCRIPTION
With old code I was not able mount ext2 pendrive, the vfat was working so I started to reworking it the way I understand how it should work.

Trying to going the $err loginc, if mount failed, the umount will be executed but to be honest I think if mount failed the device will be not mounted.

The swapoff code now will only swapoff devices what match string /dev/sd*. So if you use zram (/dev/zram0 for example, or /dev/ramzswap0 in older versions) you will be safe, as we use /proc/swaps as a list.

The 'chmod 777' part was removed. There is no point in changing permissions of mountpoint before mount as the permissions after mount will be the one from filesystem (usualy 777 for vfat/ntfs and the permissions of root of the ext2/3/4).

The code is tested in many ways I did not however tested the cifs/nfs shares, they shound't be affected by the changes I made.

also I think the usb-storage page could use 'stop' or 'umount' button. If you have swap on pendrive, you have to be sure that it is off before you remove it or propably the system will crash in one way or another.
