### PR TITLE
Fix disk_format and extroot_fieldset not showing up in some cases

### DIFF
--- a/package/plugin-gargoyle-usb-storage/files/www/usb_storage.sh
+++ b/package/plugin-gargoyle-usb-storage/files/www/usb_storage.sh
@@ -214,11 +214,9 @@
 			</div>
 
 			<div class="panel-body">
-				<div class="form-group">
-					<button id="extroot_button" class="btn btn-danger btn-lg" onclick="disableExtroot();"><%~ ExtrOff %></button>
-					<br />
-					<br />
-					<em><%~ ExtDt %> <strong><span id="extroot_drive"></span></strong>.</em>
+				<div class="row form-group">
+					<span class="col-xs-12"><button id="extroot_button" class="btn btn-danger btn-lg" onclick="disableExtroot();"><%~ ExtrOff %></button></span>
+					<span class="col-xs-12 alert alert-warning"><em><%~ ExtDt %> <strong><span id="extroot_drive"></span></strong>.</em></span>
 				</div>
 			</div>
 		</div>

--- a/package/plugin-gargoyle-usb-storage/files/www/usb_storage.sh
+++ b/package/plugin-gargoyle-usb-storage/files/www/usb_storage.sh
@@ -153,7 +153,9 @@
 			</div>
 		</div>
 	</div>
+</div>
 
+<div class="row">
 	<div id="disk_format" class="col-lg-6">
 		<div class="panel panel-default">
 			<div class="panel-heading">
@@ -212,8 +214,10 @@
 			</div>
 
 			<div class="panel-body">
-				<div class="row form-group">
-					<button id="extroot_button" class="btn btn-default" onclick="disableExtroot();"><%~ ExtrOff %></button>
+				<div class="form-group">
+					<button id="extroot_button" class="btn btn-danger btn-lg" onclick="disableExtroot();"><%~ ExtrOff %></button>
+					<br />
+					<br />
 					<em><%~ ExtDt %> <strong><span id="extroot_drive"></span></strong>.</em>
 				</div>
 			</div>


### PR DESCRIPTION
Move disk_format and extroot_fieldset to their own row.
Fixes those panels not displaying when you have attached but unmounted drives on the system.