### PR TITLE
Fix Spectrum Analyser plugin + Restore strings to firstboot

### DIFF
--- a/package/gargoyle/files/www/firstboot.sh
+++ b/package/gargoyle/files/www/firstboot.sh
@@ -6,7 +6,7 @@
 	# itself remain covered by the GPL.
 	# See http://gargoyle-router.com/faq.html#qfoss for more information
 	eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time"  )
-	gargoyle_header_footer -h -c "internal.css" -j "firstboot.js" -z "firstboot.js" system
+	gargoyle_header_footer -h -c "internal.css" -j "firstboot.js time.js" -z "firstboot.js time.js" system
 %>
 
 <script>

--- a/package/plugin-gargoyle-spectrum-analyser/files/full/www/js/spectrum_analyser.js
+++ b/package/plugin-gargoyle-spectrum-analyser/files/full/www/js/spectrum_analyser.js
@@ -369,7 +369,7 @@ function generateGraphData(detected)
 		var level = detected[3][x];
 		var vhtwidth = detected[4][x];
 		var vhtseg1 = detected[5][x];
-		var vhtseg2 = detected[6][x];
+		var vhtseg2 = (detected[6][x] == 0 ? null:detected[6][x]);
 		var BSSID = detected[7][x].replace(/:/g,"");
 		
 		if(band == "2.4GHz")
