### PR TITLE
Fix layout of generated form templates

### DIFF
--- a/package/gargoyle/files/www/quotas.sh
+++ b/package/gargoyle/files/www/quotas.sh
@@ -37,19 +37,21 @@
 
 			<div class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-12" id="add_quota_label" style="text-decoration:underline"><%~ AddQuota %>:</span>
-					<div>
+					<span class="col-xs-12">
+						<label id="add_quota_label" style="text-decoration:underline"><%~ AddQuota %>:</label>
 						<%in templates/quotas_template %>
-					</div>
-					<span class="col-xs-12"><button id="add_quota_button" class="btn btn-default" onclick="addNewQuota()"><%~ AddQuota %></button></span>
+						<button id="add_quota_button" class="btn btn-default" onclick="addNewQuota()"><%~ AddQuota %></button>
+					</span>
 				</div>
 
 				<div id="internal_divider1" class="internal_divider"></div>
 
 				<div class="row form-group">
-					<span class="col-xs-12" id="active_quotas_label" style="text-decoration:underline"><%~ ActivQuotas %>:</span>
+					<span class="col-xs-12">
+						<label id="active_quotas_label" style="text-decoration:underline"><%~ ActivQuotas %>:</label>
+						<div id="quota_table_container" class="table-responsive"></div>
+					</span>
 				</div>
-				<div id="quota_table_container" class="table-responsive"></div>
 			</div>
 		</div>
 	</div>
@@ -61,7 +63,6 @@
 </div>
 <span id="update_container" ><%~ WaitSettings %></span>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/quotas.sh
+++ b/package/gargoyle/files/www/quotas.sh
@@ -48,7 +48,7 @@
 
 				<div class="row form-group">
 					<span class="col-xs-12">
-						<label id="active_quotas_label" style="text-decoration:underline"><%~ ActivQuotas %>:</label>
+						<span id="active_quotas_label" style="text-decoration:underline"><%~ ActivQuotas %>:</span>
 						<div id="quota_table_container" class="table-responsive"></div>
 					</span>
 				</div>

--- a/package/gargoyle/files/www/quotas.sh
+++ b/package/gargoyle/files/www/quotas.sh
@@ -38,7 +38,7 @@
 			<div class="panel-body">
 				<div class="row form-group">
 					<span class="col-xs-12">
-						<label id="add_quota_label" style="text-decoration:underline"><%~ AddQuota %>:</label>
+						<span id="add_quota_label" style="text-decoration:underline"><%~ AddQuota %>:</span>
 						<%in templates/quotas_template %>
 						<button id="add_quota_button" class="btn btn-default" onclick="addNewQuota()"><%~ AddQuota %></button>
 					</span>

--- a/package/gargoyle/files/www/restriction.sh
+++ b/package/gargoyle/files/www/restriction.sh
@@ -25,17 +25,21 @@
 			</div>
 
 			<div class="panel-body">
-				<span id="add_rule_label" style="text-decoration:underline" ><%~ NRRule %>:</span>
 				<div class="row form-group">
-					<%in templates/restriction_template %>
 					<span class="col-xs-12">
+						<label id="add_rule_label" style="text-decoration:underline" ><%~ NRRule %>:</label>
+						<%in templates/restriction_template %>
 						<button id="add_restriction_button" class="btn btn-default" onclick="addNewRule('restriction_rule', 'rule_')"><%~ ANRule %></button>
 					</span>
 				</div>
 
 				<div id="internal_divider1" class="internal_divider"></div>
-				<span id="current_rule_label" style="text-decoration:underline"><%~ CRestr %>:</span>
-				<div id="rule_table_container" class="table-responsive"></div>
+				<div class="row form-group">
+					<span class="col-xs-12">
+						<label id="current_rule_label" style="text-decoration:underline"><%~ CRestr %>:</label>
+						<div id="rule_table_container" class="table-responsive"></div>
+					</span>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -46,17 +50,21 @@
 				<h3 class="panel-title"><%~ EWSect %></h3>
 			</div>
 			<div class="panel-body">
-				<span id="add_exception_label" style="text-decoration:underline"><%~ NExcp %>:</span>
 				<div class="row form-group">
-					<%in templates/whitelist_template %>
 					<span class="col-xs-12">
