### PR TITLE
Fix for populate network.wan.device for proto qmi|ncm

### DIFF
--- a/package/gargoyle/files/etc/hotplug.d/iface/99-qmincm
+++ b/package/gargoyle/files/etc/hotplug.d/iface/99-qmincm
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+[ $ACTION = "ifup" ] || exit 0
+[ $INTERFACE = "wan" ] || exit 0
+
+case $(uci -q get network.wan.proto) in
+	qmi|ncm)
+	uci -P /var/state set network.wan.device=$DEVICE
+	;;
+esac
+exit 0

--- a/package/gargoyle/files/etc/udhcpc.user
+++ b/package/gargoyle/files/etc/udhcpc.user
@@ -1,5 +1,0 @@
-case $(uci -q get network.wan.proto) in
-	qmi|ncm)
-	uci -P /var/state set network.wan.device=$interface
-	;;
-esac


### PR DESCRIPTION
This is better solution - because 00-netstate removes device.