### PR TITLE
Fixes to Bridge Config + Guest Network + Fix large graphs

### DIFF
--- a/package/gargoyle/files/www/bandwidth.sh
+++ b/package/gargoyle/files/www/bandwidth.sh
@@ -103,17 +103,17 @@
 
 				<div id="bandwidth_graphs" class="row">
 					<h1 class="page-header"><%~ BGrSect %></h1>
-					<div class="col-lg-4">
-						<div class="col-lg-12">
+					<div class="col-lg-4 col-md-12 col-sm-8 col-xs-12">
+						<div class="col-lg-12 col-md-6 col-xs-12">
 							<span class="bandwidth_title_text"><strong><%~ Dnld %></strong> (<span onclick="expand('<%~ Dnld %>')" class="pseudo_link"><%~ expd %></span>)</span>
 							<embed id="download_plot" style="margin-left:0px; margin-right:5px; float:left; width:100%; height:100%;" src="bandwidth.svg" type="image/svg+xml" pluginspage="http://www.adobe.com/svg/viewer/install/" />
 						</div>
-						<div class="col-lg-12">
+						<div class="col-lg-12 col-md-6 col-xs-12">
 							<span class="bandwidth_title_text"><strong><%~ Upld %></strong> (<span onclick="expand('<%~ Upld %>')" class="pseudo_link"><%~ expd %></span>)</span>
 							<embed id="upload_plot" style="margin-left:0px; margin-right:5px; float:left; width:100%; height:100%;" src="bandwidth.svg" type="image/svg+xml" pluginspage="http://www.adobe.com/svg/viewer/install/" />
 						</div>
 					</div>
-					<div class="col-lg-8">
+					<div class="col-lg-8 col-xs-12">
 						<span class="bandwidth_title_text"><strong><%~ Totl %></strong> (<span onclick="expand('<%~ Totl %>')" class="pseudo_link"><%~ expd %></span>)</span>
 						<br/>
 						<embed id="total_plot" style="width:100%; height:100%;" src="bandwidth.svg" type="image/svg+xml" pluginspage="http://www.adobe.com/svg/viewer/install/" />

--- a/package/gargoyle/files/www/bandwidth_distribution.sh
+++ b/package/gargoyle/files/www/bandwidth_distribution.sh
@@ -75,7 +75,7 @@
 			<h3 class="panel-title"><%~ BDst %>:</h3>
 		</div>
 		<div class="panel-body">
-			<span class="col-xs-12"><embed id="pie_chart" src="multi_pie.svg"  type="image/svg+xml" pluginspage="http://www.adobe.com/svg/viewer/install/"></embed></span>
+			<span class="col-lg-8 col-xs-12"><embed id="pie_chart" src="multi_pie.svg"  type="image/svg+xml" pluginspage="http://www.adobe.com/svg/viewer/install/"></embed></span>
 		</div>
 	</div>
 </div>

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -134,18 +134,18 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					</span>
 				</div>
 
+				<div id="bridge_gateway_container" class="row form-group">
+					<label class="col-xs-5" for="bridge_gateway" id="bridge_gateway_label"><%~ GwIP %>:</label>
+					<span class="col-xs-7">
+						<input type="text" class="form-control" name="bridge_gateway" id="bridge_gateway" onkeyup="proofreadIp(this)" size="20" maxlength="15" />
+					</span>
+				</div>
+
 				<div id="bridge_mask_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_mask" id="bridge_mask_label"><%~ SMsk %>:</label>
 					<span class="col-xs-7">
 						<input type="text" class="form-control" name="bridge_mask" id="bridge_mask" onkeyup="proofreadMask(this)" size="20" maxlength="15" />
 						<em><%~ SMNote %></em>
-					</span>
-				</div>
-
-				<div id="bridge_gateway_container" class="row form-group">
-					<label class="col-xs-5" for="bridge_gateway" id="bridge_gateway_label"><%~ GwIP %>:</label>
-					<span class="col-xs-7">
-						<input type="text" class="form-control" name="bridge_gateway" id="bridge_gateway" onkeyup="proofreadIp(this)" size="20" maxlength="15" />
 					</span>
 				</div>
 
@@ -299,7 +299,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_channel_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_channel" id="bridge_channel_label"><%~ WChn %>:</label>
 					<span class="col-xs-7">
