### PR TITLE
haserl-i18n: more b12n (bastardization)

### DIFF
--- a/package/haserl-i18n/src/src/h_script.c
+++ b/package/haserl-i18n/src/src/h_script.c
@@ -94,7 +94,7 @@ load_script (char *filename, script_t * scriptlist)
   scriptfp = open (filename, O_NONBLOCK + O_RDONLY);
   if (scriptfp == -1)
     {				/* open failed */
-      die_with_message (NULL, NULL, g_err_msg[E_FILE_OPEN_FAIL], filename);
+        die_with_message (NULL, NULL, g_err_msg[E_FILE_OPEN_FAIL], filename);
     }
 
   fstat (scriptfp, &filestat);
@@ -558,7 +558,7 @@ process_token_list (buffer_t * buf, token_t * token)
 	  shell_eval (buf, token->buf, token->len);
 	  break;
 	case TRANSLATE:
-	  lookup_key (buf, token->buf);
+	  lookup_key (buf, token->buf, HASERL_HTML_INPUT_OUTPUT);
 	  break;
 #ifdef BASHEXTENSIONS
 	case IF:

--- a/package/haserl-i18n/src/src/h_translate.h
+++ b/package/haserl-i18n/src/src/h_translate.h
@@ -21,7 +21,12 @@
 #ifndef H_TRANSLATE_H
 #define H_TRANSLATE_H
 
-void lookup_key (buffer_t *buf, char *key);
+enum {
+	HASERL_HTML_INPUT_OUTPUT    = 0, //token arrives with flanking space
+	HASERL_SHELL_SYMBOLIC_LINK  = 1, //optarg arrives without flanking space
+};
+
+void lookup_key (buffer_t *buf, char *key, unsigned char key_source);
 void buildTranslationMap ();
 
 void uci_init();

--- a/package/haserl-i18n/src/src/haserl.c
+++ b/package/haserl-i18n/src/src/haserl.c
@@ -763,7 +763,24 @@ main (int argc, char *argv[])
 
       break;
     }
-
+    
+    if (av2[0] != NULL && command == 1) { //prevents argument reconstruction (update.sh & reboot.sh)
+		unsigned int prg_len=strlen(av2[0]);
+		if (memcmp(av2[0]+prg_len-4, "i18n", 4) == 0) {
+	
+			if (global.translationKV_map == NULL) {
+				buildTranslationMap ();
+			}
+			lookup_key (NULL, av2[optind], HASERL_SHELL_SYMBOLIC_LINK);
+		
+			buffer_destroy (&script_text);
+		
+			unsigned long num_destroyed;
+			destroy_string_map(global.translationKV_map, DESTROY_MODE_IGNORE_VALUES, &num_destroyed);
+		
+			return (0);
+		}
+	}
 
   scriptchain = load_script (filename, NULL);
 /* drop permissions */
@@ -923,6 +940,9 @@ main (int argc, char *argv[])
 
   free_list_chain (env);
   free_script_list (scriptchain);
+    
+  unsigned long num_destroyed;
+  destroy_string_map(global.translationKV_map, DESTROY_MODE_IGNORE_VALUES, &num_destroyed);
 
   return (0);
 


### PR DESCRIPTION
When invoked with 'i18n', trigger translation lookup of a haserl token style variable.

Also, adds destroy_string_map.

Examples:
i18n SaveChanges
i18n time.EU
i18n openvpn.CClnt

I don't know why this never occurred to me before.

This patch allows using haserl as a shell-based translation utility. Currently /usr/bin/i18n serves that purpose via gargoyle-i18n/files/usr/lib/gargoyle/i18nServices.sh. Both mechanisms account for about 1000 bytes, so the only benefit is of speed.

When this haserl is started via 'i18n' (symlink to /usr/bin/i18n), the translation facility is triggered while not impacting other haserl operations. Changes are due to different whitespace & where to dump found values.

Note:
• the symlink is not created yet because the pages that use shell-based translations are not updated
• updating the translation entails adding a period:
i18n openvpn uc_CA_f
to
i18n openvpn.uc_CA_f
• localize.py will need to be updated to accommodate the change

---

Currently, the existing shell translation facility is used here:
- plugin-gargoyle-openvpn/files/www/utility/openvpn_upload_client.sh
- my 12h/24h hour style patch that I'm not 100% thrilled with here:
  https://github.com/BashfulBladder/gargoyle/commit/93ba926ba51323df6cd8236ca29ae3ecd499ec00
  I think the glitch in loading the page stems from the script halting while it loads & executes the shell script. Even if the function is in the parent haserl page.sh document, the calling of the function in the template halts page loading as the function runs. Its no slower than plugins.sh, but not as fast as the original time.sh page
