### PR TITLE
fixed OpenVPN Status always shows no connected clients

### DIFF
--- a/package/plugin-gargoyle-openvpn/files/usr/lib/gargoyle/openvpn.sh
+++ b/package/plugin-gargoyle-openvpn/files/usr/lib/gargoyle/openvpn.sh
@@ -143,11 +143,11 @@ create_server_conf()
 	mkdir -p "$OPENVPN_DIR/ccd"
 	mkdir -p "$OPENVPN_DIR/route_data"
 
-	mkdir -p /var/openvpn
-	touch /var/openvpn/current_status
+	mkdir -p /var/run
+	touch /var/run/openvpn_status
 	if [ ! -h /etc/openvpn/current_status ] ; then
 		rm -rf /etc/openvpn/current_status
-		ln -s  /var/openvpn/current_status /etc/openvpn/current_status 
+		ln -s  /var/run/openvpn_status /etc/openvpn/current_status 
 	fi
 
 	random_dir_num=$(random_string)
@@ -219,7 +219,7 @@ $openvpn_keysize
 
 dev                   tun
 keepalive             25 180
-status                /var/openvpn/current_status
+status                /var/run/openvpn_status
 verb                  3
 
 


### PR DESCRIPTION
openvpn server setup script placed openvpn status file under
/var/openvpn directory, which does not survive router restart.
moved the status file to /var/run directory, which is recreated
as necessary by openvpn init script.

Signed-off-by: Igor Fedorenko <igor@ifedorenko.com>