-						<select id="bridge_channel" lass="form-control" onchange="setChannel(this)">
+						<select id="bridge_channel" class="form-control" onchange="setChannel(this)">
 							<option value="auto"><%~ auto %></option>
 							<option value="1">1</option>
 							<option value="2">2</option>

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -1889,28 +1889,31 @@ function resetData()
 		var htGMode = uciOriginal.get("wireless", wifiDevG, "htmode");
 		var htAMode = uciOriginal.get("wireless", wifiDevA, "htmode");
 
-		if((htGMode != "NONE") && (htGMode != ""))
+		if((htGMode != "NONE") && (htGMode != "") && (otherdev == "" || otherdev == wifiDevG))
 		{
 			setSelectedValue("wifi_hwmode", "11gn");
 			setSelectedValue("bridge_hwmode", "11gn");
 		}
-		else if((htGMode == ""))
+		else if(((htGMode == "") || (htGMode == "NONE")) && (otherdev == "" || otherdev == wifiDevG))
 		{
 			setSelectedValue("wifi_hwmode", "11g");
 			setSelectedValue("bridge_hwmode", "11g");
 		}
 
-		if((htAMode != "NONE") && (htAMode != ""))
+		if((htAMode != "NONE") && (htAMode != "") && (otherdev == "" || otherdev == wifiDevA))
 		{
 			setSelectedValue("wifi_hwmode_5ghz", "11an");
+			setSelectedValue("bridge_hwmode", "11an");
 			if(/VHT/i.test(htAMode))
 			{
 				setSelectedValue("wifi_hwmode_5ghz", "11anac");
+				setSelectedValue("bridge_hwmode", "11anac");
 			}
 		}
-		else if((htAMode == ""))
+		else if(((htAMode == "") || (htAMode == "NONE")) && (otherdev == "" || otherdev == wifiDevA))
 		{
 			setSelectedValue("wifi_hwmode_5ghz", "11a");
+			setSelectedValue("bridge_hwmode", "11a");
 		}
 
 		setSelectedValue("wifi_channel_width", htGMode);
@@ -1926,7 +1929,6 @@ function resetData()
 	else
 	{
 		document.getElementById("bridge_channel_width_container").style.display="none";
-		document.getElementById("bridge_hwmode_container").style.display = "none";
 		hwGmode = uciOriginal.get("wireless", wifiDevG, "hwmode");
 		hwAmode = uciOriginal.get("wireless", wifiDevA, "hwmode");
 		setSelectedValue("wifi_hwmode", hwGmode);
@@ -3180,7 +3182,7 @@ function setHwMode(selectCtl)
 		var cli_only = cid.match(/2_/) || cid.match(/2a_/)
 		var cli_ap_mismatch = (ap_only && !wimode.match(/ap/)) || (cli_only && !wimode.match(/sta/))
 		var hide_in_favor_of_fixed_channel = fixedChannels && (cid.match(/channel/) && (!cid.match(/channel_width/))) && ((!wimode.match(/ap/)) || fixedChannelBand == cBand);
-		var displayWithoutWidth = cid ==  "wifi_ssid1_container" || cid == "wifi_ssid1a_container" || cid == "wifi_txpower_container" || cid == "wifi_txpower_5ghz_container" || cid == "wifi_channel1_container" || cid == "wifi_channel2_container" || cid == "bridge_txpower_container" || cid == 'bridge_channel_container' || cid == "wifi_guest_ssid1_container" || cid == "wifi_guest_ssid1a_container"
+		var displayWithoutWidth = cid ==  "wifi_ssid1_container" || cid == "wifi_ssid1a_container" || cid == "wifi_txpower_container" || cid == "wifi_txpower_5ghz_container" || cid == "wifi_channel1_container" || cid == "wifi_channel2_container" || cid == "bridge_txpower_container" || cid == 'bridge_channel_container' || cid == "wifi_guest_ssid1_container" || cid == "wifi_guest_ssid1a_container" || cid == "bridge_channel_5ghz_container" || cid == "bridge_txpower_5ghz_container"
 		var isitbridge = 1 && document.getElementById("global_bridge").checked; //are we looking at bridge?
 		var bridgeModeA = getSelectedValue("bridge_hwmode"); //true or false, are we using 5ghz for bridge?
 		var bridgeModeA = !(String(bridgeModeA).match(/11g/))

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -1316,7 +1316,7 @@ function setWifiVisibility()
 	var p1 = (e1 != 'none' && e1 != 'wep') ? 1 : 0;
 	var w1 = (e1 == 'wep') ? 1 : 0;
 	var r1 = (e1 == 'wpa' || e1 == 'wpa2') ? 1 : 0;
-	var gns = wirelessDriver == "mac80211" || wirelessDriver == "atheros"; //drivers that support guest networks
+	var gns = (wirelessDriver == "mac80211" && !isb43) || wirelessDriver == "atheros"; //drivers that support guest networks
 	var gn = getSelectedValue("wifi_guest_mode") != "disabled" ? 1 : 0;
 	var gng = getSelectedValue("wifi_guest_mode") == "24ghz" || getSelectedValue("wifi_guest_mode") == 'dual'  ? 1 : 0;
 	var gna = getSelectedValue("wifi_guest_mode") == "5ghz" || getSelectedValue("wifi_guest_mode") == 'dual' ? 1 : 0;

--- a/package/gargoyle/files/www/js/overview.js
+++ b/package/gargoyle/files/www/js/overview.js
@@ -228,6 +228,7 @@ function resetData()
 		setChildText("bridge_gateway", uciOriginal.get("network", "lan", "gateway") );
 		setChildText("bridge_mode", uciOriginal.get("wireless", bridgeSection, "client_bridge") == "1" ? ovwS.ClBr : "WDS");
 		setChildText("bridge_ssid", uciOriginal.get("wireless", bridgeSection, "ssid") );
+		setChildText("bridge_relay_ip", uciOriginal.get("network", "bridgecfg", "ipaddr"));
 	}
 
 	setChildText("qos_upload", qosUploadStatus);

