### PR TITLE
Fix UPnP show/hide function

### DIFF
--- a/package/gargoyle/files/www/js/port_forwarding.js
+++ b/package/gargoyle/files/www/js/port_forwarding.js
@@ -556,7 +556,7 @@ function resetData()
 
 
 	//upnp
-	document.getElementById("upnp_fieldset").style.display = haveUpnpd;
+	document.getElementById("upnp_fieldset").style.display = haveUpnpd == true ? "block" : "none";
 	document.getElementById("upnp_enabled").checked = upnpdEnabled;
 	upElement = document.getElementById("upnp_up");
 	downElement = document.getElementById("upnp_down");


### PR DESCRIPTION
A few forum users have complained that even though their 4MB routers don't have upnp, they can still see the options.
This fixes that issue. The existing code didn't seem to work properly.