### PR TITLE
CloudFlare: use api_json endpoint

### DIFF
--- a/package/ddns-gargoyle/files/etc/ddns_providers.conf
+++ b/package/ddns-gargoyle/files/etc/ddns_providers.conf
@@ -138,10 +138,10 @@ service dtdns.com
 	success_regexp			/now points to/
 
 service cloudflare.com
-	url_template			https://www.cloudflare.com/api.html?a=DIUP&hosts=[[DOMAIN]]&email=[[EMAIL]]&tkn=[[KEY]]&ip=[[IP]]
-	required_variables 		domain email key
-	required_variable_names		DyDNS.DoNm, DyDNS.Eml, DyDNS.AKey
-	success_regexp			/(OK|E_NOUPDATE)/
+	url_template			https://www.cloudflare.com/api_json.html?a=rec_edit&type=A&ttl=1&z=[[DOMAIN]]&name=[[DOMAIN]]&email=[[EMAIL]]&tkn=[[KEY]]&id=[[ID]]&content=[[IP]]
+	required_variables 		domain email key id
+	required_variable_names		DyDNS.DoNm, DyDNS.Eml, DyDNS.AKey, DyDNS.Key
+	success_regexp			/"result":"success"/
 
 service ovh.com
 	url_template			https://[[ID]]:[[PASSWORD]]@www.ovh.com/nic/update?system=dyndns&hostname=[[DOMAIN]]&myip=[[IP]]


### PR DESCRIPTION
This requires the ID of the domain's record in the ID variable (name Key). The old Key variable is renamed to API Key. 

Currently only support top-level domain, needs another field to distinguish the domain from the zone.