### PR TITLE
 Update USB Storage and Login pages

### DIFF
--- a/package/gargoyle/files/www/login.sh
+++ b/package/gargoyle/files/www/login.sh
@@ -70,13 +70,16 @@ var passInvalid = false;
 <div id="login_status" class="alert alert-danger" role="alert" style="display:none;"></div>
 
 <div class="row">
-	<div class="col-lg-12">
-		<div class="panel panel-primary">
+	<div class="col-lg-8">
+		<div class="panel panel-default">
+			<div class="panel-heading">
+				<h3 class="panel-title"><%~ EAdmP %></h3>
+			</div>
 			<div class="panel-body">
 				<div class="row form-group">
 					<label class="sr-only" for="password" id="password_label"><%~ EAdmP %></label>
 					<span class="col-xs-12">
-						<input id="password" class="form-control" type="password" onkeyup="proofreadLengthRange(this,1,999)" onkeydown="checkKey(event)" size="25" placeholder="<%~ EAdmP %>"/>
+						<input id="password" class="form-control" type="password" onkeyup="proofreadLengthRange(this,1,999)" onkeydown="checkKey(event)" size="25"/>
 						<button class="btn btn-default" onclick="doLogin()" ><%~ LSect %></button>
 					</span>
 				</div>
@@ -87,7 +90,7 @@ var passInvalid = false;
 
 <div class="row">
 	<div class="col-lg-4">
-		<div id="current_time" class="panel panel-info">
+		<div id="current_time" class="panel panel-default">
 			<div class="panel-heading">
 				<h3 class="panel-title"><%~ CTime %></h3>
 			</div>
@@ -99,7 +102,7 @@ var passInvalid = false;
 	</div>
 
 	<div class="col-lg-4">
-		<div id="current_ip" class="panel panel-info">
+		<div id="current_ip" class="panel panel-default">
 			<div class="panel-heading">
 				<h3 class="panel-title"><%~ CIP %></h3>
 			</div>
@@ -112,7 +115,7 @@ var passInvalid = false;
 </div>
 <div class="row">
 	<div class="col-lg-4">
-		<div id="local_quotas" class="panel panel-info" style="display:none">
+		<div id="local_quotas" class="panel panel-default" style="display:none">
 			<div class="panel-heading">
 				<h3 class="panel-title"><%~ YQot %></h3>
 			</div>
@@ -121,7 +124,7 @@ var passInvalid = false;
 	</div>
 
 	<div class="col-lg-4">
-		<div id="global_quotas" class="panel panel-info" style="display:none">
+		<div id="global_quotas" class="panel panel-default" style="display:none">
 			<div class="panel-heading">
 				<h3 class="panel-title"><%~ NQot %></h3>
 			</div>

--- a/package/gargoyle/files/www/login.sh
+++ b/package/gargoyle/files/www/login.sh
@@ -70,16 +70,13 @@ var passInvalid = false;
 <div id="login_status" class="alert alert-danger" role="alert" style="display:none;"></div>
 
 <div class="row">
-	<div class="col-lg-8">
+	<div class="col-lg-12">
 		<div class="panel panel-default">
-			<div class="panel-heading">
-				<h3 class="panel-title"><%~ EAdmP %></h3>
-			</div>
 			<div class="panel-body">
 				<div class="row form-group">
 					<label class="sr-only" for="password" id="password_label"><%~ EAdmP %></label>
 					<span class="col-xs-12">
-						<input id="password" class="form-control" type="password" onkeyup="proofreadLengthRange(this,1,999)" onkeydown="checkKey(event)" size="25"/>
+						<input id="password" class="form-control" type="password" onkeyup="proofreadLengthRange(this,1,999)" onkeydown="checkKey(event)" size="25" placeholder="<%~ EAdmP %>"/>
 						<button class="btn btn-default" onclick="doLogin()" ><%~ LSect %></button>
 					</span>
 				</div>

--- a/package/plugin-gargoyle-theme-dark-one/files/www/themes/Dark-One/theme.css
+++ b/package/plugin-gargoyle-theme-dark-one/files/www/themes/Dark-One/theme.css
@@ -437,7 +437,7 @@ nav>li.active>a
 {
 	color: #8b9af3;
 }
