### PR TITLE
fix un-aligned data access under older arm cpu(armv5) http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0472c/BABFDBCJ.html

### DIFF
--- a/package/libiptbwctl/src/ipt_bwctl.c
+++ b/package/libiptbwctl/src/ipt_bwctl.c
@@ -182,8 +182,6 @@ static int unlock_sem(int sid)
 	return success;
 }
 
-
-
 static int lock(unsigned long max_wait_milliseconds)
 {
 	int locked = 0;
@@ -302,6 +300,7 @@ static void parse_returned_ip_data(	void *out_data,
 					)
 {
 	uint32_t ip = *( (uint32_t*)(in_buffer + *in_index) );
+    ip_bw_kernel_data *ip_bw_data = (ip_bw_kernel_data*)in_buffer;
 	if(get_history == 0)
 	{
 		(((ip_bw*)out_data)[*out_index]).ip = ip;
@@ -316,23 +315,19 @@ static void parse_returned_ip_data(	void *out_data,
 			history.reset_time = reset_time;
 			history.is_constant_interval = is_constant_interval;
 
-			history.ip = ip;
-			history.num_nodes = *( (uint32_t*)(in_buffer + *in_index+4));
-			history.first_start = (time_t) *( (uint64_t*)(in_buffer + *in_index+8));
-			history.first_end   = (time_t) *( (uint64_t*)(in_buffer + *in_index+16));
-			history.last_end    = (time_t) *( (uint64_t*)(in_buffer + *in_index+24));
-			*in_index = *in_index + 32;
-
+            history.ip = ip_bw_data->ip;
+			history.num_nodes = ip_bw_data->num_nodes;
+			history.first_start = ip_bw_data->first_start;
+			history.first_end   = ip_bw_data->first_end;
+			history.last_end    = ip_bw_data->last_end;
 
 			history.history_bws =  (uint64_t*)malloc( (history.num_nodes+1)*sizeof(uint64_t) );
 			
 			/* read bws */
 			int node_index = 0;
-			while(node_index < history.num_nodes)
+            for (node_index = 0; node_index < history.num_nodes; node_index++)
 			{
-				(history.history_bws)[node_index] =  *( (uint64_t*)(in_buffer + *in_index) );
-				*in_index = *in_index + 8;
-				node_index++;
+				(history.history_bws)[node_index] =  ip_bw_data->ipbw_data[node_index];
 			}
 
 
@@ -422,7 +417,6 @@ static int get_bandwidth_data(char* id, unsigned char get_history, char* ip, uns
 			time_t reset_time                  = (time_t) *( (uint64_t*)(buf+21) );
 			unsigned char is_constant_interval = *( (unsigned char*)(buf+29) );
 			
-
 			if(!data_initialized)
 			{
 				*num_ips = total_ips;
@@ -1168,7 +1162,6 @@ void print_histories(FILE* out, char* id, ip_bw_history* histories, unsigned lon
 	for(history_index=0; history_index < num_histories; history_index++)
 	{
 		ip_bw_history history = histories[history_index];
-		
 		int history_initialized = 1;
 		if( history.first_start == 0 && history.first_end == 0 && history.last_end == 0)
 		{

--- a/package/libiptbwctl/src/ipt_bwctl.h
+++ b/package/libiptbwctl/src/ipt_bwctl.h
@@ -63,6 +63,38 @@ typedef struct ip_bw_struct
 	uint64_t bw;
 }ip_bw;
 
+#pragma pack(push, 1)
+/*
+* format of response:
+* byte 1 : error code (0 for ok)
+* bytes 2-5 : total_num_ips found in query (further gets may be necessary to retrieve them)
+* bytes 6-9 : start_index, index (in a list of total_num_ips) of first ip in response
+* bytes 10-13 : num_ips_in_response, number of ips in this response
+* bytes 14-21 : reset_interval (helps deal with DST shifts in userspace)
+* bytes 22-29 : reset_time (helps deal with DST shifts in userspace)
+* byte  30    : reset_is_constant_interval (helps deal with DST shifts in userspace)
+* remaining bytes contain blocks of ip data
+* format is dependent on whether history was queried
+*/
+typedef struct ip_bw_kernel_data_struct
+{
+    uint8_t error;
+    uint32_t ip_total;
+    uint32_t index_start;
+    uint32_t ip_num;
+    uint64_t reset_interval;
+    uint64_t reset_time;
+    uint8_t reset_is_constant_interval;
+    /*payload for history ip bw data*/
+    uint32_t ip;
+    uint32_t num_nodes;
+    uint64_t first_start;
+    uint64_t first_end;
+    uint64_t last_end;
+    uint64_t ipbw_data[0];
+}ip_bw_kernel_data;
+#pragma pack(pop)
+
 typedef struct history_struct
 {
 	uint32_t ip;


### PR DESCRIPTION
unaligned data access can result in unexpected data ldr result. More detail about this bug: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0472c/BABFDBCJ.html

This path has been tested under armv5te, and  it should work with all the compiler with "push pup program".
