### PR TITLE
Time & Date restore fix. PPPoE fix.

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/restore.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/restore.sh
@@ -106,6 +106,9 @@ old_hqu1=$(uci get "gargoyle.help.qos_up_1")
 old_hqu2=$(uci get "gargoyle.help.qos_up_2")
 old_hqd1=$(uci get "gargoyle.help.qos_down_1")
 old_hqd2=$(uci get "gargoyle.help.qos_down_2")
+# preserve previous time/date format
+old_tformat=$(uci get "gargoyle.global.hour_style")
+old_dformat=$(uci get "gargoyle.global.dateformat")
 cp /tmp/gargoyle.bak /etc/config/gargoyle
 if [ -n "$old_timeout" ] ; then
 	uci set gargoyle.global.session_timeout=$old_timeout
@@ -127,6 +130,12 @@ if [ -n "$old_hqd1" ] ; then
 fi
 if [ -n "$old_hqd2" ] ; then
 	uci set gargoyle.help.qos_down_2=$old_hqd2
+fi
+if [ -n "$old_tformat" ] ; then
+	uci set gargoyle.global.hour_style=$old_tformat
+fi
+if [ -n "$old_dformat" ] ; then
+	uci set gargoyle.global.dateformat=$old_dformat
 fi
 	
 is_bridge=$(echo $(uci show wireless | grep wds) $(uci show wireless | grep client_bridge))

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -612,6 +612,8 @@ function saveChanges()
 			else
 			{
 				uci.set("network", "wan", "proto", getSelectedValue('wan_protocol').replace(/_.*$/g, ""));
+				//Fixes some pppoe issues. To be removed if ipv6 is implemented.
+				uci.set("network", "wan", "ipv6", "0");
 			}
 			if(uci.get('network', 'lan', 'proto') === '')
 			{


### PR DESCRIPTION
Properly restore time and date formats from the backup files. Fixes #528 .
Disable ipv6 on WAN interface. This fixes an issue for some PPPoE users, and causes no harm to other users until we implement ipv6 properly. Fixes #523 