### PR TITLE
set locale for banner creation for consistent dates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ set_version_variables()
 
 	#set date here, so it's guaranteed the same for all images
 	#even though build can take several hours
-	build_date=$(date +"%B %d, %Y")
+	build_date=$(LC_ALL=C date +"%B %d, %Y")
 
 	gargoyle_git_revision=$(git log -1 --pretty=format:%h )
 

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -20,7 +20,7 @@ set_constant_variables()
 	
 	#set date here, so it's guaranteed the same for all images
 	#even though build can take several hours
-	build_date=$(date +"%B %d, %Y")
+	build_date=$(LC_ALL=C date +"%B %d, %Y")
 
 	gargoyle_git_revision=$(git log -1 --pretty=format:%h )
 
@@ -31,7 +31,7 @@ set_version_variables()
 {
 	#set date here, so it is guaranteed the same for all images
 	#even though build can take several hours
-	build_date=$(date +"%B %d, %Y")
+	build_date=$(LC_ALL=C date +"%B %d, %Y")
 
 	gargoyle_git_revision=$(git log -1 --pretty=format:%h )
 


### PR DESCRIPTION
Set the locale for banner creation so that you get consistent dates
If the locale is not set, then the date format will be taken from
the system which will result in inconsistent dates.