### PR TITLE
Change permission on original directory.

### DIFF
--- a/package/vsftpd/files/vsftpd.init
+++ b/package/vsftpd/files/vsftpd.init
@@ -127,7 +127,7 @@ mount_share_dir()
 	
 	found_share="1"
 	mkdir -p "$ftp_root/$share_name"  >/dev/null 2>&1
-	chmod 777 "$ftp_root/$share_name" >/dev/null 2>&1
+	chmod 777 "$share_dir" >/dev/null 2>&1
 
 
 	chown "$username"  "$ftp_root/$share_name" >/dev/null 2>&1


### PR DESCRIPTION
Without this, after mount/bind share still has permission from original directory. (755/root.root), so it is impossible to write something in directory.
