### PR TITLE
fix dead loop under arm CPU(char is unsigned under some arm gcc)

### DIFF
--- a/package/gargoyle-firewall-util/src/restore_quotas.c
+++ b/package/gargoyle-firewall-util/src/restore_quotas.c
@@ -63,12 +63,14 @@ int main(int argc, char** argv)
 	char* death_mark = NULL;
 	char* death_mask = NULL;
 	char* crontab_line = NULL;
+    int ret;
 	
 	unsigned char full_qos_active = 0;
 
 	char c;
-	while((c = getopt(argc, argv, "W:w:s:S:d:D:m:M:c:C:qQ")) != -1) //section, page, css includes, javascript includes, title, output interface variables
+	while((ret = getopt(argc, argv, "W:w:s:S:d:D:m:M:c:C:qQ")) != -1) //section, page, css includes, javascript includes, title, output interface variables
 	{
+        c = ret;
 		switch(c)
 		{
 			case 'W':


### PR DESCRIPTION
getopt returns signed int, and that int is converted to char. But under some arm compiler, the char is unsigned. 
When char is signed:
  getopt returns '-1', char 'c' gets '-1'. Because char 'c' is signed. so char 'c' is extended to int(still -1) to compare with '-1'.
When char is unsigned:
  getopt returns '-1', char 'c' gets '0xffffffff", then '0xffffffff' is cut to '0xffff'. so char 'c' is '0xffff'. Then char 'c' is extended to int(0x0000ffff) to compare with '-1'(0xffffffff). But '0x0000ffff' is not equal to '0xffffffff'. Then dead loop appears.

Sample code:

  1 #include <stdio.h>
  2 int main()
  3 {
  4     signed char b = -1;
  5     unsigned char c = -1;
  6     printf("b is %x, c is %x, -1 is %x\r\n", (int)b, (int)c, -1);
  7 }

Output:
b is ffffffff, c is ff, -1 is ffffffff
