### PR TITLE
Update miniupnpd.init

### DIFF
--- a/package/miniupnpd/files/miniupnpd.init
+++ b/package/miniupnpd/files/miniupnpd.init
@@ -205,4 +205,5 @@ stop() {
         [ -x /usr/sbin/ip6tables ] && {
 	    ip6tables -t filter -F MINIUPNPD 2>/dev/null
         }
+        /usr/lib/gargoyle/firewall_restart.sh
 }


### PR DESCRIPTION
From my testing, the source of Phgerin's problem (http://www.gargoyle-router.com/phpbb/viewtopic.php?f=14&t=7227#p29945) is that after a sysupgrade (preserve settings) the firewall gets a little upset.
A simple restart of the firewall fixed these issues.
Steps to fix:
1. disable upnpd
2. issue firewall restart
3. reenable upnpd

so two proposed solutions, this fix here. 
OR
making sure that if we do a "preserve settings" the firewall gets properly flushed and restarted.

What do you think?
I have yet to test this change as i am still doing the 4GB transfer test.