### PR TITLE
Bump tor-0.2.6.10

### DIFF
--- a/package/gargoyle-tor/Makefile
+++ b/package/gargoyle-tor/Makefile
@@ -182,7 +182,7 @@ CONFIGURE_VARS += \
 
 # pass CFLAGS again to override -O2 set by configure
 MAKE_FLAGS += \
-	CFLAGS="$(TARGET_CFLAGS) -fPIC "
+	CFLAGS="$(TARGET_CFLAGS) -fPIC -std=gnu99"
 
 define Package/gargoyle-tor/install
 	$(INSTALL_DIR)  $(1)/usr/sbin

--- a/package/gargoyle-tor/Makefile
+++ b/package/gargoyle-tor/Makefile
@@ -120,13 +120,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gargoyle-tor
-PKG_VERSION:=0.2.5.10
+PKG_VERSION:=0.2.6.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=tor-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.torproject.org/dist \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=4bde375229a7a7f77c0596ae05556527
+PKG_MD5SUM:=04f919e7882d1ca80f835545af562bad
 PKG_INSTALL:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/tor-$(PKG_VERSION)


### PR DESCRIPTION
**tor-0.2.6.10 Contains a large number of Major/minor fixes/features (some security related)**

`make ar71xx.usb`
completed without error

TL-WDR3600 v1 running Gargoyle v1.8.0 was flashed with
    gargoyle_1.7.x-ar71xx-generic-tl-wdr3600-v1-squashfs-sysupgrade.bin
with attempt to preserve settings

The Tor plugin was installed with opkg

`root@Gargoyle:/tmp# opkg install obfsproxy_0.1.4-1_ar71xx.ipk`
`Preparing to install the following packages, which will require 21996 bytes:`
	`obfsproxy`

`Preparing to install package obfsproxy...`
	`Successfully installed obfsproxy.`
`Installation of packages successful.`

`root@Gargoyle:/tmp# opkg install gargoyle-tor_0.2.6.10-1_ar71xx.ipk`
`Preparing to install the following packages, which will require 656213 bytes:`
	`gargoyle-tor`

`Preparing to install package gargoyle-tor...`
	`Successfully installed gargoyle-tor.`
`Installation of packages successful.`

`root@Gargoyle:/tmp# opkg install plugin-gargoyle-tor_1.7.0-1_all.ipk`
`Preparing to install the following packages, which will require 6765 bytes:`
	`plugin-gargoyle-tor`

`Preparing to install package plugin-gargoyle-tor...`
	`Successfully installed plugin-gargoyle-tor.`
`Installation of packages successful.`


Tor Client: Enabled For All Hosts
Firefox browse to http://3g2upl4pq6kufc4m.onion/

Tor Client: Toggled by Host
For your IP, Tor is: Enabled
Firefox browse to http://3g2upl4pq6kufc4m.onion/
For your IP, Tor is: Disabled
Firefox failed to browse to http://3g2upl4pq6kufc4m.onion/
