### PR TITLE
Fast fix for board wr8305rt, wan macaddr variable must ALWAYS be set.

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/cache_basic_vars.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/cache_basic_vars.sh
@@ -99,7 +99,8 @@ echo "var isBcm94704 = $isbcm94704;" >> "$out_file"
 echo "var allLanMacs = [];" >> "$out_file"
 brctl showmacs br-lan | grep "yes" | awk ' { print "allLanMacs.push(\"" $2 "\");" } ' >> "$out_file"
 
-
+# determine if this board is a ramips, for which the uci wan macaddr variable must ALWAYS be set
+[ -f /lib/ramips.sh ] && echo "var ramips = 'true';" >> "$out_file"
 
 echo "var wifiDevG=uciWirelessDevs.length > 0 ? uciWirelessDevs[0] : \"\";" >> "$out_file"
 echo "var wifiDevA=\"\";" >> "$out_file"

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -629,11 +629,11 @@ function saveChanges()
 			}
 
 			//preserve wan mac definition even if wan is disabled if this is a bcm94704
-			if(isBcm94704 && (uci.get("network", "wan", "type") != "bridge"))
+			if((isBcm94704 || ramips) && (uci.get("network", "wan", "type") != "bridge"))
 			{
 				if(uci.get("network", "wan", "macaddr") == "")
 				{
-					uci.set("network", "wan", "macaddr", defaultWanMac);
+					uci.set("network", "wan", "macaddr", defaultWanMac.toLowerCase());
 				}
 			}
 


### PR DESCRIPTION
After the initial setup, the gargoyle removes the mac address of the wan interface and after restart the wan port changes the mac address.