+						<label id="add_exception_label" style="text-decoration:underline"><%~ NExcp %>:</label>
+						<%in templates/whitelist_template %>
 						<button id="add_restriction_button" class="btn btn-default" onclick="addNewRule('whitelist_rule', 'exception_')"><%~ ANRule %></button>
 					</span>
 				</div>
 
 				<div id="internal_divider1" class="internal_divider"></div>
-				<span id="current_exceptions_label" style="text-decoration:underline" ><%~ CExcp %>:</span>
-				<div id="exception_table_container" class="table-responsive"></div>
+				<div class="row form-group">
+					<span class="col-xs-12">
+						<label id="current_exceptions_label" style="text-decoration:underline" ><%~ CExcp %>:</label>
+						<div id="exception_table_container" class="table-responsive"></div>
+					</span>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -68,7 +76,6 @@
 </div>
 <span id="update_container" ><%~ WaitSettings %></span>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/restriction.sh
+++ b/package/gargoyle/files/www/restriction.sh
@@ -27,7 +27,7 @@
 			<div class="panel-body">
 				<div class="row form-group">
 					<span class="col-xs-12">
-						<label id="add_rule_label" style="text-decoration:underline" ><%~ NRRule %>:</label>
+						<span id="add_rule_label" style="text-decoration:underline" ><%~ NRRule %>:</span>
 						<%in templates/restriction_template %>
 						<button id="add_restriction_button" class="btn btn-default" onclick="addNewRule('restriction_rule', 'rule_')"><%~ ANRule %></button>
 					</span>
@@ -36,7 +36,7 @@
 				<div id="internal_divider1" class="internal_divider"></div>
 				<div class="row form-group">
 					<span class="col-xs-12">
-						<label id="current_rule_label" style="text-decoration:underline"><%~ CRestr %>:</label>
+						<span id="current_rule_label" style="text-decoration:underline"><%~ CRestr %>:</span>
 						<div id="rule_table_container" class="table-responsive"></div>
 					</span>
 				</div>
@@ -52,7 +52,7 @@
 			<div class="panel-body">
 				<div class="row form-group">
 					<span class="col-xs-12">
-						<label id="add_exception_label" style="text-decoration:underline"><%~ NExcp %>:</label>
+						<span id="add_exception_label" style="text-decoration:underline"><%~ NExcp %>:</span>
 						<%in templates/whitelist_template %>
 						<button id="add_restriction_button" class="btn btn-default" onclick="addNewRule('whitelist_rule', 'exception_')"><%~ ANRule %></button>
 					</span>
@@ -61,7 +61,7 @@
 				<div id="internal_divider1" class="internal_divider"></div>
 				<div class="row form-group">
 					<span class="col-xs-12">
-						<label id="current_exceptions_label" style="text-decoration:underline" ><%~ CExcp %>:</label>
+						<span id="current_exceptions_label" style="text-decoration:underline" ><%~ CExcp %>:</span>
 						<div id="exception_table_container" class="table-responsive"></div>
 					</span>
 				</div>

--- a/package/gargoyle/files/www/templates/multi_forward_template
+++ b/package/gargoyle/files/www/templates/multi_forward_template
@@ -13,7 +13,6 @@
 						<td><input type='text' id='addr_sp' size='5' onkeyup='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></td>
 						<td><input type='text' id='addr_ep' size='5' onkeyup='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></td>
 						<td><input type='text' id='addr_ip' size='15' onkeyup='proofreadIp(this)' maxLength='15' class='form-control' /></td>
-							
-						<td><input type='button' id='addr_button' value='<%~ Add %>' class='btn btn-default' onclick='addPortfRangeRule()'/></td>
+						<td><button type='button' id='addr_button' class='btn btn-default' onclick='addPortfRangeRule()'><%~ Add %></button></td>
 					</tr>
 				</table>

--- a/package/gargoyle/files/www/templates/quotas_template
+++ b/package/gargoyle/files/www/templates/quotas_template
@@ -25,7 +25,7 @@
 	}
 %>
 
-<div>
+<div class="row form-group">
 	<label class="col-xs-5" id="applies_to_label" for='applies_to_type'><%~ quotas.AppliesTo %>:</label>
 	<span class="col-xs-7">
 		<select id="applies_to_type" onchange='setVisibility()' class='form-control'>
