### PR TITLE
Additional 302 loop fix.

### DIFF
--- a/package/gargoyle/files/www/login.sh
+++ b/package/gargoyle/files/www/login.sh
@@ -16,9 +16,9 @@
 		firstboot=$( uci get gargoyle.global.is_first_boot 2>/dev/null )
 		echo "Status: 302 Found" 
 		if [ "$firstboot" = "1" ] ; then
-			echo "Location: firstboot.sh"
+			echo "Location: /firstboot.sh"
 		else
-			echo "Location: overview.sh"
+			echo "Location: /overview.sh"
 		fi
 		echo ""
 		echo ""


### PR DESCRIPTION
* when a theme does not contain `images/favicon.png` file, attempts to
  access the .png cause a 302 Found to overview.sh in the relative path.

* added leading slash to firstboot.sh for consistency.