### PR TITLE
openvpn: fix arithmetic syntax error

### DIFF
--- a/package/plugin-gargoyle-openvpn/files/usr/lib/gargoyle/openvpn.sh
+++ b/package/plugin-gargoyle-openvpn/files/usr/lib/gargoyle/openvpn.sh
@@ -48,7 +48,7 @@ EXPIRATION_MAX=99999
 if [ "$TIME_BITS" -lt 64 ] ; then
 	#handle 2038 bug the best we can
 	year=$(date +%Y)
-	year_day=$(date +%j)
+	year_day=$(date +%j | awk '{printf "%d", $1}')
 	EXPIRATION_MAX=$(( (365*(2038-$year)) - $year_day  ))
 fi
 


### PR DESCRIPTION
Today: 2013-01-18

date +%j = 018

-ash: /usr/lib/gargoyle/openvpn.sh: line 53: arithmetic syntax error

echo $(( (365*(2038-2013)) - 018  )) <- wrong number

Should be 18 not 018