--- a/package/gargoyle/files/www/overview.sh
+++ b/package/gargoyle/files/www/overview.sh
@@ -203,23 +203,28 @@
 			<div class="panel-body">
 				<ul class="list-group">
 					<li class="list-group-item">
+						<span class="list-group-item-title"><%~ BrRIP %>:</span>
+						<span id="bridge_relay_ip"></span>
+					</li>
+
+					<li class="list-group-item">
 						<span class="list-group-item-title"><%~ BrIPA %>:</span>
 						<span id="bridge_ip"></span>
 					</li>
 
 					<li class="list-group-item">
-						<span class="list-group-item-title"><%~ BrNMsk %>:</span>
+						<span class="list-group-item-title"><%~ LGtwy %>:</span>
+						<span id="bridge_gateway"></span>
+					</li>
+
+					<li class="list-group-item">
+						<span class="list-group-item-title"><%~ LNmsk %>:</span>
 						<span id="bridge_mask"></span>
 					</li>
 
 					<li class="list-group-item">
 						<span class="list-group-item-title"><%~ BrMAdd %></span>
 						<span id="bridge_mac"></span>
-					</li>
-
-					<li class="list-group-item">
-						<span class="list-group-item-title"><%~ LGtwy %>:</span>
-						<span id="bridge_gateway"></span>
 					</li>
 
 					<li class="list-group-item">

--- a/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/overview.js
+++ b/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/overview.js
@@ -21,6 +21,7 @@ ovwS.CPUAvg="CPU Load Averages";
 ovwS.Uptm="Uptime";
 ovwS.CDaT="Current Date &amp; Time";
 ovwS.BrIPA="Bridge IP Address";
+ovwS.BrRIP="Relay IP Address";
 ovwS.BrNMsk="Bridge Netmask";
 ovwS.BrMAdd="Bridge MAC Address";
 ovwS.LGtwy="LAN Gateway IP";


### PR DESCRIPTION
- Make bridge configs clearer by rearranging elements
- Fix bridge logic causing displayed settings to not match configured settings
- Display the Relay IP on the overview page so people can find it without digging in the console
- Disable Guest Network on b43 devices
- Fix large graphs

I feel like basic.js is becoming more and more cobbled together and may need a complete rewrite. I think that is mostly my fault. Low priority, but definitely standing in the way of IPv6.