@@ -41,7 +41,7 @@
 		<div style="padding:0px;margin-top:0px;margin-bottom:0px">
 			<span class="col-xs-offset-5 col-xs-7">
 				<input type='text' id='add_ip' onkeyup='proofreadMultipleIps(this)' style="width:250px;" class='form-control' />
-				<input type="button" class="btn btn-default" id="add_ip_button" value="<%~ Add %>" onclick='addAddressesToTable(document,"add_ip","quota_ip_table_container","quota_ip_table",false,3,true,250)'/>
+				<button type="button" class="btn btn-default" id="add_ip_button" onclick='addAddressesToTable(document,"add_ip","quota_ip_table_container","quota_ip_table",false,3,true,250)'><%~ Add %></button>
 			</span>
 		</div>
 		<div style="padding:0px;margin-top:0px;margin-bottom:5px;">
@@ -50,7 +50,7 @@
 	</div>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class="col-xs-5" id="max_up_label" for='max_up_type'><%~ MaxUp %>:</label>
 	<span class="col-xs-7">
 		<select id="max_up_type" onchange='setVisibility()' class='form-control' >
@@ -68,7 +68,7 @@
 	</span>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class="col-xs-5" id="max_down_label" for='max_down_type'><%~ MaxDown %>:</label>
 	<span class="col-xs-7">
 		<select id="max_down_type" onchange='setVisibility()' class='form-control'>
@@ -87,7 +87,7 @@
 	</span>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class="col-xs-5" id="max_combined_label" for='max_combined_type'><%~ MaxUpDown %>:</label>
 	<span class="col-xs-7">
 		<select id="max_combined_type" onchange='setVisibility()' class='form-control'>
@@ -106,7 +106,7 @@
 	</span>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class="col-xs-5" id="quota_reset_label" for='quota_reset'><%~ QResets %>:</label>
 	<span class="col-xs-7">
 		<select id="quota_reset" onchange='setVisibility()' class='form-control'>
@@ -118,14 +118,14 @@
 	</span>
 </div>
 
-<div id="quota_day_container">
+<div id="quota_day_container" class="row form-group">
 	<label class="col-xs-5" id="quota_day_label" for='quota_day'><%~ ResetDay %>:</label>
 	<span class="col-xs-7">
 		<select id='quota_day' class='form-control'></select>
 	</span>
 </div>
 
-<div id="quota_hour_container">
+<div id="quota_hour_container" class="row form-group">
 	<label class="col-xs-5" id="quota_hour_label" for='quota_hour'><%~ ResetHour %>:</label>
 	<span class="col-xs-7">
 		<select id='quota_hour' class='form-control'>
@@ -134,7 +134,7 @@
 	</span>
 </div>
 
-<div id="quota_active_container">
+<div id="quota_active_container" class="row form-group">
 	<label class="col-xs-5" id="quota_active_label" for='quota_active'><%~ QuotaActive %>:</label>
 	<span class="col-xs-7">
 		<select id='quota_active' onchange='setVisibility()' class='form-control'>
@@ -152,7 +152,7 @@
 	</span>
 </div>
 
-<div id="quota_active_controls_container">
+<div id="quota_active_controls_container" class="row form-group">
 	<span id="active_days_container" class="col-xs-offset-5 col-xs-7" style="margin-top:10px;margin-bottom:10px;">
 		<input type='checkbox' id='quota_sun' /><label for="quota_sun"><%~ Sun %></label>
 		<input type='checkbox' id='quota_mon' /><label for="quota_mon"><%~ Mon %></label>
@@ -174,7 +174,7 @@
 	</span>
 </div>
 
-<div id="quota_exceeded_container">
+<div id="quota_exceeded_container" class="row form-group">
 	<label class="col-xs-5" id="quota_exceeded_label" for='quota_exceeded'><%~ Exceed %>:</label>
 	<span class="col-xs-7">
 		<select id='quota_exceeded' onchange='setVisibility()' class='form-control'>
@@ -184,7 +184,7 @@
 	</span>
 </div>
 
-<div id="quota_only_qos_container">
+<div id="quota_only_qos_container" class="row form-group">
 	<span class="col-xs-offset-5 col-xs-7" style="margin-top:1px;margin-bottom:1px;">
 		<label><%~ UpLimit %>: </label>
 		<input type='text' id='quota_qos_up' onkeyup='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
