### PR TITLE
Move ubnt airrouter from default to usb

### DIFF
--- a/targets/ar71xx/profiles/default/profile_images
+++ b/targets/ar71xx/profiles/default/profile_images
@@ -61,7 +61,6 @@
 -n150r-squashfs-
 -rnx-n360rt-
 -ubnt-air-gateway-squashfs-
--ubnt-airrouter-squashfs-
 -ubnt-bullet-m-squashfs-
 -ubnt-ls-sr71-squashfs-
 -ubnt-nano-m-squashfs-

--- a/targets/ar71xx/profiles/usb/profile_images
+++ b/targets/ar71xx/profiles/usb/profile_images
@@ -45,6 +45,7 @@
 -tube2h-8M-squashfs-
 -rw2458n-squashfs-
 -wnr2200-squashfs-
+-ubnt-airrouter-squashfs-
 -ubnt-unifi-outdoor-squashfs-
 -ubnt-unifi-squashfs-
 -mynet-rext-squashfs-


### PR DESCRIPTION
As per [this forum post](https://www.gargoyle-router.com/phpbb/viewtopic.php?f=5&t=8213&start=10#p42167), it works and should be there