### PR TITLE
Populate network.wan.device for proto qmi|ncm

### DIFF
--- a/package/gargoyle/files/etc/udhcpc.user
+++ b/package/gargoyle/files/etc/udhcpc.user
@@ -1,0 +1,5 @@
+case $(uci -q get network.wan.proto) in
+	qmi|ncm)
+	uci -P /var/state set network.wan.device=$interface
+	;;
+esac


### PR DESCRIPTION
This allow set proper currentwanif variable in gui. 