@@ -203,7 +203,7 @@
 	</span>
 </div>
 
-<div id="quota_full_qos_container">
+<div id="quota_full_qos_container" class="row form-group">
 	<span class="col-xs-offset-5 col-xs-7" style="margin-top:1px;margin-bottom:1px;">
 		<label for="quota_full_qos_up_class"><%~ UpClass %>: </label>
 		<select id="quota_full_qos_up_class" class='form-control'></select>

--- a/package/gargoyle/files/www/templates/restriction_template
+++ b/package/gargoyle/files/www/templates/restriction_template
@@ -1,9 +1,9 @@
-<div>
+<div class="row form-group">
 	<label class="col-xs-5" for='rule_name' id='rule_name_label'><%~ restrictions.RDesc %>:</label>
 	<span class="col-xs-7"><input type='text' class='form-control' id='rule_name' size='30'/></span>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class="col-xs-5" for='rule_applies_to' id='rule_applies_to_label'><%~ RAppl %>:</label>
 	<span class="col-xs-7">
 		<select class='form-control' id='rule_applies_to' onchange='setVisibility(document,"rule_")'>
@@ -14,18 +14,18 @@
 	</span>
 </div>
 
-<div id="rule_applies_to_container">
+<div id="rule_applies_to_container" class="row form-group">
 	<div class="col-xs-offset-5 col-xs-7" id="rule_applies_to_table_container"></div>
 	<div class="col-xs-offset-5 col-xs-7">
 		<input type='text' id='rule_applies_to_addr' size='30' onkeyup='proofreadMultipleIpsOrMacs(this)' class='form-control' />
-		<input type="button" class="btn btn-default" id="rule_add_applies_to_addr" value="<%~ Add %>" onclick='addAddressesToTable(document,"rule_applies_to_addr","rule_applies_to_table_container","rule_applies_to_table",true)'/>
+		<button type="button" class="btn btn-default" id="rule_add_applies_to_addr" onclick='addAddressesToTable(document,"rule_applies_to_addr","rule_applies_to_table_container","rule_applies_to_table",true)'><%~ Add %></button>
 	</div>
 	<div class="col-xs-offset-5 col-xs-7">
 		<em><%~ HstAddr %></em>
 	</div>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class="col-xs-5" for='rule_all_day' id='rule_schedule_label'><%~ Schd %>:</label>
 	<span class="col-xs-7">
 		<input type='checkbox' id='rule_all_day' onclick='setVisibility(document,"rule_")' /><label for="rule_all_day"><%~ ADay %></label>
@@ -66,13 +66,13 @@
 	</div>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class='col-xs-5' for='rule_all_access' id='rule_all_access_label'><%~ RRsrc %>:</label>
 	<span class="col-xs-7"><input type='checkbox' id='rule_all_access' onclick='setVisibility(document,"rule_")' /><label for="rule_all_access"><%~ NetAcc %></label></span>
 </div>
 
 <div class="indent" id="rule_resources">
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="rule_remote_ip_label" for='rule_remote_ip'><%~ RemIP %>:</label>
 		<span class="col-xs-7">
 			<select class='form-control' id='rule_remote_ip_type' onchange='setVisibility(document,"rule_")'>
@@ -82,15 +82,15 @@
 			</select>
 		</span>
 	</div>
-	<div id="rule_remote_ip_container">
+	<div id="rule_remote_ip_container" class="row form-group">
 		<div class="col-xs-offset-5 col-xs-7" id="rule_remote_ip_table_container"></div>
 		<div class="col-xs-offset-5 col-xs-7">
 			<input type='text' id='rule_remote_ip' size='30' onkeyup='proofreadMultipleIps(this)' class='form-control' />
-			<input type="button" class="btn btn-default" id="rule_add_remote_ip" value="<%~ Add %>" onclick='addAddressesToTable(document,"rule_remote_ip","rule_remote_ip_table_container","rule_remote_ip_table",false)'/>
+			<button type="button" class="btn btn-default" id="rule_add_remote_ip" onclick='addAddressesToTable(document,"rule_remote_ip","rule_remote_ip_table_container","rule_remote_ip_table",false)'><%~ Add %></button>
 		</div>
 	</div>
 
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="rule_remote_port_label" for='rule_remote_port'><%~ RemPrt %>:</label>
 		<span class="col-xs-7">
 			<select class='form-control' id="rule_remote_port_type" onchange='setVisibility(document,"rule_")'>
