### PR TITLE
Changed cloudflare.com service regexp

### DIFF
--- a/package/ddns-gargoyle/files/etc/ddns_providers.conf
+++ b/package/ddns-gargoyle/files/etc/ddns_providers.conf
@@ -141,4 +141,4 @@ service cloudflare.com
 	url_template			https://www.cloudflare.com/api.html?a=DIUP&hosts=[[DOMAIN]]&email=[[EMAIL]]&tkn=[[KEY]]&ip=[[IP]]
 	required_variables 		domain email key
 	required_variable_names		Domain Name, Email, API Key
-	success_regexp			/(OK|E_NOUPDATE)$/
+	success_regexp			/(OK|E_NOUPDATE)/


### PR DESCRIPTION
Gargoyle updates OK a domain set in Cloudflare.com but it doesn't
refresh "Last Update" value when dollar sign ($) anchor is used in
regexp.
