### PR TITLE
dnsmasq: backport CVE-2015-3294 security fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ set_version_variables()
 	# set svn revision number to use 
 	# you can set this to an alternate revision 
 	# or empty to checkout latest 
-	rnum=46287
+	rnum=46817
 
 	#set date here, so it's guaranteed the same for all images
 	#even though build can take several hours


### PR DESCRIPTION
Back port of security fix without bumping dnsmasq version. 
Fix is included in CC because dnsmasq version is up to date there.