@@ -103,7 +103,7 @@
 			<input type='text' id='rule_remote_port' onkeyup='proofreadMultiplePorts(this)' size='20' class='form-control' />
 		</span>
 	</div>
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="rule_local_port_label" for='rule_local_port'><%~ LclPrt %>:</label>
 		<span class="col-xs-7">
 			<select class='form-control' id="rule_local_port_type" onchange='setVisibility(document,"rule_")'>
@@ -118,7 +118,7 @@
 	</div>
 
 
-	<div>
+	<div class="row form-group">
 		<label class='col-xs-5' id="rule_transport_protocol_label" for='rule_transport_protocol'><%~ TrProto %>:</label>
 		<span class="col-xs-7">
 			<select class='form-control' id="rule_transport_protocol">
@@ -128,7 +128,7 @@
 			</select>
 		</span>
 	</div>
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="rule_app_protocol_label" for='rule_app_protocol'><%~ ApProto %>:</label>
 		<span class="col-xs-7">
 			<select id="rule_app_protocol_type" class='form-control' onchange='setVisibility(document,"rule_")'>
@@ -167,7 +167,7 @@
 			</select>
 		</span>
 	</div>
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="rule_url_label" for='rule_url_type'><%~ WebURL %>:</label>
 		<span class="col-xs-7">
 			<select id="rule_url_type" class='form-control' onchange='setVisibility(document,"rule_")'>
@@ -177,7 +177,7 @@
 			</select>
 		</span>
 	</div>
-	<div id="rule_url_match_list">
+	<div id="rule_url_match_list" class="row form-group">
 		<div id="rule_url_match_table_container" class="col-xs-12"></div>
 		<div class="col-xs-offset-5 col-xs-7">
 			<select id="rule_url_match_type" class='form-control'>
@@ -189,7 +189,7 @@
 				<option value="url_domain_regex"><%~ DmRgx %>:</option>
 			</select>
 			<input type='text' id='rule_url_match' size='30' class='form-control' />
-			<input type="button" class="btn btn-default" id="rule_add_url_match" value="<%~ Add %>" onclick='addUrlToTable(document, "rule_url_match", "rule_url_match_type", "rule_url_match_table_container", "rule_url_match_table")'/>
+			<button type="button" class="btn btn-default" id="rule_add_url_match" onclick='addUrlToTable(document, "rule_url_match", "rule_url_match_type", "rule_url_match_table_container", "rule_url_match_table")'><%~ Add %></button>
 		</div>
 	</div>
 </div>

--- a/package/gargoyle/files/www/templates/single_forward_template
+++ b/package/gargoyle/files/www/templates/single_forward_template
@@ -13,7 +13,6 @@
 						<td><input type='text' id='add_fp' size='5' onkeyup='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></td>
 						<td><input type='text' id='add_ip' size='15' onkeyup='proofreadIp(this)' maxLength='15' class='form-control' /></td>
 						<td><input type='text' id='add_dp' size='5' onkeyup='proofreadNumeric(this,1,65535)' maxLength='5' class='form-control' /></td>
-
-						<td><input type='button' id='add_button' value='<%~ Add %>' class='btn btn-default' onclick='addPortfRule()'/></td>
+						<td><button type="button" id="add_button" class="btn btn-default" onclick="addPortfRule()"><%~ Add %></button></td>
 					</tr>
 				</table>

--- a/package/gargoyle/files/www/templates/static_ip_template
+++ b/package/gargoyle/files/www/templates/static_ip_template
@@ -9,6 +9,6 @@
 						<td><input type='text' id='add_host' size='15' class='form-control' /></td>
 						<td><input type='text' id='add_mac' size='20' onkeyup='proofreadMac(this)' maxLength='17' class='form-control' /></td>
 						<td><input type='text' id='add_ip' size='20' onkeyup='proofreadIp(this)' maxLength='15' class='form-control' /></td>
-						<td><input type='button' id='add_button' value="<%~ Add %>" class='btn btn-default' onclick='addStatic()'/></td>
+						<td><button type='button' id='add_button' class='btn btn-default' onclick='addStatic()'><%~ Add %></button></td>
 					</tr>
 				</table>

