### PR TITLE
samba: sync patches with CC

### DIFF
--- a/package/samba36/patches/010-patch-cve-2015-5252.patch
+++ b/package/samba36/patches/010-patch-cve-2015-5252.patch
@@ -14,11 +14,9 @@ Reviewed-by: Volker Lendecke <vl@samba.org>
  source3/smbd/vfs.c | 7 +++++--
  1 file changed, 5 insertions(+), 2 deletions(-)
 
-diff --git a/source3/smbd/vfs.c b/source3/smbd/vfs.c
-index 6c56964..bd93b7f 100644
 --- a/source3/smbd/vfs.c
 +++ b/source3/smbd/vfs.c
-@@ -982,6 +982,7 @@ NTSTATUS check_reduced_name(connection_struct *conn, const char *fname)
+@@ -982,6 +982,7 @@ NTSTATUS check_reduced_name(connection_s
  	if (!allow_widelinks || !allow_symlinks) {
  		const char *conn_rootdir;
  		size_t rootdir_len;
@@ -26,7 +24,7 @@ index 6c56964..bd93b7f 100644
  
  		conn_rootdir = SMB_VFS_CONNECTPATH(conn, fname);
  		if (conn_rootdir == NULL) {
-@@ -992,8 +993,10 @@ NTSTATUS check_reduced_name(connection_struct *conn, const char *fname)
+@@ -992,8 +993,10 @@ NTSTATUS check_reduced_name(connection_s
  		}
  
  		rootdir_len = strlen(conn_rootdir);
@@ -39,5 +37,3 @@ index 6c56964..bd93b7f 100644
  			DEBUG(2, ("check_reduced_name: Bad access "
  				"attempt: %s is a symlink outside the "
  				"share path\n", fname));
--- 
-2.5.0

--- a/package/samba36/patches/011-patch-cve-2015-5296.patch
+++ b/package/samba36/patches/011-patch-cve-2015-5296.patch
@@ -12,11 +12,9 @@ Reviewed-by: Jeremy Allison <jra@samba.org>
  source3/libsmb/clidfs.c | 7 ++++++-
  1 file changed, 6 insertions(+), 1 deletion(-)
 
-diff --git a/source3/libsmb/clidfs.c b/source3/libsmb/clidfs.c
-index 23e1471..f153b6b 100644
 --- a/source3/libsmb/clidfs.c
 +++ b/source3/libsmb/clidfs.c
-@@ -98,6 +98,11 @@ static struct cli_state *do_connect(TALLOC_CTX *ctx,
+@@ -98,6 +98,11 @@ static struct cli_state *do_connect(TALL
  	const char *username;
  	const char *password;
  	NTSTATUS status;
@@ -28,7 +26,7 @@ index 23e1471..f153b6b 100644
  
  	/* make a copy so we don't modify the global string 'service' */
  	servicename = talloc_strdup(ctx,share);
-@@ -132,7 +137,7 @@ static struct cli_state *do_connect(TALLOC_CTX *ctx,
+@@ -132,7 +137,7 @@ static struct cli_state *do_connect(TALL
  	zero_sockaddr(&ss);
  
  	/* have to open a new connection */
@@ -37,26 +35,6 @@ index 23e1471..f153b6b 100644
  	if (c == NULL) {
  		d_printf("Connection to %s failed\n", server_n);
  		return NULL;
--- 
-2.5.0
-
-
-From 060adb0abdeda51b8b622c6020b5dea0c8dde1cf Mon Sep 17 00:00:00 2001
-From: Stefan Metzmacher <metze@samba.org>
-Date: Wed, 30 Sep 2015 21:17:02 +0200
-Subject: [PATCH 2/2] CVE-2015-5296: s3:libsmb: force signing when requiring
- encryption in SMBC_server_internal()
-
-BUG: https://bugzilla.samba.org/show_bug.cgi?id=11536
-
-Signed-off-by: Stefan Metzmacher <metze@samba.org>
-Reviewed-by: Jeremy Allison <jra@samba.org>
----
- source3/libsmb/libsmb_server.c | 13 +++++++++++--
- 1 file changed, 11 insertions(+), 2 deletions(-)
-
-diff --git a/source3/libsmb/libsmb_server.c b/source3/libsmb/libsmb_server.c
-index 45be660..167f2c9 100644
 --- a/source3/libsmb/libsmb_server.c
 +++ b/source3/libsmb/libsmb_server.c
 @@ -258,6 +258,7 @@ SMBC_server_internal(TALLOC_CTX *ctx,
@@ -108,5 +86,3 @@ index 45be660..167f2c9 100644
                  if (! NT_STATUS_IS_OK(nt_status)) {
                          DEBUG(1,("cli_full_connection failed! (%s)\n",
                                   nt_errstr(nt_status)));
--- 
-2.5.0

--- a/package/samba36/patches/012-patch-cve-2015-5299.patch
+++ b/package/samba36/patches/012-patch-cve-2015-5299.patch
@@ -14,8 +14,6 @@ Reviewed-by: David Disseldorp <ddiss@samba.org>
  source3/modules/vfs_shadow_copy2.c | 47 ++++++++++++++++++++++++++++++++++++++
  1 file changed, 47 insertions(+)
 
-diff --git a/source3/modules/vfs_shadow_copy2.c b/source3/modules/vfs_shadow_copy2.c
-index fedfb53..16c1ed7 100644
 --- a/source3/modules/vfs_shadow_copy2.c
 +++ b/source3/modules/vfs_shadow_copy2.c
 @@ -21,6 +21,8 @@
@@ -27,7 +25,7 @@ index fedfb53..16c1ed7 100644
  #include "system/filesys.h"
  #include "ntioctl.h"
  
-@@ -764,6 +766,43 @@ static int shadow_copy2_mkdir(vfs_handle_struct *handle,  const char *fname, mod
+@@ -764,6 +766,43 @@ static int shadow_copy2_mkdir(vfs_handle
          SHADOW2_NEXT(MKDIR, (handle, name, mode), int, -1);
  }
  
@@ -71,7 +69,7 @@ index fedfb53..16c1ed7 100644
  static int shadow_copy2_rmdir(vfs_handle_struct *handle,  const char *fname)
  {
          SHADOW2_NEXT(RMDIR, (handle, name), int, -1);
-@@ -877,6 +916,7 @@ static int shadow_copy2_get_shadow_copy2_data(vfs_handle_struct *handle,
+@@ -877,6 +916,7 @@ static int shadow_copy2_get_shadow_copy2
  	SMB_STRUCT_DIRENT *d;
  	TALLOC_CTX *tmp_ctx = talloc_new(handle->data);
  	char *snapshot;
@@ -79,7 +77,7 @@ index fedfb53..16c1ed7 100644
  
  	snapdir = shadow_copy2_find_snapdir(tmp_ctx, handle);
  	if (snapdir == NULL) {
-@@ -886,6 +926,13 @@ static int shadow_copy2_get_shadow_copy2_data(vfs_handle_struct *handle,
+@@ -886,6 +926,13 @@ static int shadow_copy2_get_shadow_copy2
  		talloc_free(tmp_ctx);
  		return -1;
  	}
@@ -93,5 +91,3 @@ index fedfb53..16c1ed7 100644
  
  	p = SMB_VFS_NEXT_OPENDIR(handle, snapdir, NULL, 0);
  
--- 
-2.5.0

--- a/package/samba36/patches/110-multicall.patch
+++ b/package/samba36/patches/110-multicall.patch
@@ -36,7 +36,7 @@
  
  BIN_PROGS1 = bin/smbclient@EXEEXT@ bin/net@EXEEXT@ bin/smbspool@EXEEXT@ \
  	bin/testparm@EXEEXT@ bin/smbstatus@EXEEXT@ bin/smbget@EXEEXT@ \
-@@ -1777,6 +1777,42 @@ bin/.dummy:
+@@ -1799,6 +1799,42 @@ bin/.dummy:
  	  dir=bin $(MAKEDIR); fi
  	@: >> $@ || : > $@ # what a fancy emoticon!
  

--- a/package/samba36/patches/111-owrt_smbpasswd.patch
+++ b/package/samba36/patches/111-owrt_smbpasswd.patch
@@ -1,6 +1,6 @@
 --- a/source3/Makefile.in
 +++ b/source3/Makefile.in
-@@ -1019,7 +1019,7 @@ TEST_LP_LOAD_OBJ = param/test_lp_load.o
+@@ -1025,7 +1025,7 @@ TEST_LP_LOAD_OBJ = param/test_lp_load.o
  
  PASSWD_UTIL_OBJ = utils/passwd_util.o
  
@@ -9,7 +9,7 @@
  		$(PARAM_OBJ) $(LIBSMB_OBJ) $(PASSDB_OBJ) \
  		$(GROUPDB_OBJ) $(LIB_NONSMBD_OBJ) $(KRBCLIENT_OBJ) \
  		$(POPT_LIB_OBJ) $(SMBLDAP_OBJ) \
-@@ -1791,7 +1791,7 @@ nmbd/nmbd_multicall.o: nmbd/nmbd.c nmbd/
+@@ -1813,7 +1813,7 @@ nmbd/nmbd_multicall.o: nmbd/nmbd.c nmbd/
  		echo "$(COMPILE_CC_PATH)" 1>&2;\
  		$(COMPILE_CC_PATH) >/dev/null 2>&1
  
@@ -18,7 +18,7 @@
  	@echo Compiling $<.c
  	@$(COMPILE_CC_PATH) -Dmain=smbpasswd_main && exit 0;\
  		echo "The following command failed:" 1>&2;\
-@@ -1800,7 +1800,7 @@ utils/smbpasswd_multicall.o: utils/smbpa
+@@ -1822,7 +1822,7 @@ utils/smbpasswd_multicall.o: utils/smbpa
  
  SMBD_MULTI_O = $(patsubst smbd/server.o,smbd/server_multicall.o,$(SMBD_OBJ))
  NMBD_MULTI_O = $(patsubst nmbd/nmbd.o,nmbd/nmbd_multicall.o,$(filter-out $(LIB_DUMMY_OBJ),$(NMBD_OBJ)))

--- a/package/samba36/patches/120-add_missing_ifdef.patch
+++ b/package/samba36/patches/120-add_missing_ifdef.patch
@@ -24,3 +24,18 @@
  	epmapper_commands,
  	shutdown_commands,
   	test_commands,
+--- a/source3/rpc_server/srv_pipe.c
++++ b/source3/rpc_server/srv_pipe.c
+@@ -433,10 +433,12 @@ static bool check_bind_req(struct pipes_
+ 	if (ok) {
+ 		context_fns->allow_connect = true;
+ 	}
++#ifdef DEVELOPER
+ 	ok = ndr_syntax_id_equal(abstract, &ndr_table_rpcecho.syntax_id);
+ 	if (ok) {
+ 		context_fns->allow_connect = true;
+ 	}
++#endif
+ 	/*
+ 	 * every interface can be modified to allow "connect" auth_level by
+ 	 * using a parametric option like:

--- a/package/samba36/patches/210-remove_ad_support.patch
+++ b/package/samba36/patches/210-remove_ad_support.patch
@@ -71,7 +71,7 @@
  #endif
 --- a/source3/rpc_client/cli_pipe.c
 +++ b/source3/rpc_client/cli_pipe.c
-@@ -2904,12 +2904,14 @@ NTSTATUS cli_rpc_pipe_open_noauth_transp
+@@ -3391,12 +3391,14 @@ NTSTATUS cli_rpc_pipe_open_noauth_transp
  	status = rpc_pipe_bind(result, auth);
  	if (!NT_STATUS_IS_OK(status)) {
  		int lvl = 0;

--- a/package/samba36/patches/250-remove_domain_logon.patch
+++ b/package/samba36/patches/250-remove_domain_logon.patch
@@ -183,3 +183,31 @@
  
          /*
  	 * Force a log file check.
+--- a/source3/rpc_server/srv_pipe.c
++++ b/source3/rpc_server/srv_pipe.c
+@@ -421,10 +421,12 @@ static bool check_bind_req(struct pipes_
+ 	if (ok) {
+ 		context_fns->allow_connect = false;
+ 	}
++#ifdef NETLOGON_SUPPORT
+ 	ok = ndr_syntax_id_equal(abstract, &ndr_table_netlogon.syntax_id);
+ 	if (ok) {
+ 		context_fns->allow_connect = false;
+ 	}
++#endif
+ 	/*
+ 	 * for the epmapper and echo interfaces we allow "connect"
+ 	 * auth_level by default.
+--- a/source3/rpc_client/cli_pipe.c
++++ b/source3/rpc_client/cli_pipe.c
+@@ -2221,6 +2221,10 @@ static void rpc_pipe_bind_step_two_trigg
+ 				      struct schannel_state);
+ 	struct tevent_req *subreq;
+ 
++#ifndef NETLOGON_SUPPORT
++	tevent_req_nterror(req, NT_STATUS_UNSUCCESSFUL);
++	return;
++#endif
+ 	if (schannel_auth == NULL ||
+ 	    !ndr_syntax_id_equal(&state->cli->abstract_syntax,
+ 				 &ndr_table_netlogon.syntax_id)) {

--- a/package/samba36/patches/260-remove_samr.patch
+++ b/package/samba36/patches/260-remove_samr.patch
@@ -142,3 +142,21 @@
  	if (!str1 || !str2 || !UserName || !p) {
  		return False;
  	}
+--- a/source3/rpc_server/srv_pipe.c
++++ b/source3/rpc_server/srv_pipe.c
+@@ -409,6 +409,7 @@ static bool check_bind_req(struct pipes_
+ 	context_fns->syntax = *abstract;
+ 
+ 	context_fns->allow_connect = lp_allow_dcerpc_auth_level_connect();
++#ifdef SAMR_SUPPORT
+ 	/*
+ 	 * for the samr and the lsarpc interfaces we don't allow "connect"
+ 	 * auth_level by default.
+@@ -417,6 +418,7 @@ static bool check_bind_req(struct pipes_
+ 	if (ok) {
+ 		context_fns->allow_connect = false;
+ 	}
++#endif
+ 	ok = ndr_syntax_id_equal(abstract, &ndr_table_lsarpc.syntax_id);
+ 	if (ok) {
+ 		context_fns->allow_connect = false;

--- a/package/samba36/patches/290-remove_lsa.patch
+++ b/package/samba36/patches/290-remove_lsa.patch
@@ -71,3 +71,18 @@
  }
  
  size_t num_pipe_handles(struct pipes_struct *p)
+--- a/source3/rpc_server/srv_pipe.c
++++ b/source3/rpc_server/srv_pipe.c
+@@ -419,10 +419,12 @@ static bool check_bind_req(struct pipes_
+ 		context_fns->allow_connect = false;
+ 	}
+ #endif
++#ifdef LSA_SUPPORT
+ 	ok = ndr_syntax_id_equal(abstract, &ndr_table_lsarpc.syntax_id);
+ 	if (ok) {
+ 		context_fns->allow_connect = false;
+ 	}
++#endif
+ #ifdef NETLOGON_SUPPORT
+ 	ok = ndr_syntax_id_equal(abstract, &ndr_table_netlogon.syntax_id);
+ 	if (ok) {

--- a/package/samba36/patches/310-remove_error_strings.patch
+++ b/package/samba36/patches/310-remove_error_strings.patch
@@ -65,7 +65,7 @@
  }
 --- a/librpc/ndr/libndr.h
 +++ b/librpc/ndr/libndr.h
-@@ -604,4 +604,20 @@ _PUBLIC_ enum ndr_err_code ndr_push_enum
+@@ -663,4 +663,20 @@ _PUBLIC_ enum ndr_err_code ndr_push_enum
  
  _PUBLIC_ void ndr_print_bool(struct ndr_print *ndr, const char *name, const bool b);
  
@@ -251,3 +251,87 @@
  	print "	       return;";
  	print "       }";
  	print "";
+--- a/source3/rpc_client/cli_pipe.c
++++ b/source3/rpc_client/cli_pipe.c
+@@ -445,7 +445,6 @@ static NTSTATUS cli_pipe_validate_curren
+ 				  rpccli_pipe_txt(talloc_tos(), cli),
+ 				  pkt->ptype, expected_pkt_type,
+ 				  nt_errstr(ret)));
+-			NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 			return ret;
+ 		}
+ 
+@@ -466,7 +465,6 @@ static NTSTATUS cli_pipe_validate_curren
+ 				  rpccli_pipe_txt(talloc_tos(), cli),
+ 				  pkt->ptype, expected_pkt_type,
+ 				  nt_errstr(ret)));
+-			NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 			return ret;
+ 		}
+ 
+@@ -486,7 +484,6 @@ static NTSTATUS cli_pipe_validate_curren
+ 				  rpccli_pipe_txt(talloc_tos(), cli),
+ 				  pkt->ptype, expected_pkt_type,
+ 				  nt_errstr(ret)));
+-			NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 			return ret;
+ 		}
+ 
+@@ -508,7 +505,6 @@ static NTSTATUS cli_pipe_validate_curren
+ 				  rpccli_pipe_txt(talloc_tos(), cli),
+ 				  pkt->ptype, expected_pkt_type,
+ 				  nt_errstr(ret)));
+-			NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 			return ret;
+ 		}
+ 
+@@ -526,7 +522,6 @@ static NTSTATUS cli_pipe_validate_curren
+ 				  rpccli_pipe_txt(talloc_tos(), cli),
+ 				  pkt->ptype, expected_pkt_type,
+ 				  nt_errstr(ret)));
+-			NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 			return ret;
+ 		}
+ 
+@@ -570,7 +565,6 @@ static NTSTATUS cli_pipe_validate_curren
+ 				  rpccli_pipe_txt(talloc_tos(), cli),
+ 				  pkt->ptype, expected_pkt_type,
+ 				  nt_errstr(ret)));
+-			NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 			return ret;
+ 		}
+ 
+--- a/source3/rpc_server/srv_pipe.c
++++ b/source3/rpc_server/srv_pipe.c
+@@ -991,7 +991,6 @@ static bool api_pipe_bind_req(struct pip
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		DEBUG(1, ("api_pipe_bind_req: invalid pdu: %s\n",
+ 			  nt_errstr(status)));
+-		NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 		goto err_exit;
+ 	}
+ 
+@@ -1325,7 +1324,6 @@ bool api_pipe_bind_auth3(struct pipes_st
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		DEBUG(1, ("api_pipe_bind_auth3: invalid pdu: %s\n",
+ 			  nt_errstr(status)));
+-		NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 		goto err;
+ 	}
+ 
+@@ -1483,7 +1481,6 @@ static bool api_pipe_alter_context(struc
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		DEBUG(1, ("api_pipe_alter_context: invalid pdu: %s\n",
+ 			  nt_errstr(status)));
+-		NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 		goto err_exit;
+ 	}
+ 
+@@ -2057,7 +2054,6 @@ static bool process_request_pdu(struct p
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		DEBUG(1, ("process_request_pdu: invalid pdu: %s\n",
+ 			  nt_errstr(status)));
+-		NDR_PRINT_DEBUG(ncacn_packet, pkt);
+ 		set_incoming_fault(p);
+ 		return false;
+ 	}

--- a/package/samba36/patches/330-librpc_default_print.patch
+++ b/package/samba36/patches/330-librpc_default_print.patch
@@ -8844,7 +8844,7 @@
 +done
 --- a/librpc/ndr/libndr.h
 +++ b/librpc/ndr/libndr.h
-@@ -603,6 +603,7 @@ _PUBLIC_ enum ndr_err_code ndr_push_enum
+@@ -662,6 +662,7 @@ _PUBLIC_ enum ndr_err_code ndr_push_enum
  _PUBLIC_ enum ndr_err_code ndr_push_enum_uint1632(struct ndr_push *ndr, int ndr_flags, uint16_t v);
  
  _PUBLIC_ void ndr_print_bool(struct ndr_print *ndr, const char *name, const bool b);


### PR DESCRIPTION
https://dev.openwrt.org/changeset/49177

CC: samba: fix some security problems
Backport of r49175.
This fixes the following security problems:
CVE-2015-7560
CVE-2015-5370
CVE-2016-2110
CVE-2016-2111
CVE-2016-2112
CVE-2016-2115
CVE-2016-2118