### PR TITLE
duplicate -j

### DIFF
--- a/package/plugin-gargoyle-email-notifications/files/www/email.sh
+++ b/package/plugin-gargoyle-email-notifications/files/www/email.sh
@@ -10,7 +10,7 @@
 # Cron configuration code was derived from wifi_schedule plugin, which was written by BashfulBladder.
 #
 eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time" )
-gargoyle_header_footer -h -s "system" -p "mail" -c "internal.css" -j "email.js" -j "email.js" -z "email.js" -i email
+gargoyle_header_footer -h -s "system" -p "mail" -c "internal.css" -j "email.js" -z "email.js" -i email
 %>
 
 <script>


### PR DESCRIPTION
Removed duplicated -j switch, no need to list email.js twice.