### PR TITLE
Multiple fixes

### DIFF
--- a/package/gargoyle/files/www/js/quota_usage.js
+++ b/package/gargoyle/files/www/js/quota_usage.js
@@ -111,7 +111,7 @@ function getTimeParametersFromUci(srcUci, quotaSection)
 		active = hours != "" || days != "" || weekly != "" ? "only" : "always";
 
 	}
-	return [hours,days,weekly,active];
+	return [hours,dayToi18n(days),weekly_i18n(weekly,"uci"),active];
 }
 
 function timeParamsToTableSpan(timeParameters)
@@ -297,4 +297,45 @@ function updateTableData()
 		runAjax("POST", "utility/run_commands.sh", param, stateChangeFunction);
 	}
 
+}
+
+function dayToi18n(daystrings) { //this is part of i18n; TODO: best to have an uci get language to see if absent to just return daystrings
+	var days=daystrings.split(",");
+	for (var i = 0; i < days.length; i++) {
+		if (days[i] == "sun") { days[i] = UI.Sun; }
+		if (days[i] == "mon") { days[i] = UI.Mon; }
+		if (days[i] == "tue") { days[i] = UI.Tue; }
+		if (days[i] == "wed") { days[i] = UI.Wed; }
+		if (days[i] == "thu") { days[i] = UI.Thu; }
+		if (days[i] == "fri") { days[i] = UI.Fri; }
+		if (days[i] == "sat") { days[i] = UI.Sat; }
+	}
+	return days.join();
+}
+
+function weekly_i18n(weekly_schd, direction) { //this is part of i18n; TODO: best to have an uci get language to see if absent to just return daystrings
+	if (weekly_schd.length < 6) return weekly_schd;
+	var localdays=[UI.Sun, UI.Mon, UI.Tue, UI.Wed, UI.Thu, UI.Fri, UI.Sat];
+	var fwdays=["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+	var indays, outdays, splits, idx;
+	var joiner=[];
+
+	if (direction == "uci") {
+		indays=fwdays;
+		outdays=localdays;
+	} else { // from the browser
+		indays=localdays;
+		outdays=fwdays;
+	}
+
+	splits=weekly_schd.split(" ");
+	for (idx=0; idx < splits.length; idx++) {
+		var pos= indays.indexOf(splits[idx]);
+		if (pos >= 0) {
+			joiner[idx]=outdays[pos];
+		} else {
+			joiner[idx]=splits[idx];
+		}
+	}
+	return joiner.join(" ");
 }

--- a/package/gargoyle/files/www/js/quotas.js
+++ b/package/gargoyle/files/www/js/quotas.js
@@ -208,7 +208,7 @@ function timeParamsToTableSpan(timeParameters)
 		else
 		{
 			if(hours != ""){ textList = hours.match(",") ? hours.split(/[\t ]*,[\t ]*/) : [ hours ]; }
-			if(days  != ""){ textList.unshift(days); }
+			if(days  != ""){ textList.unshift(dayToi18n(days)); }
 		}
 		textList.unshift( active == "only" ? quotasStr.Only+":" : quotasStr.AllExcept+":" );
 	}

--- a/patches-generic/112-mvebu-rango-swconfig-backport.patch
+++ b/patches-generic/112-mvebu-rango-swconfig-backport.patch
@@ -1,0 +1,32 @@
+--- a/target/linux/generic/files/drivers/net/phy/mvsw61xx.c
++++ b/target/linux/generic/files/drivers/net/phy/mvsw61xx.c
+@@ -754,6 +754,9 @@ static int mvsw61xx_probe(struct platfor
+ 	case MV_IDENT_VALUE_6176:
+ 		model_str = MV_IDENT_STR_6176;
+ 		break;
++	case MV_IDENT_VALUE_6352:
++		model_str = MV_IDENT_STR_6352;
++		break;
+ 	default:
+ 		dev_err(&pdev->dev, "No compatible switch found at 0x%02x\n",
+ 				state->base_addr);
+@@ -817,6 +820,7 @@ static const struct of_device_id mvsw61x
+ 	{ .compatible = "marvell,88e6171" },
+ 	{ .compatible = "marvell,88e6172" },
+ 	{ .compatible = "marvell,88e6176" },
++	{ .compatible = "marvell,88e6352" },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, mvsw61xx_match);
+--- a/target/linux/generic/files/drivers/net/phy/mvsw61xx.h
++++ b/target/linux/generic/files/drivers/net/phy/mvsw61xx.h
+@@ -222,6 +222,9 @@ enum {
+ #define MV_IDENT_VALUE_6176		0x1760
+ #define MV_IDENT_STR_6176		"MV88E6176"
+ 
++#define MV_IDENT_VALUE_6352		0x3520
++#define MV_IDENT_STR_6352		"MV88E6352"
++
+ #define MV_PVID_MASK			0x0fff
+ 
+ struct mvsw61xx_state {


### PR DESCRIPTION
- Add missing i18n strings to quotas.sh and quotas_usage.sh (Closes #657 )
- Backport swconfig support for the switch in WRT3200ACM (Rango). Fixes complaint from forum that Overview page has missing switchinfo data

Patch won't be required in LEDE branch.