@@ -419,10 +419,10 @@ function generateGraphData(detected)
 				{
 					if(! vhtseg2)							//80mhz
 					{
-						plotdata[y] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(channel,2)};
-						plotdata[y+1] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(channel,2)+freqoffset)};
-						plotdata[y+2] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData((channel-(-vhtoffset)),3)-freqoffset)};
-						plotdata[y+3] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData((channel-(-vhtoffset)),3)};
+						plotdata[y] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(vhtseg1-(0.5*vhtoffset),2)};
+						plotdata[y+1] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(vhtseg1-(0.5*vhtoffset),2)+freqoffset)};
+						plotdata[y+2] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData((vhtseg1-(-0.5*vhtoffset)),3)-freqoffset)};
+						plotdata[y+3] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData((vhtseg1-(-0.5*vhtoffset)),3)};
 					}
 					else if(Math.abs(vhtseg1 - vhtseg2) == 8)	//160mhz
 					{
@@ -458,10 +458,10 @@ function generateGraphData(detected)
 				{
 					if(! vhtseg2)							//80mhz
 					{
-						plotdata[y] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(channel-vhtoffset,2)};
-						plotdata[y+1] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(channel-vhtoffset,2)+freqoffset)};
-						plotdata[y+2] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(channel,3)-freqoffset)};
-						plotdata[y+3] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(channel,3)};
+						plotdata[y] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(vhtseg1-(0.5*vhtoffset),2)};
+						plotdata[y+1] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(vhtseg1-(0.5*vhtoffset),2)+freqoffset)};
+						plotdata[y+2] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData((vhtseg1-(-0.5*vhtoffset)),3)-freqoffset)};
+						plotdata[y+3] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData((vhtseg1-(-0.5*vhtoffset)),3)};
 					}
 					else if(Math.abs(vhtseg1 - vhtseg2) == 8)	//160mhz
 					{
@@ -512,8 +512,8 @@ function generateTableData(detected)
 		var level = detected[3][x];
 		var vhtwidth = detected[4][x];
 		var vhtseg1 = detected[5][x];
-		var vhtseg2 = detected[6][x];
-		var BSSID = detected[7][x];
+		var vhtseg2 = (detected[6][x] == 0 ? null:detected[6][x]);
+		var BSSID = detected[7][x].toUpperCase();
 		var htmode = detected[8][x];
 		var vhtmode = detected[9][x];
 		//var encryption = detected[8][x];
@@ -549,7 +549,7 @@ function generateTableData(detected)
 				{
 					if(! vhtseg2)							//80mhz
 					{
-						TableData.push([ SSID, BSSID, channel+"-"+(channel-(-vhtoffset)), "80MHz", "n,ac", level+"dBm" ]);
+						TableData.push([ SSID, BSSID, (vhtseg1-(0.5*vhtoffset))+"-"+(vhtseg1-(-0.5*vhtoffset)), "80MHz", "n,ac", level+"dBm" ]);
 					}
 					else if(Math.abs(vhtseg1 - vhtseg2) == 8)	//160mhz
 					{
@@ -571,7 +571,7 @@ function generateTableData(detected)
 				{
 					if(! vhtseg2)							//80mhz
 					{
-						TableData.push([ SSID, BSSID, channel+"-"+(channel-vhtoffset), "80MHz", "n,ac", level+"dBm" ]);
+						TableData.push([ SSID, BSSID, (vhtseg1-(0.5*vhtoffset))+"-"+(vhtseg1-(-0.5*vhtoffset)), "80MHz", "n,ac", level+"dBm" ]);
 					}
 					else if(Math.abs(vhtseg1 - vhtseg2) == 8)	//160mhz
 					{

--- a/package/plugin-gargoyle-spectrum-analyser/files/full/www/spectrum_analyser.sh
+++ b/package/plugin-gargoyle-spectrum-analyser/files/full/www/spectrum_analyser.sh
@@ -60,7 +60,7 @@
 	<div class="col-lg-12">
 		<div class="panel panel-default">
 			<div class="panel-body">
-				<div id="spectrum_table_container">
+				<div id="spectrum_table_container" class="table-responsive">
 				</div>
 			</div>
 		</div>

--- a/package/plugin-gargoyle-spectrum-analyser/files/minimal/www/js/spectrum_analyser.js
+++ b/package/plugin-gargoyle-spectrum-analyser/files/minimal/www/js/spectrum_analyser.js
@@ -369,7 +369,7 @@ function generateGraphData(detected)
 		var level = detected[3][x];
 		var vhtwidth = detected[4][x];
 		var vhtseg1 = detected[5][x];
-		var vhtseg2 = detected[6][x];
+		var vhtseg2 = (detected[6][x] == 0 ? null:detected[6][x]);
 		var BSSID = detected[7][x].replace(/:/g,"");
 		
 		if(band == "2.4GHz")
@@ -419,10 +419,10 @@ function generateGraphData(detected)
 				{
 					if(! vhtseg2)							//80mhz
 					{
-						plotdata[y] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(channel,2)};
-						plotdata[y+1] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(channel,2)+freqoffset)};
-						plotdata[y+2] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData((channel-(-vhtoffset)),3)-freqoffset)};
-						plotdata[y+3] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData((channel-(-vhtoffset)),3)};
+						plotdata[y] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(vhtseg1-(0.5*vhtoffset),2)};
+						plotdata[y+1] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(vhtseg1-(0.5*vhtoffset),2)+freqoffset)};
+						plotdata[y+2] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData((vhtseg1-(-0.5*vhtoffset)),3)-freqoffset)};
+						plotdata[y+3] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData((vhtseg1-(-0.5*vhtoffset)),3)};
 					}
 					else if(Math.abs(vhtseg1 - vhtseg2) == 8)	//160mhz
 					{
@@ -458,10 +458,10 @@ function generateGraphData(detected)
 				{
 					if(! vhtseg2)							//80mhz
 					{
-						plotdata[y] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(channel-vhtoffset,2)};
-						plotdata[y+1] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(channel-vhtoffset,2)+freqoffset)};
-						plotdata[y+2] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(channel,3)-freqoffset)};
-						plotdata[y+3] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(channel,3)};
+						plotdata[y] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData(vhtseg1-(0.5*vhtoffset),2)};
+						plotdata[y+1] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData(vhtseg1-(0.5*vhtoffset),2)+freqoffset)};
+						plotdata[y+2] = {"bssid":BSSID, "ssid":SSID, "level":level, "freq":(getfreqData((vhtseg1-(-0.5*vhtoffset)),3)-freqoffset)};
+						plotdata[y+3] = {"bssid":BSSID, "ssid":SSID, "level":"-100", "freq":getfreqData((vhtseg1-(-0.5*vhtoffset)),3)};
 					}
 					else if(Math.abs(vhtseg1 - vhtseg2) == 8)	//160mhz
 					{
@@ -512,8 +512,8 @@ function generateTableData(detected)
 		var level = detected[3][x];
 		var vhtwidth = detected[4][x];
 		var vhtseg1 = detected[5][x];
-		var vhtseg2 = detected[6][x];
-		var BSSID = detected[7][x];
+		var vhtseg2 = (detected[6][x] == 0 ? null:detected[6][x]);
+		var BSSID = detected[7][x].toUpperCase();
 		var htmode = detected[8][x];
 		var vhtmode = detected[9][x];
 		//var encryption = detected[8][x];
@@ -549,7 +549,7 @@ function generateTableData(detected)
 				{
 					if(! vhtseg2)							//80mhz
 					{
-						TableData.push([ SSID, BSSID, channel+"-"+(channel-(-vhtoffset)), "80MHz", "n,ac", level+"dBm" ]);
+						TableData.push([ SSID, BSSID, (vhtseg1-(0.5*vhtoffset))+"-"+(vhtseg1-(-0.5*vhtoffset)), "80MHz", "n,ac", level+"dBm" ]);
 					}
 					else if(Math.abs(vhtseg1 - vhtseg2) == 8)	//160mhz
 					{
@@ -571,7 +571,7 @@ function generateTableData(detected)
 				{
 					if(! vhtseg2)							//80mhz
 					{
-						TableData.push([ SSID, BSSID, channel+"-"+(channel-vhtoffset), "80MHz", "n,ac", level+"dBm" ]);
+						TableData.push([ SSID, BSSID, (vhtseg1-(0.5*vhtoffset))+"-"+(vhtseg1-(-0.5*vhtoffset)), "80MHz", "n,ac", level+"dBm" ]);
 					}
 					else if(Math.abs(vhtseg1 - vhtseg2) == 8)	//160mhz
 					{

--- a/package/plugin-gargoyle-spectrum-analyser/files/minimal/www/spectrum_analyser.sh
+++ b/package/plugin-gargoyle-spectrum-analyser/files/minimal/www/spectrum_analyser.sh
@@ -60,7 +60,7 @@
 	<div class="col-lg-12">
 		<div class="panel panel-default">
 			<div class="panel-body">
-				<div id="spectrum_table_container">
+				<div id="spectrum_table_container" class="table-responsive">
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Fix various calculation fails for spectrum analyser plugin and stop the table from escaping under mobile conditions.
Also restore the strings to the firstboot (non i18n) page. I think these went missing during the large UI update patches.