### PR TITLE
Change the way we grab plugins defaults

### DIFF
--- a/package/gpkg/files/gpkg-uci-defaults
+++ b/package/gpkg/files/gpkg-uci-defaults
@@ -3,7 +3,8 @@
 gpkg_conf_template="/etc/opkg.gpkg.tmp"
 
 if [ ! -f /etc/opkg.conf ] ; then
-	mv $gpkg_conf_template /etc/opkg.conf
+	cp $gpkg_conf_template /etc/opkg.conf
+	rm $gpkg_conf_template
 else
 	local plugin_root="/plugin_root"
 	local escaped_plugin_root=$(echo "$plugin_root" | sed 's/\//\\\//g' )


### PR DESCRIPTION
On the mvebu target something is preventing the "mv" command from completing and therefore breaking the plugins.sh page.
`root@Gargoyle:~# mv /etc/opkg.gpkg.tmp /etc/opkg.conf`
`mv: can't rename '/etc/opkg.gpkg.tmp': Invalid argument`

We can solve this by doing a "cp" instead, and then removing the old file.

Other targets appear unaffected, however this change doesn't affect them either.