### PR TITLE
Bump Openwrt to latest. + Kernel 3.18.44

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ set_version_variables()
 	# set precise commit in repo to use 
 	# you can set this to an alternate commit 
 	# or empty to checkout latest 
-	openwrt_commit="eadf19c0b43d2f75f196ea8d875a08c7c348530c"
+	openwrt_commit="1378f4a4d9908dd48dcf21ee526334d86344ec68"
 	openwrt_abbrev_commit=$( echo "$openwrt_commit" | cut -b 1-7 )
 	
 


### PR DESCRIPTION
Hi I have build tested a bump to Openwrt on target= mvebu
I bumped Openwrt to commit 1378f4a4d9908dd48dcf21ee526334d86344ec68

Runs fine on my wrt1900 ac v2
This brings the Kernel up to 3.18.44
https://git.openwrt.org/?p=15.05/openwr ... d86344ec68

Here is my build log:
https://dl.dropboxusercontent.com/u/5377433/log.txt

It seems to be running fine.
I have tested addblock USB storage Bandwidth graphs ddns UPMP qos 2.4 and 5 ghz radios the firewall with a port scanner adding and removing plugins.

The one thing that is not working for me is syslog

Pleas note that I haven't tested on any other routers
If there is any thing wrong with this pleas let me know I am a real noob at this stuff! :D