### PR TITLE
standard version numbers for language files

### DIFF
--- a/package/plugin-gargoyle-i18n-German-DE/Makefile
+++ b/package/plugin-gargoyle-i18n-German-DE/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=plugin-gargoyle-i18n-German-DE
-PKG_VERSION:=20160221
-PKG_RELEASE:=1
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=0
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 

--- a/package/plugin-gargoyle-i18n-Polish-PL/Makefile
+++ b/package/plugin-gargoyle-i18n-Polish-PL/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=plugin-gargoyle-i18n-Polish-PL
-PKG_VERSION:=20160228
-PKG_RELEASE:=1
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=0
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 


### PR DESCRIPTION
I realized that the language files can not be selected, when using the date as a version number.