### PR TITLE
compile fixes necessary to fix qos compile error

### DIFF
--- a/package/qos-gargoyle/Makefile
+++ b/package/qos-gargoyle/Makefile
@@ -15,7 +15,7 @@ define Package/qos-gargoyle
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=A set of QoS scripts designed for use with Gargoyle Web Interface
-	DEPENDS:=+tc +ip +kmod-sched +iptables-mod-filter +iptables-mod-ipopt  +iptables-mod-imq +gargoyle-firewall-util
+	DEPENDS:=+tc +ip +kmod-sched +iptables-mod-filter +iptables-mod-ipopt  +iptables-mod-imq +gargoyle-firewall-util +libncurses
 	MAINTAINER:=Eric Bishop <eric@gargoyle-router.com>
 endef
 
@@ -48,7 +48,7 @@ define Package/qos-gargoyle/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(INSTALL_DIR) $(1)/etc/config
-	
+
 	$(INSTALL_BIN) ./files/qos_gargoyle.init $(1)/etc/init.d/qos_gargoyle
 	$(INSTALL_BIN) ./files/qos_gargoyle.hotplug $(1)/etc/hotplug.d/iface/23-qos_gargoyle
 	$(INSTALL_DATA) ./files/qos_gargoyle.conf $(1)/etc/config/qos_gargoyle

--- a/package/qos-gargoyle/src/Makefile
+++ b/package/qos-gargoyle/src/Makefile
@@ -1,5 +1,5 @@
 BINDIR = /usr/sbin
-TCDIR:=$(BUILD_DIR)/iproute2*/ip*
+TCDIR:=$(BUILD_DIR)/iproute2-tiny/ip*
 
 #The ncurses library only needed if we remove the ONLYBG switch
 #below.  Mostly for debug


### PR DESCRIPTION
These changes are necessary to avoid compile errors in qos.