### PR TITLE
Lantis plugins fixes

### DIFF
--- a/package/plugin-gargoyle-adblock/files/usr/lib/adblock/runadblock.sh
+++ b/package/plugin-gargoyle-adblock/files/usr/lib/adblock/runadblock.sh
@@ -15,7 +15,7 @@ END_RANGE=`uci get adblock.config.exend`
 ENDPOINT_IP4=`uci get adblock.config.endpoint4`
 
 #Change the cron command to what is comfortable, or leave as is
-CRON="0 4 * * 0 sh /usr/lib/adblock/runadblock.sh"
+CRON="0 4 * * 0 sh /plugin_root/usr/lib/adblock/runadblock.sh"
 
 #Check if Tor is enabled
 TOR=`uci get tor.global.enabled`
@@ -115,9 +115,9 @@ update_blocklist()
 
 	#Add black list, if non-empty
 	logger -t ADBLOCK Adding entries from black.list
-	if [ -s "/usr/lib/adblock/black.list" ]
+	if [ -s "/plugin_root/usr/lib/adblock/black.list" ]
 	then
-		awk -v r="$ENDPOINT_IP4" '{ print r,$1 }' /usr/lib/adblock/black.list >> /tmp/block.build.list
+		awk -v r="$ENDPOINT_IP4" '{ print r,$1 }' /plugin_root/usr/lib/adblock/black.list >> /tmp/block.build.list
 	fi
 
 	#Sort the download/black lists
@@ -125,10 +125,10 @@ update_blocklist()
 
 	#Filter (if applicable)
 	logger -t ADBLOCK Removing entries from white.list
-	if [ -s "/usr/lib/adblock/white.list" ]
+	if [ -s "/plugin_root/usr/lib/adblock/white.list" ]
 	then
 		#Filter the blacklist, supressing whitelist matches
-		egrep -v "^[[:space:]]*$" /usr/lib/adblock/white.list | awk '/^[^#]/ {sub(/\r$/,"");print $1}' | grep -vf - /tmp/block.build.before > /plugin_root/adblock/block.hosts
+		egrep -v "^[[:space:]]*$" /plugin_root/usr/lib/adblock/white.list | awk '/^[^#]/ {sub(/\r$/,"");print $1}' | grep -vf - /tmp/block.build.before > /plugin_root/adblock/block.hosts
 	else
 		cat /tmp/block.build.before > /plugin_root/adblock/block.hosts
 	fi

--- a/package/plugin-gargoyle-adblock/files/www/ablock.sh
+++ b/package/plugin-gargoyle-adblock/files/www/ablock.sh
@@ -14,9 +14,9 @@
 	echo "var blocklistlines = new Array();"
 	cat /plugin_root/adblock/block.hosts | awk '{print "blocklistlines.push(\""$2"\");"}'
 	echo "var blacklistlines = new Array();"
-	cat /usr/lib/adblock/black.list | awk '{print "blacklistlines.push(\""$0"\");"}'
+	cat /plugin_root/usr/lib/adblock/black.list | awk '{print "blacklistlines.push(\""$0"\");"}'
 	echo "var whitelistlines = new Array();"
-	cat /usr/lib/adblock/white.list | awk '{print "whitelistlines.push(\""$0"\");"}'
+	cat /plugin_root/usr/lib/adblock/white.list | awk '{print "whitelistlines.push(\""$0"\");"}'
 %>
 </script>
 

--- a/package/plugin-gargoyle-spectrum-analyser/files/full/www/js/spectrum_analyser.js
+++ b/package/plugin-gargoyle-spectrum-analyser/files/full/www/js/spectrum_analyser.js
@@ -47,7 +47,10 @@ function initialiseAll()
 
 		getWifiData();
 	}
-	//otherwise do nothing
+	else
+	{
+		document.getElementById("interface").disabled = true;	//do nothing and disable interface
+	}
 }
 
 

--- a/package/plugin-gargoyle-spectrum-analyser/files/minimal/www/js/spectrum_analyser.js
+++ b/package/plugin-gargoyle-spectrum-analyser/files/minimal/www/js/spectrum_analyser.js
@@ -47,7 +47,10 @@ function initialiseAll()
 
 		getWifiData();
 	}
-	//otherwise do nothing
+	else
+	{
+		document.getElementById("interface").disabled = true;	//do nothing and disable interface
+	}
 }
 
 


### PR DESCRIPTION
- Spectrum Analyser: Disable interface if no wlans detected
- Adblock: point all references at /plugin_root instead of picking and choosing randomly (Closes #628 )