### PR TITLE
Tweek Plugins page

### DIFF
--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -411,8 +411,8 @@ function updatePackagesList()
 		document.getElementById("wan-warn").style.display = "inline";
 	} else {	
 		document.getElementById("wan-warn").style.display = "none";
- 		var e=["opkg update"];
-		execute(e)
+ 		var cmd=["opkg update"];
+		execute(cmd)
  	}
 }
 

--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -405,8 +405,15 @@ function uninstallPackage()
 
 function updatePackagesList()
 {
-	var cmd = [ "opkg update" ];
-	execute(cmd);
+ 
+	if(uciOriginal.get("network", "wan", "") == "")
+	{
+		document.getElementById("wan-warn").style.display = "inline";
+	} else {	
+		document.getElementById("wan-warn").style.display = "none";
+ 		var e=["opkg update"];
+		execute(e)
+ 	}
 }
 
 function getCurrentOrLatestVersion(pkgVersions)

--- a/package/gargoyle/files/www/plugins.sh
+++ b/package/gargoyle/files/www/plugins.sh
@@ -87,6 +87,7 @@
 		<div id="bottom_button_container">
 			<input type='button' value='<%~ RfshP %>' id="update_button" class="bottom_button" onclick='updatePackagesList()' />
 		</div>
+		<span id="wan-warn" style="color:red;display:none">Check your Internet connection.</span>
 		<div>
 			<div id="languages_table_container" style="margin-left:5px" ></div>
 		</div>

--- a/package/gargoyle/files/www/plugins.sh
+++ b/package/gargoyle/files/www/plugins.sh
@@ -84,6 +84,9 @@
 
 	<fieldset id="plugin_list">
 		<legend class="sectionheader"><%~ PList %></legend>
+		<div id="bottom_button_container">
+			<input type='button' value='<%~ RfshP %>' id="update_button" class="bottom_button" onclick='updatePackagesList()' />
+		</div>
 		<div>
 			<div id="languages_table_container" style="margin-left:5px" ></div>
 		</div>
@@ -95,9 +98,6 @@
 		</div>
 		<div id="no_packages" style='display:none;'>
 			<%~ NoPkg %>
-		</div>
-		<div id="bottom_button_container">
-			<input type='button' value='<%~ RfshP %>' id="update_button" class="bottom_button" onclick='updatePackagesList()' />
 		</div>
 	</fieldset>
 


### PR DESCRIPTION
Some users find the "Refresh Plugins" button hard to locate at the bottom of the page. Move it to the top of the section to improve visibility.

Some users have not realized that a WAN connection is required to Refresh Plugins. Show a red prompt if the user clicks the Refresh Plugins button without an active WAN connection.