### PR TITLE
Update minidlna.js

### DIFF
--- a/package/plugin-gargoyle-minidlna/files/www/js/minidlna.js
+++ b/package/plugin-gargoyle-minidlna/files/www/js/minidlna.js
@@ -240,7 +240,7 @@ function rescanMedia()
 {
 	var Commands = [];
 	Commands.push("/etc/init.d/minidlna stop");
-	Commands.push("kill -9 $(pidof minidlnad)");
+	Commands.push("kill -9 $(pidof minidlna)");
 	Commands.push("rm -f $(uci get minidlna.config.db_dir)/files.db");
 	Commands.push("/etc/init.d/minidlna start");
 


### PR DESCRIPTION
Addresses an issue in 1.7.0 Gargoyle which prevents minidlna from rescanning the media drive. 
Error: [2015/01/30 12:57:51] minidlna.c:939: error: MiniDLNA is already running. EXITING.

Issue was that the process wasn't being terminated correctly and so would never begin rescanning.