### PR TITLE
allow timezone translations to be used in more than 1 page (i18n)

### DIFF
--- a/package/gargoyle-i18n/files/www/firstboot.i18n.sh
+++ b/package/gargoyle-i18n/files/www/firstboot.i18n.sh
@@ -6,7 +6,7 @@
 	# itself remain covered by the GPL.
 	# See http://gargoyle-router.com/faq.html#qfoss for more information
 	eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time"  )
-	gargoyle_header_footer -h -c "internal.css" -j "i18n.js firstboot.js table.js" -z "firstboot.js i18n.js" system gargoyle
+	gargoyle_header_footer -h -c "internal.css" -j "i18n.js firstboot.js table.js time.js" -z "firstboot.js i18n.js time.js" system gargoyle
 %>
 
 <script>

--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -7,6 +7,7 @@
  */
 
 var UI=new Object(); //part of i18n
+var TiZ=new Object(); //i18n timezones
 
 window.onresize = function onresize()
 {
@@ -2063,7 +2064,7 @@ function cnv_LocaleTime(full_date) { //
 	return tcomponents[0]+" "+cnv24hToLocal(tcomponents[1])+" "+tcomponents[2]
 }
 
-function parseTimezones(timezoneLines, TZobj)
+function parseTimezones(timezoneLines)
 {
 	timezoneList = [];
 	timezoneRegions = [];
@@ -2078,7 +2079,7 @@ function parseTimezones(timezoneLines, TZobj)
 			region = stripQuotes( splitLine.pop() );
 			definition = stripQuotes( splitLine.pop() );
 			timezone = stripQuotes( splitLine.pop() );
-			if (ObjLen(TZobj) > 0) { //localized firmware will = 0
+			if (ObjLen(TiZ) > 0) { //localized firmware will = 0
 				tz_parts=timezone.split(" ");
 				if (tz_parts.length == 2 && tz_parts[1].search("TiZ.") == 0) {
 					timezone=tz_parts[0]+" "+eval(tz_parts[1]);

--- a/package/gargoyle/files/www/js/time.js
+++ b/package/gargoyle/files/www/js/time.js
@@ -7,7 +7,6 @@
  */
 
 var timeStr=new Object(); //part of i18n; currently unused
-var TiZ=new Object();
 
 var previousTimezoneDefinition = "PST8PDT,M3.2.0/2,M11.1.0/2";
 

--- a/package/gargoyle/files/www/time.sh
+++ b/package/gargoyle/files/www/time.sh
@@ -15,7 +15,7 @@
 	if [ -e ./data/timezones.txt ] ; then
 		awk '{gsub(/"/, "\\\""); print "timezoneLines.push(\""$0"\");"}' ./data/timezones.txt
 	fi
-	echo "var timezoneData = parseTimezones(timezoneLines, TiZ);"
+	echo "var timezoneData = parseTimezones(timezoneLines);"
 
 	dateformat=$(uci get gargoyle.global.dateformat 2>/dev/null)
 	if [ "$dateformat" == "iso" ]; then


### PR DESCRIPTION
firstboot.i18n.sh: add /www/time.js to gargoyle_header_footer pages required (holds the timeStr object needed when the Language-LG/time.js page is loaded) + the Language-LG/time.js for timezone definitions.

common.js: now hold the timezone definitions; more than 1 page uses timezones (firstboot & time), so this saves carrying the object thru to the common.js parseTimezones function

Note: ordinary/localized firstboot.sh doesn't require the added /www/time.js page because localized timezone translations are carried within the /www/data/timezones.txt document
