### PR TITLE
Add new bandwidth monitor (month) with variable reset time

### DIFF
--- a/package/bwmon-gargoyle/files/bwmond.init
+++ b/package/bwmon-gargoyle/files/bwmond.init
@@ -157,6 +157,10 @@ start()
 	bdist5_interval="month"
 	bdist5_num_intervals=12
 
+	bdist6_interval="month"
+	bdist6_num_intervals=12
+	bdist6_reset_time=$(($(uci get gargoyle.bandwidth_display.month_reset_day)*$day_s))
+
 	ids=""
 
 
@@ -179,6 +183,10 @@ start()
 	fi
 	
 	mon_nums="1 2 3 4 5"
+	custom_bwmon=$(uci get gargoyle.bandwidth_display.custom_bwmon_enable 2>/dev/null)
+	if [ "$custom_bwmon" = "1" ] ; then
+		mon_nums="$mon_nums 6"
+	fi
 	for n in $mon_nums ; do
 		total_interval=$(eval "echo \$total"$n"_interval")
 		total_num_intervals=$(eval "echo \$total"$n"_num_intervals")
@@ -190,15 +198,16 @@ start()
 		bdist_reset_time=$(eval "echo \$bdist"$n"_reset_time")
 		if [ -n "$bdist_reset_time" ] ; then bdist_reset_time="--reset_time $bdist_reset_time" ; fi
 
-		
-		iptables -t $download_table -A $download_chain -m bandwidth --id "total"$n"-download-$total_interval-$total_num_intervals" --reset_interval $total_interval --intervals_to_save $total_num_intervals $total_reset_time
-		iptables -t $upload_table   -A $upload_chain   -m bandwidth --id "total"$n"-upload-$total_interval-$total_num_intervals"   --reset_interval $total_interval --intervals_to_save $total_num_intervals $total_reset_time
+		if [ $n -lt 6 ] ; then
+			iptables -t $download_table -A $download_chain -m bandwidth --id "total"$n"-download-$total_interval-$total_num_intervals" --reset_interval $total_interval --intervals_to_save $total_num_intervals $total_reset_time
+			iptables -t $upload_table   -A $upload_chain   -m bandwidth --id "total"$n"-upload-$total_interval-$total_num_intervals"   --reset_interval $total_interval --intervals_to_save $total_num_intervals $total_reset_time
 
-		next_ids="total"$n"-download-$total_interval-$total_num_intervals total"$n"-upload-$total_interval-$total_num_intervals"
-		if [ -z "$ids" ] ; then
-			ids="$next_ids"
-		else
-			ids="$ids $next_ids"
+			next_ids="total"$n"-download-$total_interval-$total_num_intervals total"$n"-upload-$total_interval-$total_num_intervals"
+			if [ -z "$ids" ] ; then
+				ids="$next_ids"
+			else
+				ids="$ids $next_ids"
+			fi
 		fi
 
 		if [ -n "$lan_mask" ] && [ -n "$lan_ip" ] ; then
@@ -210,7 +219,7 @@ start()
 	done
 
 	if [ "$high_res_15m" = "1" ] ; then
