### PR TITLE
Add wps file back to rc.button to make work reboot button again on all supported devices.

### DIFF
--- a/patches-generic/028-add-procd-wps-button.patch
+++ b/patches-generic/028-add-procd-wps-button.patch
@@ -1,0 +1,6 @@
+--- a/package/base-files/files/etc/rc.button/wps	1970-01-01 01:00:00.000000000 +0100
++++ b/package/base-files/files/etc/rc.button/wps	2016-06-20 11:14:16.000000000 +0200
+@@ -0,0 +1,3 @@
++#!/bin/sh
++
++return 0


### PR DESCRIPTION
Hi,

This commit breaks to install "hostapd-utils" package because it contains the same name of file (wps) on the same path.
So "hostapd-utils" package needs the --force-overwrite switch to install it. But I think, because it's not bundled with Gargoyle, it's not relevant...
