### PR TITLE
Enforce dhcp assignments ip !mac

### DIFF
--- a/package/gargoyle-firewall-util/files/gargoyle_firewall_util.sh
+++ b/package/gargoyle-firewall-util/files/gargoyle_firewall_util.sh
@@ -543,6 +543,7 @@ enforce_dhcp_assignments()
 			ip=$(echo $p | sed 's/^.*\^//g')
 			if [ -n "$ip" ] && [ -n "$mac" ] ; then
 				iptables -t filter -A lease_mismatch_check  ! -s  "$ip"  -m mac --mac-source  "$mac"  -j REJECT
+				iptables -t filter -A lease_mismatch_check  -s  "$ip"  ! -m mac --mac-source  "$mac"  -j REJECT
 			fi
 		done
 		iptables -t filter -I delegate_forward -j lease_mismatch_check


### PR DESCRIPTION
We need to handle both cases:

    Block a known MAC using an unassigned IP address
    and
    Block an assigned IP address being used by another MAC