### PR TITLE
Allow for devices with no wireless capability

### DIFF
--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -1114,6 +1114,12 @@ function setGlobalVisibility()
 	{
 		currentMode=getSelectedValue('wifi_mode');
 		setAllowableSelections('wifi_mode', ['ap', 'ap+wds', 'adhoc', 'disabled'], [basicS.AcPt+' (AP)', 'AP+WDS', 'Ad Hoc', UI.Disabled]);
+		if(wirelessDriver == "")
+		{
+			removeOptionFromSelectElementByValue("wifi_mode", "ap", document);
+			removeOptionFromSelectElementByValue("wifi_mode", "ap+wds", document);
+			removeOptionFromSelectElementByValue("wifi_mode", "adhoc", document);
+		}
 		if(currentMode == 'ap+sta' || currentMode == 'sta')
 		{
 			setSelectedValue('wifi_mode', 'ap');
@@ -1124,9 +1130,14 @@ function setGlobalVisibility()
 		}
 	}
 
-	var proto1 = ['dhcp_wired', 'pppoe_wired', 'static_wired', 'dhcp_wireless', 'static_wireless'];
-	var proto2 = ['DHCP ('+basicS.Wird+')', 'PPPoE ('+basicS.Wird+')', basicS.StIP+' ('+basicS.Wird+')', 'DHCP ('+basicS.Wrlss+')', basicS.StIP+' ('+basicS.Wrlss+')'];
+	var proto1 = ['dhcp_wired', 'pppoe_wired', 'static_wired'];
+	var proto2 = ['DHCP ('+basicS.Wird+')', 'PPPoE ('+basicS.Wird+')', basicS.StIP+' ('+basicS.Wird+')'];
 
+	if(wirelessDriver)
+	{
+		proto1.push('dhcp_wireless','static_wireless');
+		proto2.push('DHCP ('+basicS.Wrlss+')',basicS.StIP+' ('+basicS.Wrlss+')');
+	}
 	if(hasUSB)
 	{
 		proto1.push('3g');
@@ -1450,6 +1461,11 @@ function setBridgeVisibility()
 	}
 
 
+	//If no wireless, disable bridge/repeater setup
+	if(wirelessDriver == "")
+	{
+		document.getElementById("global_bridge").disabled = true;
+	}
 	setAllowableSelections("bridge_hwmode",allowedbridgemodes2,allowedbridgemodes)
 
 	setHwMode(document.getElementById("bridge_hwmode"))
@@ -2725,6 +2741,10 @@ function parseWifiScan(rawScanOutput)
 
 function setChannelWidth(selectCtl, band)
 {
+	if(wirelessDriver == "")
+	{
+		return;
+	}
 	var chw =  getSelectedValue(selectCtl.id)
 	var hplus = chw =='HT40+';
 	var h40 = (chw == 'HT40+' || chw == 'HT40-');
@@ -2814,6 +2834,10 @@ function getSelectedWifiChannels()
 	var channels = []
 	channels["A"] = ""
 	channels["G"] = ""
+	if(wirelessDriver == "")
+	{
+		return channels;
+	}
 	if(document.getElementById("global_gateway").checked)
 	{
 		var wimode = getSelectedValue("wifi_mode")

--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -1143,6 +1143,22 @@ function removeOptionFromSelectElement(selectId, optionText, controlDocument)
 	}
 }
 
+function removeOptionFromSelectElementByValue(selectId, optionValue, controlDocument)
+{
+	controlDocument = controlDocument == null ? document : controlDocument;
+
+	selectElement = controlDocument.getElementById(selectId);
+	selectionFound = false;
+	for(optionIndex = 0; optionIndex < selectElement.options.length && (!selectionFound); optionIndex++)
+	{
+		selectionFound = (selectElement.options[optionIndex].value == optionValue);
+		if(selectionFound)
+		{
+			selectElement.remove(optionIndex);
+		}
+	}
+}
+
 function removeAllOptionsFromSelectElement(selectElement)
 {
 	while(selectElement.length > 0)
@@ -2963,5 +2979,4 @@ function sidebar()
 		row.className = "row-offcanvas full-height active";
 	}
 }
-
 


### PR DESCRIPTION
Please consider this a more comprehensive version of #682  

If the device has no wireless capability (i.e. cached_basic_vars contains the minimal variables, and /etc/config/wireless is empty):
- Removal all options except "Disabled" from wireless mode
- Remove wireless WAN modes
- Disable selection of wireless bridge/repeater

Add new function removeOptionFromSelectElementByValue to enhance existing functionality but allow us to be i18n safe

Closes #626 