### PR TITLE
Make currentWanIp available

### DIFF
--- a/package/gargoyle/files/www/plugins.sh
+++ b/package/gargoyle/files/www/plugins.sh
@@ -7,7 +7,7 @@
 	# itself remain covered by the GPL.
 	# See http://gargoyle-router.com/faq.html#qfoss for more information
 	eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time"  )
-	gargoyle_header_footer -h -s "system" -p "plugins" -c "internal.css" -j "table.js plugins.js" -z "plugins.js" gargoyle
+	gargoyle_header_footer -h -s "system" -p "plugins" -c "internal.css" -j "table.js plugins.js" -z "plugins.js" -i gargoyle
 %>
 <script>
 


### PR DESCRIPTION
Add the gargoyle_header_footer -i option to make the variable currentWanIp available to the "Refresh Plugins" button