### PR TITLE
dhcp: fix dhcp limit calculation

### DIFF
--- a/package/gargoyle/files/www/js/dhcp.js
+++ b/package/gargoyle/files/www/js/dhcp.js
@@ -152,7 +152,7 @@ function resetData()
 	dhcpOptions = ['start', ['start','limit'], 'leasetime'];
 	
 	enabledTest = function(value){return value != 1;};
-	endCombineFunc= function(values) { return (parseInt(values[0])+parseInt(values[1])); };
+	endCombineFunc= function(values) { return (parseInt(values[0])+parseInt(values[1])-1); };
 	leaseModFunc = function(value)
 	{
 		var leaseHourValue;


### PR DESCRIPTION
In gui: range 100 - 107 should produce option start '100' and option limit '7', not option limit '6'
