### PR TITLE
plugin usb-printer: fix for additional fallback to generate USB printer name

### DIFF
--- a/package/plugin-gargoyle-usb-printer/files/usr/lib/gargoyle/configure_printer.sh
+++ b/package/plugin-gargoyle-usb-printer/files/usr/lib/gargoyle/configure_printer.sh
@@ -65,7 +65,9 @@ if [ -z "$printer" ] ; then
 		printer="Unknown Printer with S/N $printer"
 	else
 		printer=$(printf "%s" "$usb_device_lines" | grep "Driver=usblp" | sed 's/^.*Vendor=/Vendor=/g' | sed 's/ .:.*$//g'| head -n1)
-		printer="Unknown Printer $printer"
+		if [ -n "$printer" ] ; then
+			printer="Unknown Printer $printer"
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Previous change #588 failed to remove printer from UI upon disconnection, see https://github.com/ericpaulbishop/gargoyle/pull/588#commitcomment-20440884.