### PR TITLE
cache_basic_vars.sh: fix channel's parsing for VHT160

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/cache_basic_vars.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/cache_basic_vars.sh
@@ -57,7 +57,7 @@ print_mac80211_channels_for_wifi_dev()
 	# however, as far as I can tell there is no other way to get max txpower for each channel
 	# so... here it goes.
 	# If stuff gets FUBAR, take a look at iw output, and see if this god-awful expression still works
-	iw "phy${dev_num}" info 2>&1 | sed -e '/MHz/!d; /GI/d; /disabled/d; /radar detect /d;s/[:blank:]*\*[:blank:]*//g; s:[]()[]::g; s/\..*$//g' | awk ' { print "nextCh.push("$3"); nextChFreq["$3"] = \""$1"MHz\"; nextChPwr["$3"] = "$4";"   ; } ' >> "$out"
+	iw "phy${dev_num}" info 2>&1 | sed -e '/MHz/!d; /GI/d; /disabled/d; /radar detect /d; /Supported Channel Width/d; s/[:blank:]*\*[:blank:]*//g; s:[]()[]::g; s/\..*$//g' | awk ' { print "nextCh.push("$3"); nextChFreq["$3"] = \""$1"MHz\"; nextChPwr["$3"] = "$4";"   ; } ' >> "$out"
 
 	echo "mac80211Channels[\"$chId\"] = nextCh ;"     >> "$out"
 	echo "mac80211ChFreqs[\"$chId\"]  = nextChFreq ;" >> "$out"


### PR DESCRIPTION
Device: Linksys WRT3200ACM

root@Gargoyle:~# iw phy0 info
Wiphy phy0
        max # scan SSIDs: 4
[...]
                        Supported Channel Width: 160 MHz
[...]
                        * 5180 MHz [36] (23.0 dBm)
                        * 5200 MHz [40] (23.0 dBm)
                        * 5220 MHz [44] (23.0 dBm)
[...]

This Linksys supports 160MHz channel width, current version of the script gives incorrect data in the tables:

nextCh.push(Width:); nextChFreq[Width:] = "SupportedMHz"; nextChPwr[Width:] = 160;
nextCh.push(36); nextChFreq[36] = "5180MHz"; nextChPwr[36] = 23;
nextCh.push(40); nextChFreq[40] = "5200MHz"; nextChPwr[40] = 23;
nextCh.push(44); nextChFreq[44] = "5220MHz"; nextChPwr[44] = 23;