--- a/package/gargoyle/files/www/templates/static_route_template
+++ b/package/gargoyle/files/www/templates/static_route_template
@@ -9,6 +9,6 @@
 						<td><input type='text' id='add_dest' size='26' onkeyup='proofreadRouteIp(this)' maxLength='35' class='form-control' /></td>
 						<td><select id='add_iface' class='form-control'><option value="wan">WAN</option><option value="lan">LAN</option></select></td>
 						<td><input type='text' id='add_gateway' size='20' onkeyup='proofreadGatewayIp(this)' maxLength='15' class='form-control' /></td>
-						<td><input type='button' id='add_button' value="<%~ Add %>" class='btn btn-default' onclick='addStaticRoute()'/></td>
+						<td><button type='button' id='add_button' class='btn btn-default' onclick='addStaticRoute()'><%~ Add %></button></td>
 					</tr>
 				</table>

--- a/package/gargoyle/files/www/templates/whitelist_template
+++ b/package/gargoyle/files/www/templates/whitelist_template
@@ -1,9 +1,9 @@
-<div>
+<div class="row form-group">
 	<label class='col-xs-5' for='exception_name' id='exception_name_label'><%~ restrictions.ESect %>:</label>
 	<span class="col-xs-7"><input type='text' class='form-control' id='exception_name' size='30'/></span>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class='col-xs-5' for='exception_applies_to' id='exception_applies_to_label'><%~ EAppl %>:</label>
 	<span class="col-xs-7">
 		<select class='form-control' id='exception_applies_to' onchange='setVisibility(document,"exception_")'>
@@ -14,18 +14,18 @@
 	</span>
 </div>
 
-<div id="exception_applies_to_container">
+<div id="exception_applies_to_container" class="row form-group">
 	<div class="col-xs-offset-5 col-xs-7" id="exception_applies_to_table_container"></div>
 	<div class="col-xs-offset-5 col-xs-7">
 		<input type='text' id='exception_applies_to_addr' size='30' onkeyup='proofreadMultipleIpsOrMacs(this)' class='form-control' />
-		<input type="button" class="btn btn-default" id="exception_add_applies_to_addr" value="<%~ Add %>" onclick='addAddressesToTable(document,"exception_applies_to_addr","exception_applies_to_table_container","exception_applies_to_table",true)'/>
+		<button type="button" class="btn btn-default" id="exception_add_applies_to_addr" onclick='addAddressesToTable(document,"exception_applies_to_addr","exception_applies_to_table_container","exception_applies_to_table",true)'><%~ Add %></button>
 	</div>
 	<div class="col-xs-offset-5 col-xs-7">
 		<em><%~ HstAddr %></em>
 	</div>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class='col-xs-5' for='exception_all_day' id='exception_schedule_label'><%~ Schd %>:</label>
 	<span class="col-xs-7">
 		<input type='checkbox' id='exception_all_day' onclick='setVisibility(document,"exception_")' /><label for="exception_all_day"><%~ ADay %></label>
@@ -66,13 +66,13 @@
 	</div>
 </div>
 
-<div>
+<div class="row form-group">
 	<label class='col-xs-5' for='exception_all_access' id='exception_all_access_label'><%~ PRsrc %>:</label>
 	<span class="col-xs-7"><input type='checkbox' id='exception_all_access' onclick='setVisibility(document,"exception_")' /><label for="exception_all_access"><%~ NetAcc %></label></span>
 </div>
 
 <div class="indent" id="exception_resources">
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="exception_remote_ip_label" for='exception_remote_ip'><%~ RemIP %>:</label>
 		<span class="col-xs-7">
 			<select class='form-control' id='exception_remote_ip_type' onchange='setVisibility(document,"exception_")'>
@@ -82,15 +82,15 @@
 			</select>
 		</span>
 	</div>
-	<div id="exception_remote_ip_container">
+	<div id="exception_remote_ip_container" class="row form-group">
 		<div class="col-xs-offset-5 col-xs-7" id="exception_remote_ip_table_container"></div>
 		<div class="col-xs-offset-5 col-xs-7">
 			<input type='text' id='exception_remote_ip' size='30' onkeyup='proofreadMultipleIps(this)' class='form-control' />