-		mon_nums="0 1 2 3 4 5"
+		mon_nums="0 $mon_nums"
 	fi
 	qos_enabled=$(ls /etc/rc.d/*qos_gargoyle 2>/dev/null)
 	if [ -n "$qos_enabled" ] && [ -e /etc/qos_class_marks ] ; then

--- a/package/bwmon-gargoyle/files/bwmond.init
+++ b/package/bwmon-gargoyle/files/bwmond.init
@@ -157,9 +157,13 @@ start()
 	bdist5_interval="month"
 	bdist5_num_intervals=12
 
+	custom_reset_time=$(uci get gargoyle.bandwidth_display.month_reset_day 2>/dev/null)
+	if [ -z "$custom_reset_time" ] ; then
+		custom_reset_time=0
+	fi
 	bdist6_interval="month"
 	bdist6_num_intervals=12
-	bdist6_reset_time=$(($(uci get gargoyle.bandwidth_display.month_reset_day)*$day_s))
+	bdist6_reset_time=$(($custom_reset_time*$day_s))
 
 	ids=""
 

--- a/package/gargoyle/files/www/bandwidth.sh
+++ b/package/gargoyle/files/www/bandwidth.sh
@@ -108,7 +108,7 @@
 							<label class="col-xs-11" id="use_high_res_15m_label" for="use_high_res_15m"><%~ HRInf %></label>
 							<span class="col-xs-11 col-xs-offset-1"><em><%~ HRWrn %></em></span>
 						</div>
-						<span class="col-xs-12"><br /><%~ UsInf %><br /><%~ LclTrff %></span>
+						<span class="alert alert-warning col-xs-12" role="alert"><%~ UsInf %><br /><%~ LclTrff %></span>
 					</div>
 				</div>
 
@@ -185,7 +185,43 @@
 				<div class="form-group">
 					<button id="delete_data_button" class="btn btn-danger btn-lg" onclick="deleteData();"><%~ DelD %></button>
 				</div>
+			</div>
+		</div>
+	</div>
+	<div class="col-lg-6">
+		<div class="panel panel-default">
+			<div class="panel-heading">
+				<h3 class="panel-title"><%~ BMonSet %></h3>
+			</div>
+			<div id="custom_bwmon_settings" class="panel-body">
+				<div class="row form-group">
+					<span class="col-xs-1"><input type="checkbox" id="enable_custom_bwmon" onclick="setCustBWMonVisilbility()"></span>
+					<label class="col-xs-11" id="enable_custom_bwmon_label" for="enable_custom_bwmon"><%~ EnCustBMon %></label>
+				</div>
 
+				<div class="row form-group">
+					<label class="col-xs-5" for="custom_time_frame" id="custom_time_frame_label"><%~ BMonIntvl %>:</label>
+					<span class="col-xs-7">
+						<select id="custom_time_frame" class="form-control" disabled="true">
+							<option value="1"><%~ mnths %></option>
+						</select>
+					</span>
+				</div>
+
+				<div class="row form-group">
+					<label class="col-xs-5" for="custom_reset_day" id="custom_reset_day_label"><%~ BMonReset %>:</label>
+					<span class="col-xs-7">
+						<select id="custom_reset_day" class="form-control" onchange="setCustBWMonVisilbility()"></select>
+					</span>
+				</div>
+
+				<div class="row form-group">
+					<span class="alert alert-danger col-xs-12" role="alert"><%~ CustBMonWarn %></span>
+				</div>
+
+				<div class="form-group">
+					<button id="bwcustSaveChanges" class="btn btn-danger btn-lg" onclick="bwcustSaveChanges()" disabled="true"><%~ SaveChanges %></button>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/package/gargoyle/files/www/bandwidth.sh
+++ b/package/gargoyle/files/www/bandwidth.sh
@@ -195,7 +195,7 @@
 			</div>
 			<div id="custom_bwmon_settings" class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="enable_custom_bwmon" onclick="setCustBWMonVisilbility()"></span>
+					<span class="col-xs-1"><input type="checkbox" id="enable_custom_bwmon" onclick="setCustBWMonVisibility()"></span>
 					<label class="col-xs-11" id="enable_custom_bwmon_label" for="enable_custom_bwmon"><%~ EnCustBMon %></label>
 				</div>
 
@@ -211,7 +211,7 @@
 				<div class="row form-group">
 					<label class="col-xs-5" for="custom_reset_day" id="custom_reset_day_label"><%~ BMonReset %>:</label>
 					<span class="col-xs-7">
-						<select id="custom_reset_day" class="form-control" onchange="setCustBWMonVisilbility()"></select>
+						<select id="custom_reset_day" class="form-control" onchange="setCustBWMonVisibility()"></select>
 					</span>
 				</div>
 

--- a/package/gargoyle/files/www/js/bandwidth.js
+++ b/package/gargoyle/files/www/js/bandwidth.js
@@ -957,7 +957,7 @@ function deleteData()
 	runAjax("POST", "utility/run_commands.sh", param, stateChangeFunction);
 }
 
-function setCustBWMonVisilbility()
+function setCustBWMonVisibility()
 {
 	var bwcustDisabled = document.getElementById("enable_custom_bwmon").checked == true ? false : true;
 	//document.getElementById("custom_time_frame").disabled = bwcustDisabled;	//Currently always disabled as we only want people to be able to set months

--- a/package/gargoyle/files/www/js/bandwidth.js
+++ b/package/gargoyle/files/www/js/bandwidth.js
@@ -103,6 +103,38 @@ function initializePlotsAndTable()
 
 	document.getElementById("use_high_res_15m").checked = uciOriginal.get("gargoyle", "bandwidth_display", "high_res_15m") == "1" ? true : false;
 
+	var bwUCIval = uciOriginal.get("gargoyle", "bandwidth_display", "custom_bwmon_enable");
+	var enable_custom_bwmon = (bwUCIval == "0") || (bwUCIval == "") ? 0 : 1;
+	document.getElementById("enable_custom_bwmon").checked = enable_custom_bwmon;
+	document.getElementById("custom_reset_day").disabled = enable_custom_bwmon ? false : true;
+	var vals = [];
+	var names = [];
+	var day=1;
+	for(day=1; day <= 28; day++)
+	{
+		var dayStr = "" + day;
+		var lastDigit = dayStr.substr( dayStr.length-1, 1);
+		var suffix=bndwS.Digs
+		if( day % 100  != 11 && lastDigit == "1")
+		{
+			suffix=bndwS.LD1s
+		}
+		if( day % 100 != 12 && lastDigit == "2")
+		{
+			suffix=bndwS.LD2s
+		}
+		if( day %100 != 13 && lastDigit == "3")
+		{
+			suffix=bndwS.LD3s
+		}
+		names.push(dayStr + suffix);
+		vals.push( (day-1) + "" );
+	}
+	setAllowableSelections("custom_reset_day", vals, names, document);
+	bwUCIval = uciOriginal.get("gargoyle", "bandwidth_display", "month_reset_day");
+	document.getElementById("custom_reset_day").value = bwUCIval == "" ? "0" : bwUCIval;
+	if(enable_custom_bwmon){addOptionToSelectElement("table_time_frame", bndwS.mnths + " " + bndwS.CustBMon, 6);}
+
 	var haveQosUpload = false;
 	var haveQosDownload = false;
 	var haveTor = false;
@@ -727,6 +759,8 @@ function updateBandwidthTable(tablePointSets, interval, tableLastTimePoint)
 	var rowIndex = 0;
 	var displayUnits = getSelectedValue("table_units");
 	var timePoint = tableLastTimePoint;
+	var custom_bwmon = document.getElementById("table_time_frame").value == 6 ? true : false;
+	var month_reset_day = uciOriginal.get("gargoyle", "bandwidth_display", "month_reset_day");
 	var nextDate = new Date();
 	nextDate.setTime(timePoint*1000);
 	nextDate.setUTCMinutes( nextDate.getUTCMinutes()+tzMinutes );
@@ -766,6 +800,19 @@ function updateBandwidthTable(tablePointSets, interval, tableLastTimePoint)
 		{
 			timeStr = monthNames[nextDate.getUTCMonth()] + " " + nextDate.getUTCDate();
 			nextDate.setUTCDate( nextDate.getUTCDate()-1);
+		}
+		else if(interval.match(/month/) && custom_bwmon)
+		{
+			if(nextDate.getUTCDate() <= month_reset_day)
+			{
+				timeStr = (month_reset_day - -1) + " " + monthNames[nextDate.getUTCMonth(nextDate.setUTCMonth(nextDate.getUTCMonth()-1))] + " " + nextDate.getUTCFullYear() + " - " + month_reset_day + " " + monthNames[nextDate.getUTCMonth(nextDate.setUTCMonth(nextDate.getUTCMonth()+1))] + " " + nextDate.getUTCFullYear();
+				nextDate.setUTCMonth(nextDate.getUTCMonth()-1);
+			}
+			else if(nextDate.getUTCDate() > month_reset_day)
+			{
+				timeStr = (month_reset_day - -1) + " " + monthNames[nextDate.getUTCMonth()] + " " + nextDate.getUTCFullYear() + " - " + month_reset_day + " " + monthNames[nextDate.getUTCMonth(nextDate.setUTCMonth(nextDate.getUTCMonth()+1))] + " " + nextDate.getUTCFullYear();
+				nextDate.setUTCMonth(nextDate.getUTCMonth()-2);
+			}
 		}
 		else if(interval.match(/month/))
 		{
@@ -903,6 +950,67 @@ function deleteData()
 	{
 		if(req.readyState == 4)
 		{
+			setControlsEnabled(true);
+		}
+	}
+	var param = getParameterDefinition("commands", commands.join("\n"))  + "&" + getParameterDefinition("hash", document.cookie.replace(/^.*hash=/,"").replace(/[\t ;]+.*$/, ""));
+	runAjax("POST", "utility/run_commands.sh", param, stateChangeFunction);
+}
+
+function setCustBWMonVisilbility()
+{
+	var bwcustDisabled = document.getElementById("enable_custom_bwmon").checked == true ? false : true;
+	//document.getElementById("custom_time_frame").disabled = bwcustDisabled;	//Currently always disabled as we only want people to be able to set months
+	document.getElementById("custom_reset_day").disabled = bwcustDisabled;
+
+	checkCustBWMonChanges();
+}
+
+function checkCustBWMonChanges()
+{
+	var orig_bwcustStatus = uciOriginal.get("gargoyle","bandwidth_display","custom_bwmon_enable");
+	var orig_bwcustResetDay = uciOriginal.get("gargoyle","bandwidth_display","month_reset_day");
+
+	var bwcustStatus = document.getElementById("enable_custom_bwmon").checked == true ? 1 : 0;
+	var bwcustResetDay = document.getElementById("custom_reset_day").value;
+
+	if((orig_bwcustStatus != bwcustStatus) || (orig_bwcustResetDay != bwcustResetDay))
+	{
+		//We must have changed something, allow saving
+		document.getElementById("bwcustSaveChanges").disabled = false;
+	}
+	else
+	{
+		document.getElementById("bwcustSaveChanges").disabled = true;
+	}
+}
+
+function bwcustSaveChanges()
+{
+	if (confirm(bndwS.CustBMonWarn) == false)
+	{
+		return;
+	}
+
+	setControlsEnabled(false, true, UI.WaitSettings);
+
+	var bwcustStatus = document.getElementById("enable_custom_bwmon").checked == true ? 1 : 0;
+	var bwcustResetDay = document.getElementById("custom_reset_day").value;
+	bwcustResetDay = bwcustResetDay == "" ? "0" : bwcustResetDay;
+	var commands = [];
+	commands.push("uci set gargoyle.bandwidth_display.custom_bwmon_enable=" + bwcustStatus);
+	commands.push("uci set gargoyle.bandwidth_display.month_reset_day=" + bwcustResetDay);
+	commands.push("uci commit gargoyle");
+	commands.push("/etc/init.d/bwmon_gargoyle stop");
+	commands.push("rm /tmp/data/bwmon/bdist6* 2>/dev/null");
+	commands.push("rm /usr/data/bwmon/bdist6* 2>/dev/null");
+	commands.push("/etc/init.d/bwmon_gargoyle start");
+
+	var stateChangeFunction = function(req)
+	{
+		if(req.readyState == 4)
+		{
+			window.location = window.location;
 			setControlsEnabled(true);
 		}
 	}

--- a/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/bandwidth.js
+++ b/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/bandwidth.js
@@ -31,6 +31,16 @@ bndwS.DSep="Data is comma separated";
 bndwS.DFmt="[Direction],[Interval Length],[Intervals Saved],[IP],[Interval Start],[Interval End],[Bytes Used]";
 bndwS.DNow="Download Now";
 bndwS.expd="expand";
+bndwS.BMonSet="Custom Bandwith Monitor Settings";
+bndwS.EnCustBMon="Enable Custom Bandwith Monitor";
+bndwS.CustBMonWarn="Changing any settings will ERASE previously stored Custom Bandwidth Monitor history. This will NOT affect the history of the default Bandwidth Monitors";
+bndwS.BMonIntvl="Monitor Interval";
+bndwS.BMonReset="Reset Day";
+bndwS.LD1s="st";
+bndwS.LD2s="nd";
+bndwS.LD3s="rd";
+bndwS.Digs="th";
+bndwS.CustBMon="(Custom)";
 
 //javascript
 bndwS.UpCl="Upload Class";


### PR DESCRIPTION
This option allows users to spin-up a new monthly bandwidth monitor that resets on the day they choose. This will allow them to align the monitoring with their ISPs reset dates (a highly requested feature).

Feature could be extended easily to allow any interval/reset time custom monitor, however it is currently written with months hardcoded for this particular purpose.