### PR TITLE
Proper and strict sed to ensure that we extract UUID even in presence of LABEL.

### DIFF
--- a/package/plugin-gargoyle-usb-storage/files/etc/init.d/usb_storage
+++ b/package/plugin-gargoyle-usb-storage/files/etc/init.d/usb_storage
@@ -53,7 +53,7 @@ do_start()
 		uci commit
 	fi
 
-	drives="$(blkid | sed -r 's#"##g; s#:[[:blank:]]+UUID=#:#g')"
+	drives="$(blkid | sed -r 's#^/dev/(.+):.+UUID="([^"]+).+"#/dev/\1:\2#g')"
 	
 	echo "$drives" >/tmp/drives_found.txt
 	date >>/tmp/drives_found.txt


### PR DESCRIPTION
The bug was found by Obsy, the updated sed should do things right, even if the LABEL will be printed after UUID still the script will be all right.