-			<input type="button" class="btn btn-default" id="exception_add_remote_ip" value="<%~ Add %>" onclick='addAddressesToTable(document,"exception_remote_ip","exception_remote_ip_table_container","exception_remote_ip_table",false)'/>
+			<button type="button" class="btn btn-default" id="exception_add_remote_ip" onclick='addAddressesToTable(document,"exception_remote_ip","exception_remote_ip_table_container","exception_remote_ip_table",false)'><%~ Add %></button>
 		</div>
 	</div>
 
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="exception_remote_port_label" for='exception_remote_port'><%~ RemPrt %>:</label>
 		<span class="col-xs-7">
 			<select class='form-control' id="exception_remote_port_type" onchange='setVisibility(document,"exception_")'>
@@ -103,7 +103,7 @@
 			<input type='text' id='exception_remote_port' onkeyup='proofreadMultiplePorts(this)' size='20' class='form-control' />
 		</span>
 	</div>
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="exception_local_port_label" for='exception_local_port'><%~ LclPrt %>:</label>
 		<span class="col-xs-7">
 			<select class='form-control' id="exception_local_port_type" onchange='setVisibility(document,"exception_")'>
@@ -117,7 +117,7 @@
 		</span>
 	</div>
 
-	<div>
+	<div class="row form-group">
 		<label class='col-xs-5' id="exception_transport_protocol_label" for='exception_transport_protocol'><%~ TrProto %>:</label>
 		<span class="col-xs-7">
 			<select class='form-control' id="exception_transport_protocol">
@@ -127,7 +127,7 @@
 			</select>
 		</span>
 	</div>
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="exception_app_protocol_label" for='exception_app_protocol'><%~ ApProto %>:</label>
 		<span class="col-xs-7">
 			<select id="exception_app_protocol_type" class='form-control' onchange='setVisibility(document,"exception_")'>
@@ -166,7 +166,7 @@
 			</select>
 		</span>
 	</div>
-	<div>
+	<div class="row form-group">
 		<label class="col-xs-5" id="exception_url_label" for='exception_url_type'><%~ WebURL %>:</label>
 		<span class="col-xs-7">
 			<select id="exception_url_type" class='form-control' onchange='setVisibility(document,"exception_")'>
@@ -176,7 +176,7 @@
 			</select>
 		</span>
 	</div>
-	<div id="exception_url_match_list">
+	<div id="exception_url_match_list" class="row form-group">
 		<div id="exception_url_match_table_container" class="col-xs-12"></div>
 		<div class="col-xs-offset-5 col-xs-7">
 			<select id="exception_url_match_type" class='form-control'>
@@ -188,7 +188,7 @@
 				<option value="url_domain_regex"><%~ DmRgx %>:</option>
 			</select>
 			<input type='text' id='exception_url_match' size='30' class='form-control' />
-			<input type="button" class="btn btn-default" id="exception_add_url_match" value="<%~ Add %>" onclick='addUrlToTable(document, "exception_url_match", "exception_url_match_type", "exception_url_match_table_container", "exception_url_match_table")'/>
+			<button type="button" class="btn btn-default" id="exception_add_url_match" onclick='addUrlToTable(document, "exception_url_match", "exception_url_match_type", "exception_url_match_table_container", "exception_url_match_table")'><%~ Add %></button>
 		</div>
 	</div>
 </div>

--- a/package/plugin-gargoyle-usb-storage/files/www/templates/usb_storage_template
+++ b/package/plugin-gargoyle-usb-storage/files/www/templates/usb_storage_template
@@ -1,20 +1,20 @@
-<div id="share_disk_container">
+<div id="share_disk_container" class="row form-group">
 	<label class="col-xs-5" id="share_disk_label" for="share_disk"><%~ usb_storage.Disk %>:</label>
 	<span class="col-xs-7"><select class="form-control" id="share_disk"></select></span>
 	<span class="col-xs-12" id="share_disk_text"></span>
 </div>
 
-<div id="share_dir_container">
+<div id="share_dir_container" class="row form-group">
 	<label class="col-xs-5" id="share_dir_label" for="share_dir"><%~ SDir %>:</label>
 	<span class="col-xs-7"><input type='text' id='share_dir' size='30' class="form-control" /></span>
 </div>
 
