### PR TITLE
Tweek Plugins page

### DIFF
--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -411,8 +411,8 @@ function updatePackagesList()
 		document.getElementById("wan-warn").style.display = "inline";
 	} else {	
 		document.getElementById("wan-warn").style.display = "none";
- 		var e=["opkg update"];
-		execute(e)
+ 		var cmd=["opkg update"];
+		execute(cmd)
  	}
 }
 

--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -405,8 +405,15 @@ function uninstallPackage()
 
 function updatePackagesList()
 {
-	var cmd = [ "opkg update" ];
-	execute(cmd);
+ 
+	if(uciOriginal.get("network", "wan", "") == "")
+	{
+		document.getElementById("wan-warn").style.display = "inline";
+	} else {	
+		document.getElementById("wan-warn").style.display = "none";
+ 		var e=["opkg update"];
+		execute(e)
+ 	}
 }
 
 function getCurrentOrLatestVersion(pkgVersions)

--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -405,8 +405,7 @@ function uninstallPackage()
 
 function updatePackagesList()
 {
- 
-	if(uciOriginal.get("network", "wan", "") == "")
+	if(currentWanIp=="")
 	{
 		document.getElementById("wan-warn").style.display = "inline";
 	} else {	

--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -410,9 +410,9 @@ function updatePackagesList()
 		document.getElementById("wan-warn").style.display = "inline";
 	} else {	
 		document.getElementById("wan-warn").style.display = "none";
- 		var cmd=["opkg update"];
-		execute(cmd)
- 	}
+	}
+ 	var cmd=["opkg update"];
+	execute(cmd);
 }
 
 function getCurrentOrLatestVersion(pkgVersions)

--- a/package/gargoyle/files/www/plugins.sh
+++ b/package/gargoyle/files/www/plugins.sh
@@ -87,6 +87,7 @@
 		<div id="bottom_button_container">
 			<input type='button' value='<%~ RfshP %>' id="update_button" class="bottom_button" onclick='updatePackagesList()' />
 		</div>
+		<span id="wan-warn" style="color:red;display:none">Check your Internet connection.</span>
 		<div>
 			<div id="languages_table_container" style="margin-left:5px" ></div>
 		</div>

--- a/package/gargoyle/files/www/plugins.sh
+++ b/package/gargoyle/files/www/plugins.sh
@@ -87,7 +87,7 @@
 		<div id="bottom_button_container">
 			<input type='button' value='<%~ RfshP %>' id="update_button" class="bottom_button" onclick='updatePackagesList()' />
 		</div>
-		<span id="wan-warn" style="color:red;display:none">Check your Internet connection.</span>
+		<span id="wan-warn" style="color:red;display:none"><%~ NoWan %></span>
 		<div>
 			<div id="languages_table_container" style="margin-left:5px" ></div>
 		</div>

--- a/package/gargoyle/files/www/plugins.sh
+++ b/package/gargoyle/files/www/plugins.sh
@@ -84,6 +84,9 @@
 
 	<fieldset id="plugin_list">
 		<legend class="sectionheader"><%~ PList %></legend>
+		<div id="bottom_button_container">
+			<input type='button' value='<%~ RfshP %>' id="update_button" class="bottom_button" onclick='updatePackagesList()' />
+		</div>
 		<div>
 			<div id="languages_table_container" style="margin-left:5px" ></div>
 		</div>
@@ -95,9 +98,6 @@
 		</div>
 		<div id="no_packages" style='display:none;'>
 			<%~ NoPkg %>
-		</div>
-		<div id="bottom_button_container">
-			<input type='button' value='<%~ RfshP %>' id="update_button" class="bottom_button" onclick='updatePackagesList()' />
 		</div>
 	</fieldset>
 

--- a/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/plugins.js
+++ b/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/plugins.js
@@ -13,6 +13,7 @@ pgS.APSrc="Add Plugin Source";
 pgS.PList="Plugin List";
 pgS.NoPkg="Packages not found. Refresh plugins list.";
 pgS.RfshP="Refresh Plugins";
+pgS.NoWan="Please check your Internet connection.";
 
 //javascript
 pgS.NInst="Not Installed";


### PR DESCRIPTION
Some people have had trouble locating the "Refresh Plugins" button at the bottom of plugins.sh. Move the button to the top of the section.

Some people have not recognised the need to have an Internet connection in order to Refresh Plugins.  Show a red prompt to "check Internet Connection" when the "Refresh Plugins" button is clicked when there is not a currentWanIp address.

[EDIT] Added i18n stuff