### PR TITLE
Avoid DNS reverse lookups when listing to-be-deleted iptables rules

### DIFF
--- a/package/gargoyle-firewall-util/src/delete_chain_from_table.c
+++ b/package/gargoyle-firewall-util/src/delete_chain_from_table.c
@@ -20,7 +20,7 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
-	char *command = dynamic_strcat(3, "iptables -t ", table, " -L --line-numbers 2>/dev/null");
+	char *command = dynamic_strcat(3, "iptables -t ", table, " -L -n --line-numbers 2>/dev/null");
 	unsigned long num_lines = 0;
 	char** table_dump = get_shell_command_output_lines(command, &num_lines);
 	free(command);

--- a/package/gargoyle-firewall-util/src/restore_quotas.c
+++ b/package/gargoyle-firewall-util/src/restore_quotas.c
@@ -954,7 +954,7 @@ uint32_t ip_to_host_int(char* ip_str)
 
 void delete_chain_from_table(char* table, char* delete_chain)
 {
-	char *command = dynamic_strcat(3, "iptables -t ", table, " -L --line-numbers 2>/dev/null");
+	char *command = dynamic_strcat(3, "iptables -t ", table, " -L -n --line-numbers 2>/dev/null");
 	unsigned long num_lines = 0;
 	char** table_dump = get_shell_command_output_lines(command, &num_lines );
 	free(command);	


### PR DESCRIPTION
These lookups can take quite some time when there are many
user-defined rules (such as a set of rules derived from a block
list).  We never look at the domain names anyway, so it's safe to have
just the IP addresses dumped.
