### PR TITLE
plugin usb-printer: Additional fallback to generate USB printer name

### DIFF
--- a/package/plugin-gargoyle-usb-printer/files/usr/lib/gargoyle/configure_printer.sh
+++ b/package/plugin-gargoyle-usb-printer/files/usr/lib/gargoyle/configure_printer.sh
@@ -63,6 +63,9 @@ if [ -z "$printer" ] ; then
 	printer=$(printf "%s" "$usb_device_lines" | grep "Driver=usblp" | sed 's/^.*SerialNumber=//g' | sed 's/ .:.*$//g'| head -n1)
 	if [ -n "$printer" ] ; then
 		printer="Unknown Printer with S/N $printer"
+	else
+		printer=$(printf "%s" "$usb_device_lines" | grep "Driver=usblp" | sed 's/^.*Vendor=/Vendor=/g' | sed 's/ .:.*$//g'| head -n1)
+		printer="Unknown Printer $printer"
 	fi
 fi
 


### PR DESCRIPTION
If an USB printer neither provides Product nor SerialNumber tag, the
printer configuration scripts fail to generate a printer name and exits.
This change adds an additional fallback combining Vendor, ProdID, and
Rev tag to generate a printer name. These tags should be available for
all USB devices.

This change fixes ericpaulbishop/gargoyle#587