### PR TITLE
Modem LTE: fix qmi; add ncm protocol

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/cache_basic_vars.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/cache_basic_vars.sh
@@ -113,20 +113,6 @@ else
 	echo "var wifiN = false;" >> "$out_file"
 fi
 
-
-#detect qmi interface if it exists
-qmi_if=""
-if [ -e /sys/class/usbmisc/ ] ; then
-	local devnames=$(ls /sys/class/usbmisc)
-	for devname in $devnames ; do
-		if [ -e "/sys/class/usbmisc/$devname/device/net" ] && [ -z "$qmi_if" ] ; then
-			qmi_if=$( ls "/sys/class/usbmisc/$devname/device/net" | head -n 1 )
-		fi
-	done
-fi
-echo "qmiInterface=\"$qmi_if\";"
-
-
 # cache default interfaces if we haven't already
 # this script is run on first boot by hotplug, so
 # this will make sure the defaults get cached right

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -45,11 +45,18 @@
 
 	fi
 
-	has_qmi=$( ls /dev/cdc-wdm* 2>/dev/null )
+	has_qmi=$( grep qmi_wwan /sys/kernel/debug/usb/devices 2>/dev/null)
 	if [ -z "$has_qmi" ] ; then
 		echo "hasQMI = false;"
 	else
 		echo "hasQMI = true;"
+	fi
+
+	has_ncm=$( grep cdc_ncm /sys/kernel/debug/usb/devices 2>/dev/null)
+	if [ -z "$has_ncm" ] ; then
+		echo "hasNCM = false;"
+	else
+		echo "hasNCM = true;"
 	fi
 
 
@@ -316,6 +323,7 @@ var isb43 = wirelessDriver == "mac80211" && (!wifiN) ? true : false ;
 				<option value='static_wireless'><%~ StIP %> (<%~ Wrlss %>)</option>
 				<option value='3g'><%~ Mo3g %></option>
 				<option value='qmi'><%~ Mo3gQMI %></option>
+				<option value='ncm'><%~ Mo3gNCM %></option>
 				<option value='none'><%~ Disabled %></option>
 			</select>
 		</div>

--- a/package/gargoyle/files/www/utility/scan_3gdevices.sh
+++ b/package/gargoyle/files/www/utility/scan_3gdevices.sh
@@ -4,5 +4,5 @@
 	echo "Content-type: text/plain"
 	echo ""
 
-	ls -1 /dev/tty[A\|U][C\|S]* 2>/dev/null
+	ls -1 /dev/ttyUSB* /dev/ttyACM* /dev/cdc-wdm* 2>/dev/null
 ?>

--- a/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/basic.js
+++ b/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/basic.js
@@ -53,7 +53,7 @@ basicS.WANSec="Internet / WAN";
 basicS.Cnct="Connect Via";
 basicS.Wird="Wired";
 basicS.Wrlss="Wireless";
-basicS.Mo3g="3G (GSM)";
+basicS.Mo3g="3G (ppp)";
 basicS.CLsExp="Current Lease Expires";
 basicS.Renew="DHCP Renew";
 basicS.Rleas="DHCP Release";
@@ -127,4 +127,5 @@ basicS.NoDv="No devices found";
 
 basicS.WANIntr="WAN Interface";
 basicS.Mo3gQMI="LTE (QMI)";
+basicS.Mo3gNCM="LTE (NCM)";
 basicS.Dfult="Default";

--- a/package/plugin-gargoyle-i18n-Polish-PL/files/www/i18n/Polish-PL/basic.js
+++ b/package/plugin-gargoyle-i18n-Polish-PL/files/www/i18n/Polish-PL/basic.js
@@ -126,5 +126,6 @@ basicS.ScnMo="Poszukiwanie urządzeń mobilnych";
 basicS.NoDv="Nie znaleziono urządzeń";
 
 basicS.WANIntr="Interfejs WAN";
-basicS.Mo3gQMI="LTE (QMI)";
+basicS.Mo3gQMI="Modem LTE (QMI)";
+basicS.Mo3gNCM="Modem LTE (NCM)";
 basicS.Dfult="Domyślny";

--- a/package/plugin-gargoyle-usb-storage/Makefile
+++ b/package/plugin-gargoyle-usb-storage/Makefile
@@ -26,8 +26,9 @@ define Package/plugin-gargoyle-usb-storage
 	SUBMENU:=Gargoyle Web Interface
 	TITLE:=USB Storage Support for Gargoyle
 	DEPENDS:=+share-users +samba36-server +nfs-kernel-server +nfs-kernel-server-utils +gargoyle +fdisk +blkid +dosfsck
-	DEPENDS+=+libusb-1.0 +chat +kmod-usb-acm +kmod-usb-serial +comgt +usb-modeswitch +kmod-usb-net-qmi-wwan +uqmi +kmod-usb-wdm
-	DEPENDS+=+kmod-usb2 +kmod-usb-net +kmod-usb-serial-option +kmod-usb-serial-qualcomm +kmod-usb-serial-wwan +kmod-usb-serial-sierrawireless 
+	DEPENDS+=+libusb-1.0 +chat +kmod-usb-acm +kmod-usb-serial +comgt +comgt-ncm +usb-modeswitch
+	DEPENDS+=+kmod-usb-wdm +kmod-usb-net-qmi-wwan +uqmi +kmod-usb-net-cdc-ncm +kmod-usb-net-huawei-cdc-ncm
+	DEPENDS+=+kmod-usb2 +kmod-usb-net +kmod-usb-serial-option +kmod-usb-serial-qualcomm +kmod-usb-serial-wwan +kmod-usb-serial-sierrawireless
 	DEPENDS+=+kmod-usb-sierrawireless-directip +e2fsprogs +kmod-usb-storage +kmod-usb-storage-extras +swap-utils +vsftpd +block-mount
 	DEPENDS+=+nfs-utils +badblocks +kmod-fs-ext4 +kmod-fs-msdos +kmod-fs-vfat +kmod-fs-hfsplus
 	DEPENDS+=+kmod-nls-base +kmod-nls-cp1250 +kmod-nls-cp1251 +kmod-nls-cp437 +kmod-nls-cp775 +kmod-nls-cp850 


### PR DESCRIPTION
- Detect qmi interface is not longer necessary
- Fix modem device scan
- Add NCM protocol
- Show modem protocol based on loaded drivers