### PR TITLE
Check for sufficient space on new plugin root drive

### DIFF
--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -113,6 +113,17 @@ function changePluginRoot()
 	var oldRootDrive = uciOriginal.get("gargoyle", "plugin_options", "root_drive")
 	oldRootDrive = oldRootDrive == "" ? "root" : oldRootDrive;
 
+        if (pluginRootSize > pkg_dests[newRootDrive]['Bytes-Free'])
+        {
+            window.alert
+    		(       pgS.NoSpace + " " + newRootDrive + "\n\n" +
+                	pgS.PlgSz + " = " + parseBytes(pluginRootSize) + "\n" +
+                	pgS.FreeSp + " = " + parseBytes(pkg_dests[newRootDrive]['Bytes-Free']) + "\n\n" +
+                	pgS.Rslv
+        	);
+        return;
+    }
+
 	var commands = [];
 	var newDirPath = driveToPath[ newRootDrive ] + "/" + newRootDir
 	if(oldRootDrive == "root" && newRootDrive != "root")
@@ -148,6 +159,7 @@ function changePluginRoot()
 	commands.push("/sbin/uci commit");
 
 	execute(commands);
+	document.reload(); // ensure that pkg_info is refreshed
 }
 
 function removePluginSource()
@@ -189,7 +201,7 @@ function addPluginSource()
 	for(sourceIndex=0; sourceIndex < pluginSources.length; sourceIndex++)
 	{
 		dupeName = srcName == pluginSources[sourceIndex][0] ? true : dupeName
-		dupeUrl  = srcUrl  == pluginSources[sourceIndex][1] ? true : dupeUrl 
+		dupeUrl  = srcUrl  == pluginSources[sourceIndex][1] ? true : dupeUrl
 	}
 	if(dupeName)
 	{
@@ -247,7 +259,7 @@ function resetData()
 
 		rootDriveDisplay.push(pgS.RDrv + ": " + parseBytes(pkg_dests['root']['Bytes-Total']) + " " + pgS.Totl + ", " + parseBytes(pkg_dests['root']['Bytes-Free']) + " " + pgS.Free)
 		rootDriveValues.push("root");
-		
+
 		var driveIndex;
 		for(driveIndex=0;driveIndex < storageDrives.length; driveIndex++)
 		{
@@ -391,7 +403,7 @@ function installPackage()
 	var cmd = [ "sh /usr/lib/gargoyle/install_gargoyle_package.sh " + pkg  ];
 
 	// This should be done by implementing post-inst script for a given package, not as part of package installation procedure
-	//cmd.push("for i in $(opkg files " + package + " | grep \"/etc/init.d\"); do $i enable; $i start; done"); 
+	//cmd.push("for i in $(opkg files " + package + " | grep \"/etc/init.d\"); do $i enable; $i start; done");
 
 	execute(cmd);
 }
@@ -408,7 +420,7 @@ function updatePackagesList()
 	if(currentWanIp=="")
 	{
 		document.getElementById("wan-warn").style.display = "inline";
-	} else {	
+	} else {
 		document.getElementById("wan-warn").style.display = "none";
 	}
  	var cmd=["opkg update"];

--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -395,6 +395,8 @@ function resetData()
 			setSingleChild(tableContainer, packTable)
 		}
 	}
+
+	document.getElementById("wan-warn").style.display = currentWanIp=="" ? "inline" : "none";
 }
 
 function installPackage()
@@ -417,12 +419,6 @@ function uninstallPackage()
 
 function updatePackagesList()
 {
-	if(currentWanIp=="")
-	{
-		document.getElementById("wan-warn").style.display = "inline";
-	} else {
-		document.getElementById("wan-warn").style.display = "none";
-	}
  	var cmd=["opkg update"];
 	execute(cmd);
 }

--- a/package/gargoyle/files/www/plugins.sh
+++ b/package/gargoyle/files/www/plugins.sh
@@ -30,7 +30,7 @@
 	pkg_info=$(gpkg info -v 'Install-Destination,Required-Size,Required-Depends,Description,Will-Fit,User-Installed' -d plugin_root -o 'js' -r /^plugin\-gargoyle/)
 	gpkg dest-info -o 'js'
 	if [ -n "$pkg_info" ] ; then
-		printf "%s\n" "$pkg_info" 
+		printf "%s\n" "$pkg_info"
 	fi
 
 	echo "var pluginSources = [];"
@@ -39,6 +39,7 @@
 	echo "var storageDrives = [];"
 	awk '{ print "storageDrives.push([\""$1"\",\""$2"\",\""$3"\",\""$4"\", \""$5"\", \""$6"\"]);" }' /tmp/mounted_usb_storage.tab 2>/dev/null
 
+    du -s $plugin_root_dest | awk '{ print "var pluginRootSize="$1*1000";" }' 2>/dev/null
 %>
 
 </script>

--- a/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/plugins.js
+++ b/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/plugins.js
@@ -39,3 +39,7 @@ pgS.Name="Name";
 pgS.Langs="Languages";
 pgS.Thems="Themes";
 pgS.Pkgs="Packages";
+pgS.NoSpace="Insufficient space on";
+pgS.PlgSz="Installed plugins";
+pgS.FreeSp="Free space";
+pgS.Rslv="Please uninstall some plugins and try again,\n or choose another destination.";

--- a/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/plugins.js
+++ b/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/plugins.js
@@ -13,7 +13,7 @@ pgS.APSrc="Add Plugin Source";
 pgS.PList="Plugin List";
 pgS.NoPkg="Packages not found. Refresh plugins list.";
 pgS.RfshP="Refresh Plugins";
-pgS.NoWan="Please check your Internet connection.";
+pgS.NoWan="An Internet connection is required to Refresh Plugins.";
 
 //javascript
 pgS.NInst="Not Installed";


### PR DESCRIPTION
When a user attempts to change the plugin root to a location with
insufficient space the user is alerted and a resolution suggested.

resolves; ericpaylbishop/gargoyle#426