### PR TITLE
ewget: fix for compile with openssl

### DIFF
--- a/package/ewget/src/libewget.c
+++ b/package/ewget/src/libewget.c
@@ -1337,6 +1337,8 @@ static void destroy_connection_http(void* connection_data)
 
 #ifdef HAVE_SSL
 
+#ifdef USE_POLARSSL
+
 static int urandom_fd = -1;
 static int ewget_urandom_init(void)
 {
@@ -1360,6 +1362,7 @@ static int ewget_urandom(void *ctx, unsigned char *out, size_t len)
 
 	return 0;
 }
+#endif
 
 
 static void* initialize_connection_https(char* host, int port)


### PR DESCRIPTION
Without this, if compilation is with openssl:
```
libewget.c: In function 'ewget_urandom':
libewget.c:1359:10: error: 'POLARSSL_ERR_ENTROPY_SOURCE_FAILED' undeclared (first use in this function)
   return POLARSSL_ERR_ENTROPY_SOURCE_FAILED;
          ^
```
