### PR TITLE
Gargoyle wifi-schedule plugin 1.1

### DIFF
--- a/package/plugin-gargoyle-wifi-schedule/README.txt
+++ b/package/plugin-gargoyle-wifi-schedule/README.txt
@@ -1,0 +1,34 @@
+/*
+TODO:
+• handle (not currently used, but some user might manually edit) crontabs with   * / 2   1,2,3,4,5   1-4,5 hours or days
+
+ENHANCEMENTS:
+A disclosure triangle to show actual crontabs - I don't think is needed.
+  It would just confuse new users when the summary presents a natural language representation of the crontabs.
+*/
+
+/* in this table:
+	+minutes represent an hour where wifi is up UNTIL that minute, where it goes down for the remainder of the hour
+	-minutes represent an hour where wifi is down UNTIL that minute, where it goes up for the remainder of the hour
+	 (- for when the hour starts wifi-off and some minutes later turns on)
+	 (+ for when the hour starts wifi-on and some minutes later turns on)
+	
+	all tables *display* positive minutes, but their .value may be positive or negative or 0 (fully off for the hour) or 60 (fully on)
+	an hour can only have negative minutes coming after an hour that was off (meaning this hour will go up) OR
+	 or after an hour that has positive minutes (@12:+05 goes down, up @ 13:-45)
+	
+	an hour can only have positive minutes coming after an hour that was on (meaning this hour will go down at some minutes) OR
+	 or after an hour that has positive minutes (was up at 23:+05, down @ 00:-55)
+*/
+
+/* version history
+v1.0 	initial release
+v1.1 	transition to storing positive/negative minutes in each table cell
+		display wifi status based on iwconfig & evaluate current time to find the wifi status @ current time
+		added diagonal gradients for cells with 1-59 minutes (Safari/Chrome/Firefox)
+		fix cycling issues by forcing/keeping specific events
+		check wifi every 5 seconds to update status against a stripped down cloned array
+		added warnings & manual wifi buttons
+		added even day crontab to delete /tmp/cron-(datestamp).backup files older than 7 days
+		...and revert back to not saving full backup crontabs & deleting every 7 days; instead just 1 backup of system (non-wifi) crontabs
+*/

--- a/package/plugin-gargoyle-wifi-schedule/files/www/wifi_schedule.sh
+++ b/package/plugin-gargoyle-wifi-schedule/files/www/wifi_schedule.sh
@@ -14,7 +14,6 @@
 	if [ -e /etc/crontabs/root ] ; then
 		awk '{gsub(/"/, "\\\""); print "cron_data.push(\""$0"\");" }' /etc/crontabs/root
 	fi
-	echo "var current_time=\"`date \"+%Y%m%d-%H%M\"`\";"
 	echo "var weekly_time=\"`date \"+%w-%H-%M\"`\";"
 		
 	echo "var wifi_status = new Array();"
@@ -47,6 +46,14 @@ for (tab_idx in cron_data) {
 	<div id='wlan_stat'>
 		<label class='leftcolumn'>Wireless radio(s) status:</label>
 		<span class='rightcolumn' id='wlan_status'></span>
+	</div>
+	
+	<div id='wifi_action' style="margin-top:15px">
+		<label class='leftcolumn' style="margin-top:5px">Stop/Start wireless radios(s)</label>
+		<span class='rightcolumn'>
+			<input type='button' class='default_button' id='wifi_up_button' value="Start Wireless" onclick='GetWifiUpdate("up")'/>
+			<input type='button' class='default_button' id='wifi_down_button' value="Stop Wireless" onclick='GetWifiUpdate("down")'/>
+		</span>
 	</div>
 
 	<div class="internal_divider"></div>


### PR DESCRIPTION
Fixed some bugs with the table by appending "keep" to certain crontabs & stripping them after they are culled. This addresses many issues like double-up events (was missing an interim down event) & cycling around weekdays.

Added table gradients on Safari/Chrome/Firefox which visually show users what "15" means. It means: during this hour wifi starts red (off) & 15 minutes in becomes green (on). I feel this visual feedback is more effective than a darker green shaded cell. The CSS gradient feature used is not present in Windows 7 IE8, only in IE10 - which I don't have installed.

![gradients](https://f.cloud.github.com/assets/3741901/235391/3fd790fe-87a2-11e2-9452-305db3085f7e.png)

I changed how backups are done. I had a whole elaborate backup strategy & a specific crontab to delete 7 day old timestamped backups. But I figured this just added unneeded overhead - I never even looked at a backup. So it is simplified to keeping "system" crontabs (meaning not wifi-scheduling related) to a simple backup file.

Also added are manual wifi up/down buttons & a 5second status check of wifi.
