### PR TITLE
updated the repository location of mjpg-streamer per the message

### DIFF
--- a/package/gargoyle-mjpg-streamer/Makefile
+++ b/package/gargoyle-mjpg-streamer/Makefile
@@ -14,7 +14,7 @@ PKG_VERSION:=r$(PKG_REV)
 PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://mjpg-streamer.svn.sourceforge.net/svnroot/mjpg-streamer/mjpg-streamer/
+PKG_SOURCE_URL:=https://svn.code.sf.net/p/mjpg-streamer/code/mjpg-streamer
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=$(PKG_REV)
 PKG_SOURCE_PROTO:=svn


### PR DESCRIPTION
returned from svn when attempting to checkout using the old repo
URL.
Previous repo URL: https://mjpg-streamer.svn.sourceforge.net/svnroot/mjpg-streamer/mjpg-streamer/
New repo URL: https://svn.code.sf.net/p/mjpg-streamer/code/mjpg-streamer
