### PR TITLE
OpenVPN Client, Manually: add missing ca, cert, key

### DIFF
--- a/package/plugin-gargoyle-openvpn/files/www/js/openvpn.js
+++ b/package/plugin-gargoyle-openvpn/files/www/js/openvpn.js
@@ -169,6 +169,11 @@ function saveChanges()
 		{
 			configureFirewall(true,false)
 			uci.remove("gargoyle", "status", "openvpn_connections")
+
+			if (document.getElementById("openvpn_client_manual_controls").style.display != "none")
+			{
+				clientManualCheckCaCertKey();
+			}
 		}
 
 
@@ -322,6 +327,29 @@ function proofreadAll()
 		}
 	}
 	return errors;
+}
+
+function clientManualCheckCaCertKey()
+{
+	var toAdd = "";
+	var elem = document.getElementById("openvpn_client_conf_text");
+	var clientConf = elem.value;
+	if ("" !== document.getElementById("openvpn_client_ca_text").value && !clientConf.match(/^[\t ]*ca[\t ].*$/im))
+	{
+		toAdd += "\nca ca.crt";
+	}
+	if ("" !== document.getElementById("openvpn_client_cert_text").value && !clientConf.match(/^[\t ]*cert[\t ].*$/im))
+	{
+		toAdd += "\ncert cert.crt";
+	}
+	if ("" !== document.getElementById("openvpn_client_key_text").value && !clientConf.match(/^[\t ]*key[\t ].*$/im))
+	{
+		toAdd += "\nkey key.key";
+	}
+	if ("" !== toAdd)
+	{
+		elem.value += toAdd;
+	}
 }
 
 


### PR DESCRIPTION
Config Client Manually: currently, enabling tls-auth adds a dummy template line "tls-auth ta.key 1" to the conf text. Server-side, openvpn_upload_client.sh: sed changes it to "tls-auth /etc/openvpn/[clientName]_ta.key 1".

openvpn_upload_client.sh is written to do the same for ca, cert, key. However, the web client currently doesn't add such template lines to the conf text for {ca,cert,key}.

Fix: before saving, if any of the {ca,cert,key} lines are missing, append a template line to conf text so it can later be properly rewritten.
