### PR TITLE
fix include of iproute

### DIFF
--- a/package/qos-gargoyle/src/Makefile
+++ b/package/qos-gargoyle/src/Makefile
@@ -1,5 +1,5 @@
 BINDIR = /usr/sbin
-TCDIR:=$(BUILD_DIR)/iproute2*/ip*
+TCDIR:=$(BUILD_DIR)/iproute2-tiny/ip*
 
 #The ncurses library only needed if we remove the ONLYBG switch
 #below.  Mostly for debug


### PR DESCRIPTION
The current qos makefile matches two directories for iproute causing
multiple define errors.