### PR TITLE
UI Fixes and Button Handler

### DIFF
--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -611,6 +611,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="nortoncsa"><%~ NrtnCSA %></option>
 							<option value="nortoncsb"><%~ NrtnCSB %></option>
 							<option value="nortoncsc"><%~ NrtnCSC %></option>
+							<option value="quad9"><%~ Quad9 %></option>
 							<option value="custom"><%~ CstDSrv %></option>
 						</select>
 						<div id="lan_dns_custom_container" class="second_row_right_column">

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -18,6 +18,7 @@ var openDnsFS = ["208.67.222.123", "208.67.220.123" ];
 var nortonCSA = ["199.85.126.10", "199.85.127.10" ];
 var nortonCSB = ["199.85.126.20", "199.85.127.20" ];
 var nortonCSC = ["199.85.126.30", "199.85.127.30" ];
+var quad9DNS = ["9.9.9.9" ];
 
 var ncDns  = [ "178.32.31.41", "106.187.47.17", "176.58.118.172" ]
 var onDns  = [ "66.244.95.20", "95.211.32.162", "95.142.171.235" ]
@@ -898,6 +899,10 @@ function saveChanges()
 			{
 				dnsList = nortonCSC;
 			}
+			else if(dnsSource == "quad9" && notBridge )
+			{
+				dnsList = quad9DNS;
+			}
 			else //custom
 			{
 				var dnsData = getTableDataArray(document.getElementById("lan_dns_table_container").firstChild);
@@ -1770,6 +1775,10 @@ function resetData()
 	else if( dnsTableData.join(",") == googleDns.join(",") || dnsTableData.join(",") == googleDns.reverse().join(",") )
 	{
 		dnsType = "google";
+	}
+	else if( dnsTableData.join(",") == quad9DNS.join(",") || dnsTableData.join(",") == quad9DNS.reverse().join(",") )
+	{
+		dnsType = "quad9";
 	}
 	setSelectedValue("lan_dns_source", dnsType);
 	setDnsSource(document.getElementById("lan_dns_source"))

--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -1963,7 +1963,7 @@ function proofreadText(input, proofFunction, validReturnCode)
 {
 	if(input.disabled != true)
 	{
-		input.style.color = (proofFunction(input.value) == validReturnCode) ? "black" : "red";
+		input.style.color = (proofFunction(input.value) == validReturnCode) ? "" : "red";
 	}
 }
 

--- a/package/plugin-gargoyle-i18n-SimplifiedChinese-ZH-CN/files/www/i18n/SimplifiedChinese-ZH-CN/time.js
+++ b/package/plugin-gargoyle-i18n-SimplifiedChinese-ZH-CN/files/www/i18n/SimplifiedChinese-ZH-CN/time.js
@@ -64,3 +64,4 @@ TiZ.UTCm10="关岛，俄罗斯";
 TiZ.UTCm11="所罗门群岛";
 TiZ.UTCm12="斐济";
 TiZ.NZST="新西兰";
+TiZ.IRST = "伊朗";

--- a/patches-generic/017-ar71xx-button-handlers.patch
+++ b/patches-generic/017-ar71xx-button-handlers.patch
@@ -1,6 +1,6 @@
---- /dev/null	1970-01-01 01:00:00.000000000 +0100
-+++ b/target/linux/ar71xx/base-files/etc/uci-defaults/gargoyle_button_handlers	2016-06-20 10:32:24.000000000 +0200
-@@ -0,0 +1,65 @@
+--- /dev/null
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/gargoyle_button_handlers
+@@ -0,0 +1,66 @@
 +#!/bin/sh
 +#
 +# Copyright (C) 2010 OpenWrt.org
@@ -8,8 +8,9 @@
 +
 +. /lib/ar71xx.sh
 +
-+is_tplink=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo | grep "TL\-[WM][DR]")
++is_tplink=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo | grep "T[LP]\-[WML][DRI]")
 +is_tplink_wr841_v9_v10_v11=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo | grep "TL\-WR841N\/ND v9")
++is_tplink_archer=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo | grep "TP-LINK Archer")
 +is_wrt160nl=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo | grep "WRT160NL")
 +is_netgear=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo | grep "WNDR3700")
 +is_ubntrspro=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo | grep "RouterStation Pro")
@@ -17,7 +18,7 @@
 +is_dlink=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo | grep -i "DIR.8[23]5")
 +is_hornet=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo | grep -i "ALFA.*Hornet")
 +
-+[ -n "$is_tplink_wr841_v9_v10_v11" ] && keycode='rfkill' || keycode='wps'
++[ -n "$is_tplink_wr841_v9_v10_v11" -o -n "$is_tplink_archer" ] && keycode='rfkill' || keycode='wps'
 +
 +if [ -n "$is_tplink" ] || [ -n "$is_wrt160nl" ] || [ -n "$is_netgear" ] || [ -n "$is_buffalo_wzr" ] || [ -n "$is_dlink" ] ; then
 +	uci batch <<EOF


### PR DESCRIPTION
Add Iran Timezone translation to ZH-CN
Addresses part of #683 

Fix the valid case for proofread functions. Instead of returning "black", return nothing so that the default colour for the theme takes over. This also stops people on the forums thinking their 5ghz network is "disabled" because it is a slightly different shade of grey to the 2.4ghz network.
(note for future, apparently the 5ghz network isn't being proofread. That's probably my fault)

Add TP Link Archer's to the button handler patch. This patch may need to be made more specific for different variations, but we can handle that in due time
is_tplink now looks for "TP-LI" at the beginning of the machine string as well.
Addresses #681 

Add Quad9 DNS to UI as an option
https://www.quad9.net/#/about
Requested by forum users