### PR TITLE
Better automatic target for ACC.

### DIFF
--- a/package/qos-gargoyle/files/qos_gargoyle.init
+++ b/package/qos-gargoyle/files/qos_gargoyle.init
@@ -625,10 +625,20 @@ initialize_qos()
 
 		$echo_on
 
-		#if the user specified a ping target then use that otherwise use the gateway.
+		#if the user specified a ping target then use that otherwise use the next non private router. If not possible to use traceroute to detect it, gateway will be used.
 		if [ -z "$ptarget_ip" ] ; then
-		       ptarget_ip=$(gargoyle_header_footer -i gargoyle | sed -n 's/.*currentWanGateway.*"\(.*\)".*/\1/p')
-		fi
+                       targets=$(traceroute -n -I -w 1 -q 2 -m4 100.100.100.100 | grep -v $(route -n | awk '/^0.0.0.0/ {print $2}') | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | grep -v -E '^(192\.168|10\.|172\.1[6789]\.|172\.2[0-9]\.|172\.3[01]\.|0\.0\.0\.0|127\.|255\.|100\.100\.100\.100)')
+                       for IP in $targets ; do
+                               ping -c 2 $IP > /dev/null
+                               if [ $? -eq 0 ] ; then
+                                       ptarget_ip=$IP
+                                       break
+                               fi
+                       done
+                       if [ -z "$ptarget_ip" ] ; then
+                                ptarget_ip=$(gargoyle_header_footer -i gargoyle | sed -n 's/.*currentWanGateway.*"\(.*\)".*/\1/p')
+                       fi
+                fi
 
 		#Ping responses for the ping target never go to the IMQ device.
 		iptables -t mangle -I qos_ingress -p icmp --icmp-type 0 -d $wan_ip -s $ptarget_ip -j RETURN


### PR DESCRIPTION
ACC needs better automatic target than gateway, because when WAN is not PPPoE, probably  it is a ADSL/Cable modem. Using this kind of router is almost sure that ACC wont work properly.
This mod uses traceroute to find the next non private router in the next 4 hops, it is using -n -w 1 -q 2 to avoid lost to much time.
If you want to use this idea, would be better to make other changes to make GUI updated with this patch.