-.panel.panel-default
+.panel.panel-default, .page-header
 {
 	-moz-border-radius: 20px 0px 20px 0px;
 	-webkit-border-radius: 20px 0px 20px 0px;

--- a/package/plugin-gargoyle-theme-dark-one/files/www/themes/Dark-One/theme.css
+++ b/package/plugin-gargoyle-theme-dark-one/files/www/themes/Dark-One/theme.css
@@ -437,7 +437,7 @@ nav>li.active>a
 {
 	color: #8b9af3;
 }
-.panel.panel-default, .page-header
+.panel.panel-default
 {
 	-moz-border-radius: 20px 0px 20px 0px;
 	-webkit-border-radius: 20px 0px 20px 0px;

--- a/package/plugin-gargoyle-theme-dark-one/files/www/themes/Dark-One/theme.js
+++ b/package/plugin-gargoyle-theme-dark-one/files/www/themes/Dark-One/theme.js
@@ -1,0 +1,6 @@
+addLoadFunction( function(){ 
+	if(haveCollapsibleMenus == 1)
+	{
+		setNavMouseEvents() ; 
+	}
+});

--- a/package/plugin-gargoyle-usb-storage/files/www/usb_storage.sh
+++ b/package/plugin-gargoyle-usb-storage/files/www/usb_storage.sh
@@ -72,14 +72,18 @@
 
 			<div class="panel-body">
 				<div id='ftp_wan_access_container' class="row form-group">
-					<span class="col-xs-1"><input type='checkbox' id='ftp_wan_access' onclick='updateWanFtpVisibility()'/></span>
-					<label class="col-xs-11" id='ftp_wan_access_label' for='ftp_wan_access'><%~ WFTP %></label>
+					<span class="col-xs-12">
+						<input type='checkbox' id='ftp_wan_access' onclick='updateWanFtpVisibility()'/>
+						<label id='ftp_wan_access_label' for='ftp_wan_access'><%~ WFTP %></label>
+					</span>
 				</div>
 
 				<div id='ftp_pasv_container' class="row form-group">
-					<span class="col-xs-1"><input type='checkbox' id='ftp_wan_pasv' onclick='updateWanFtpVisibility()'/></span>
-					<span class="col-xs-11">
-						<label id='ftp_wan_access_label' for='ftp_wan_pasv'><%~ WpFTP %></label>&nbsp;
+					<span class="col-xs-5">
+						<input type='checkbox' id='ftp_wan_pasv' onclick='updateWanFtpVisibility()'/>
+						<label id='ftp_wan_access_label' for='ftp_wan_pasv'><%~ WpFTP %></label>
+					</span>
+					<span class="col-xs-7">
 						<input class="form-control" type="text" size='7' maxLength='5' onkeyup='proofreadPort(this)' id='pasv_min_port' />&nbsp;-&nbsp;
 						<input class="form-control" type="text" size='7' maxLength='5' onkeyup='proofreadPort(this)' id='pasv_max_port' />
 					</span>
@@ -93,7 +97,7 @@
 				</div>
 
 				<div id="user_container" class="row form-group">
-					<label class="col-xs-12" id="cifs_user_label"><%~ CFUsr %>:</label>
+					<span class="col-xs-12" id="cifs_user_label" style="text-decoration:underline"><%~ CFUsr %>:</span>
 					<label class="col-xs-5" id="user_label" for="new_user"><%~ NewU %>:</label>
 					<span class="col-xs-7"><input id="new_user" class="form-control" type="text"/></span>
 				</div>
@@ -119,22 +123,28 @@
 				</div>
 
 				<div id="sharing_add_controls_container" class="row form-group">
-					<%in templates/usb_storage_template %>
 					<span class="col-xs-12">
+						<%in templates/usb_storage_template %>
 						<button id="add_share_button" class="btn btn-default" onclick="addNewShare()"><%~ ADsk %></button>
 					</span>
 				</div>
 				<div class="internal_divider"></div>
 
 				<div id="sharing_current_heading_container" class="row form-group">
-					<span class="col-xs-12" style="text-decoration:underline"><%~ CShare %>:</span>
+					<span class="col-xs-12">
+						<span style="text-decoration:underline"><%~ CShare %>:</span>
+						<div id="sharing_mount_table_container" class="table-responsive"></div>
+					</span>
 				</div>
-				<div id="sharing_mount_table_container" class="table-responsive"></div>
 
 				<div class="internal_divider"></div>
 
-				<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
-				<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
+				<div class="row form-group">
+					<span class="col-xs-12">
+						<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
+						<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
+					</span>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -147,8 +157,12 @@
 
 			<div class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-12"><button id="unmount_usb_button" class="btn btn-warning btn-lg" onclick="unmountAllUsb()"><%~ UmntB %></button></span>
-					<span class="col-xs-12 alert alert-warning"><em><%~ UmntWarn %></em></span>
+					<span class="col-xs-12">
+						<div class="alert alert-warning"><em><%~ UmntWarn %></em></div>
+					</span>
+					<span class="col-xs-12">
+						<button id="unmount_usb_button" class="btn btn-warning btn-lg" onclick="unmountAllUsb()"><%~ UmntB %></button>
+					</span>
 				</div>
 			</div>
 		</div>
@@ -158,18 +172,17 @@
 <div class="row">
 	<div id="disk_format" class="col-lg-6">
 		<div class="panel panel-default">
-			<div class="panel-heading">
+ 			<div class="panel-heading">
 				<h3 class="panel-title"><%~ FDisk %></h3>
 			</div>
 
 			<div class="panel-body">
 				<div id="no_unmounted_drives" class="row form-group">
-					<em><span class="col-xs-12"><%~ NoUmntDev %></span></em>
+					<span class="col-xs-12">
+						<div class="alert alert-warning"><em><%~ NoUmntDev %></em></div>
+					</span>
 				</div>
 
-				<div id="format_warning" class="row form-group">
-					<em><span class="col-xs-12 alert alert-danger"><%~ FmtWarn %></span></em>
-				</div>
 
 				<div id="format_disk_select_container" class="row form-group">
 					<label class="col-xs-5" id="format_disk_select_label" for="format_disk_select"><%~ DskForm %>:</label>
@@ -193,15 +206,25 @@
 				</div>
 
 				<div id="extroot_container" class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="extroot" name="extroot"/></span>
-					<label class="col-xs-11" id="extroot_label" for="extroot" style="vertical-align:middle"><%~ MExtr %></label>
-					<div class="col-xs-12 alert alert-warning">
-						<em><%~ ExtrWarn %></em>
-					</div>
+					<span class="col-xs-12">
+						<input type="checkbox" id="extroot" name="extroot"/>
+						<label id="extroot_label" for="extroot" style="vertical-align:middle"><%~ MExtr %></label>
+					</span>
+					<span class="col-xs-12">
+						<div class="alert alert-warning"><em><%~ ExtrWarn %></em></div>
+					</span>
+				</div>
+
+				<div id="format_warning" class="row form-group">
+					<span class="col-xs-12">
+						<div class="alert alert-danger"><em><%~ FmtWarn %></em></div>
+					</span>
 				</div>
 
 				<div id="usb_format_button_container" class="row form-group">
-					<span class="col-xs-12"><button id="usb_format_button" class="btn btn-danger btn-lg" onclick="formatDiskRequested()"><%~ FmtNow %></button></span>
+					<span class="col-xs-12">
+						<button id="usb_format_button" class="btn btn-danger btn-lg" onclick="formatDiskRequested()"><%~ FmtNow %></button>
+					</span>
 				</div>
 			</div>
 		</div>
@@ -215,8 +238,12 @@
 
 			<div class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-12"><button id="extroot_button" class="btn btn-danger btn-lg" onclick="disableExtroot();"><%~ ExtrOff %></button></span>
-					<span class="col-xs-12 alert alert-warning"><em><%~ ExtDt %> <strong><span id="extroot_drive"></span></strong>.</em></span>
+					<span class="col-xs-12">
+						<button id="extroot_button" class="btn btn-danger btn-lg" onclick="disableExtroot();"><%~ ExtrOff %></button>
+					</span>
+					<span class="col-xs-12">
+						<div class="alert alert-warning"><em><%~ ExtDt %> <strong><span id="extroot_drive"></span></strong>.</em></div>
+					</span>
 				</div>
 			</div>
 		</div>
@@ -225,7 +252,6 @@
 
 <iframe id="reboot_test" onload="reloadPage()" style="display:none"></iframe>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id='output'></textarea> -->
 
 <script>
 <!--


### PR DESCRIPTION
- Fix panel class style in `Login.sh` page, so theme specific panel style is applied properly.
- Add collapsible menu support to Dark One theme.

![803e354d-97e0-4aa3-a1f7-247a0afe92e1](https://user-images.githubusercontent.com/22578839/34611345-3dda7b48-f20c-11e7-8966-fc5069f699bc.png)

Closes #709

- Fix USB Storage checkbox formatting.
- Fix USB Storage template alignment.
- Other minor formatting fixes.

Before:
 ![d14e1781-4d81-45e7-ae48-37e81e6a3c40](https://user-images.githubusercontent.com/22578839/34624800-ab8a688e-f23d-11e7-9fe2-0ff1a9b4fb5f.png)
After:
![9ae8a291-0d08-4c7c-8fa4-f09c4dca1e7f](https://user-images.githubusercontent.com/22578839/34624957-28460c8e-f23e-11e7-91a5-e0894621032c.png)

  
  
  
  
  