-<div id="share_name_container">
+<div id="share_name_container" class="row form-group">
 	<label class="col-xs-5" id="share_name_label" for="share_name"><%~ SNam %>:</label>
 	<span class="col-xs-7"><input type="text" class="form-control" id="share_name" size='30' onkeyup="setSharePaths(this.ownerDocument)" /></span>
 </div>
 
-<div id="share_specificity_container">
+<div id="share_specificity_container" class="row form-group">
 	<label class="col-xs-5" id="share_name_label" for="share_specificity"><%~ SAppl %>:</label>
 	<span class="col-xs-7">
 		<select class="form-control" id="share_specificity">
@@ -24,7 +24,7 @@
 	</span>
 </div>
 
-<div id="select_share_type_container">
+<div id="select_share_type_container" class="row form-group">
 	<label class="col-xs-5" id="share_type_label" for="share_type"><%~ STyp %>:</label>
 	<span class="col-xs-7">
 		<input type='checkbox' id='share_type_cifs' onclick="setShareTypeVisibility(this.ownerDocument)"/>
@@ -36,7 +36,7 @@
 	</span>
 </div>
 
-<div id="anonymous_access_container">
+<div id="anonymous_access_container" class="row form-group">
 	<label class="col-xs-5" id="anonymous_access_label" for="anonymous_access"><%~ FAAcc %>:</label>
 	<span class="col-xs-7">
 		<select class="form-control" id="anonymous_access">
@@ -47,7 +47,7 @@
 	</span>
 </div>
 
-<div id="user_access_container">
+<div id="user_access_container" class="row form-group">
 	<label class="col-xs-5" id="user_access_label" for="user_access"><%~ FAUsr %>:</label>
 	<span class="col-xs-7">
 		<select id="user_access" class="form-control"></select>
@@ -60,7 +60,7 @@
 	<div id="user_access_table_container" class="col-xs-offset-5 col-xs-7"></div>
 </div>
 
-<div id="nfs_access_container">
+<div id="nfs_access_container" class="row form-group">
 	<label class="col-xs-5" id="nfs_access_label" for="nfs_access"><%~ NAcc %>:</label>
 	<span class="col-xs-7">
 		<select class="form-control" id="nfs_access">
@@ -70,7 +70,7 @@
 	</span>
 </div>
 
-<div id="nfs_policy_container">
+<div id="nfs_policy_container" class="row form-group">
 	<label class="col-xs-5" id="nfs_policy_label" for="nfs_policy"><%~ NAccPo %>:</label>
 	<span class="col-xs-7">
 		<select class="form-control" id="nfs_policy" onchange="setShareTypeVisibility()" >
@@ -80,7 +80,7 @@
 	</span>
 </div>
 
-<div id="nfs_ip_container" >
+<div id="nfs_ip_container" class="row form-group">
 	<span class="col-xs-offset-5 col-xs-7">
 		<input type='text' id='nfs_ip' size='30' onkeyup='proofreadIpRange(this)' class="form-control" />
 		<button class="btn btn-default" id="add_nfs_ip" onclick='addAddressesToTable(document,"nfs_ip","nfs_ip_table_container","nfs_ip_table",false, 2, true, "")'><%~ Add %></button>
@@ -91,12 +91,12 @@
 
 <div id="nfs_spacer" style="margin-bottom:20px"></div>
 
-<div id="ftp_path_container" class="col-xs-12">
+<div id="ftp_path_container" class="col-xs-12 row form-group">
 	<label id="ftp_path_label" for="ftp_path"><%~ FPath %>:</label>
 	<span id="ftp_path"></span>
 </div>
 
-<div id="nfs_path_container" class="col-xs-12">
+<div id="nfs_path_container" class="col-xs-12 row form-group">
 	<label id="nfs_path_label" for="nfs_path"><%~ NPath %>:</label>
 	<span id="nfs_path"></span>
 </div>


### PR DESCRIPTION
- Add missing responsive class="row form-group" to div containers. This adds a bottom margin (for better readability/consistency ) and also fixes form controls breaking the layout when going mobile.
- Minor formatting fixes for Quotas/Restriction pages.
- Switch button element declaration inside templates from `<input type="button"/>` to `<button type="button"></button>` for consistency and better styling flexibility.