### PR TITLE
Fix checkbox/label elements arrangement on various pages

### DIFF
--- a/package/gargoyle/files/www/access.sh
+++ b/package/gargoyle/files/www/access.sh
@@ -124,8 +124,10 @@
 				</div>
 
 				<div class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="disable_web_password"/></span>
-					<label class="col-xs-11" id="disable_web_password_label" for="disable_web_password"><%~ DisablePassword %> <em>(<%~ warning %>)</em></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="disable_web_password"/>
+						<label id="disable_web_password_label" for="disable_web_password"><%~ DisablePassword %> <em>(<%~ warning %>)</em></label>
+					</span>
 				</div>
 			</div>
 		</div>
@@ -144,8 +146,10 @@
 				</div>
 
 				<div class="row form-group" id="remote_ssh_enabled_container">
-					<span class="col-xs-1"><input type="checkbox" id="remote_ssh_enabled" onclick="updateVisibility()"/></span>
-					<label class="col-xs-11" id="remote_ssh_enabled_label" for="remote_ssh_enabled"><%~ EnableRemoteAccess %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="remote_ssh_enabled" onclick="updateVisibility()"/>
+						<label id="remote_ssh_enabled_label" for="remote_ssh_enabled"><%~ EnableRemoteAccess %></label>
+					</span>
 				</div>
 
 				<div class="row form-group" id="remote_ssh_port_container">
@@ -169,8 +173,10 @@
 
 				<div style="display: block;" id="internal_divider1" class="internal_divider"></div>
 				<div class="row form-group" id="pwd_enabled_container">
-					<span class="col-xs-1"><input type="checkbox" id="pwd_auth_enabled" /></span>
-					<label class="col-xs-11" id="pwd_auth_label" for="pwd_auth_enabled"><%~ SSHEnablePwd %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="pwd_auth_enabled" />
+						<label id="pwd_auth_label" for="pwd_auth_enabled"><%~ SSHEnablePwd %></label>
+					</span>
 				</div>
 
 				<div style="display: block;" id="internal_divider2" class="internal_divider"></div>

--- a/package/gargoyle/files/www/bandwidth.sh
+++ b/package/gargoyle/files/www/bandwidth.sh
@@ -104,9 +104,11 @@
 				<div class="row">
 					<div class="col-lg-12">
 						<div class="row form-group">
-							<span class="col-xs-1"><input type="checkbox" id="use_high_res_15m" onclick="highResChanged()"></span>
-							<label class="col-xs-11" id="use_high_res_15m_label" for="use_high_res_15m"><%~ HRInf %></label>
-							<span class="col-xs-11 col-xs-offset-1"><em><%~ HRWrn %></em></span>
+							<span class="col-xs-12">
+								<input type="checkbox" id="use_high_res_15m" onclick="highResChanged()">
+								<label id="use_high_res_15m_label" for="use_high_res_15m"><%~ HRInf %></label>
+								<span class="col-xs-12"><em><%~ HRWrn %></em></span>
+							</span>
 						</div>
 						<span class="alert alert-warning col-xs-12" role="alert"><%~ UsInf %><br /><%~ LclTrff %></span>
 					</div>
@@ -195,8 +197,10 @@
 			</div>
 			<div id="custom_bwmon_settings" class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="enable_custom_bwmon" onclick="setCustBWMonVisibility()"></span>
-					<label class="col-xs-11" id="enable_custom_bwmon_label" for="enable_custom_bwmon"><%~ EnCustBMon %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="enable_custom_bwmon" onclick="setCustBWMonVisibility()">
+						<label id="enable_custom_bwmon_label" for="enable_custom_bwmon"><%~ EnCustBMon %></label>
+					</span>
 				</div>
 
 				<div class="row form-group">

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -558,20 +558,26 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 
 				<div id="wan_mac_container" class="row form-group">
 					
-					<span class="col-xs-1"><input type="checkbox" id="wan_use_mac" onclick="enableAssociatedField(this, 'wan_mac', defaultWanMac)"/></span>
-					<label class="col-xs-4 short-left-pad" for="wan_use_mac" id="wan_mac_label"><%~ CustMAC %>:</label>
+					<span class="col-xs-5">
+						<input type="checkbox" id="wan_use_mac" onclick="enableAssociatedField(this, 'wan_mac', defaultWanMac)"/>
+						<label class="short-left-pad" for="wan_use_mac" id="wan_mac_label"><%~ CustMAC %>:</label>
+					</span>
 					<span class="col-xs-7"><input type="text" name="wan_mac" id="wan_mac" class="form-control" onkeyup="proofreadMac(this)" size="20" maxlength="17"/></span>
 				</div>
 
 				<div id="wan_mtu_container" class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="wan_use_mtu" onclick="enableAssociatedField(this, 'wan_mtu', 1500)"/></span>
-					<label class="col-xs-4 short-left-pad" for="wan_use_mtu" id="wan_mtu_label"><%~ CustMTU %>:</label>
+					<span class="col-xs-5">
+						<input type="checkbox" id="wan_use_mtu" onclick="enableAssociatedField(this, 'wan_mtu', 1500)"/>
+						<label class="short-left-pad" for="wan_use_mtu" id="wan_mtu_label"><%~ CustMTU %>:</label>
+					</span>
 					<span class="col-xs-7"><input type="text" name="wan_mtu" id="wan_mtu" class="form-control" onkeyup="proofreadNumeric(this)" size="20" maxlength="4"/></span>
 				</div>
 
 				<div id="wan_ping_container" class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="drop_wan_ping"/></span>
-					<label class="col-xs-11 short-left-pad" for="drop_wan_ping" id="wan_ping_label"><%~ DPing %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="drop_wan_ping"/>
+						<label class="short-left-pad" for="drop_wan_ping" id="wan_ping_label"><%~ DPing %></label>
+					</span>
 				</div>
 
 			</div>
@@ -626,13 +632,17 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="lan_dns_options_container">
 				
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="checkbox" id="lan_dns_altroot" /></span>
-						<label class="col-xs-11 short-left-pad" for="lan_dns_altroot" id="lan_dns_altroot_label" ><%~ Allow %> <a href="https://bit.namecoin.info">NameCoin</a>/<a href="http://www.opennicproject.org">OpenNIC</a> <%~ Rsln %></label>
+						<span class="col-xs-12">
+							<input type="checkbox" id="lan_dns_altroot" />
+							<label class="short-left-pad" for="lan_dns_altroot" id="lan_dns_altroot_label" ><%~ Allow %> <a href="https://bit.namecoin.info">NameCoin</a>/<a href="http://www.opennicproject.org">OpenNIC</a> <%~ Rsln %></label>
+						</span>
 					</div>
 
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="checkbox" id="lan_dns_force"/></span>
-						<label class="col-xs-11 short-left-pad" for="lan_dns_force" id="lan_dns_force_label" style="vertical-align:middle"><%~ RtrDNS %></label>
+						<span class="col-xs-12">
+							<input type="checkbox" id="lan_dns_force"/>
+							<label class="short-left-pad" for="lan_dns_force" id="lan_dns_force_label" style="vertical-align:middle"><%~ RtrDNS %></label>
+						</span>
 					</div>
 				</div>
 

--- a/package/gargoyle/files/www/dhcp.sh
+++ b/package/gargoyle/files/www/dhcp.sh
@@ -63,8 +63,10 @@ for (etherIndex in etherData)
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<div class="row form-group" id="dhcp_enabled_container">
-					<span class="col-xs-1"><input type="checkbox" id="dhcp_enabled" onclick="setEnabled(this.checked)" /></span>
-					<label class="col-xs-11" id="dhcp_enabled_label" for="dhcp_enabled"><%~ dhcp.SrvE %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="dhcp_enabled" onclick="setEnabled(this.checked)" />
+						<label id="dhcp_enabled_label" for="dhcp_enabled"><%~ dhcp.SrvE %></label>
+					</span>
 				</div>
 
 				<div id="dhcp_range_container" class="row form-group">
@@ -108,8 +110,10 @@ for (etherIndex in etherData)
 			</div>
 			<div class="panel-body">
 				<div id="block_mismatches_container" class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="block_mismatches" /></span>
-					<label class="col-xs-11" id="block_mismatch_label" for="block_mismatches"><%~ BlckM %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="block_mismatches" />
+						<label id="block_mismatch_label" for="block_mismatches"><%~ BlckM %></label>
+					</span>
 				</div>
 
 				<div id="staticip_add_heading_container" class="row form-group">

--- a/package/gargoyle/files/www/port_forwarding.sh
+++ b/package/gargoyle/files/www/port_forwarding.sh
@@ -83,8 +83,10 @@
 
 			<div class="panel-body">
 				<div id="upnp_enabled_container" class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="upnp_enabled" onclick="setUpnpEnabled()" /></span>
-					<label class="col-xs-11" id="upnp_enabled_label" for="upnp_enabled"><%~ UPNAT_En %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="upnp_enabled" onclick="setUpnpEnabled()" />
+						<label id="upnp_enabled_label" for="upnp_enabled"><%~ UPNAT_En %></label>
+					</span>
 				</div>
 
 				<div id="upnp_table_heading_container" class="row form-group">
@@ -129,8 +131,10 @@
 
 			<div class="panel-body">
 				<div id="dmz_enabled_container" class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="dmz_enabled" onclick="setDmzEnabled()" /></span>
-					<label class="col-xs-11" id="dmz_enabled_label" for="dmz_enabled"><%~ UseDMZ %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="dmz_enabled" onclick="setDmzEnabled()" />
+						<label id="dmz_enabled_label" for="dmz_enabled"><%~ UseDMZ %></label>
+					</span>
 				</div>
 
 				<div id="dmz_ip_container" class="row form-group">

--- a/package/gargoyle/files/www/qos_download.sh
+++ b/package/gargoyle/files/www/qos_download.sh
@@ -37,8 +37,10 @@
 
 			<div class="panel-body">
 				<div id="qos_enabled_container" class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="qos_enabled" onclick="setQosEnabled()" /></span>
-					<label class="col-xs-11" id="qos_enabled_label" for="qos_enabled"><%~ DEnable %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="qos_enabled" onclick="setQosEnabled()" />
+						<label id="qos_enabled_label" for="qos_enabled"><%~ DEnable %></label>
+					</span>
 				</div>
 
 				<div class="row form-group">
@@ -71,42 +73,42 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_source_ip" onclick="enableAssociatedField(this,'source_ip', '')" />
-						<label id="source_ip_label" for="source_ip"><%~ SrcIP %>:</label>
+						<label id="source_ip_label" for="use_source_ip"><%~ SrcIP %>:</label>
 					</span>
-					<span class="col-xs-7"><input class="form-control" type="text" id="source_ip" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" /></span>
+					<span class="col-xs-7"><input class="form-control" type="text" id="source_ip" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" aria-labelledby="source_ip_label"/></span>
 				</div>
 
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_source_port" onclick="enableAssociatedField(this,'source_port', '')"/>
-						<label id="source_port_label" for="source_port"><%~ SrcPort %>:</label>
+						<label id="source_port_label" for="use_source_port"><%~ SrcPort %>:</label>
 					</span>
-					<span class="col-xs-7"><input class="form-control" type="text" id="source_port" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" /></span>
+					<span class="col-xs-7"><input class="form-control" type="text" id="source_port" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" aria-labelledby="source_port_label"/></span>
 				</div>
 
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_dest_ip" onclick="enableAssociatedField(this,'dest_ip', '')" />
-						<label id="dest_ip_label" for="dest_ip"><%~ DstIP %>:</label>
+						<label id="dest_ip_label" for="use_dest_ip"><%~ DstIP %>:</label>
 					</span>
-					<span class="col-xs-7"><input class="form-control" type="text" id="dest_ip" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" /></span>
+					<span class="col-xs-7"><input class="form-control" type="text" id="dest_ip" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" aria-labelledby="dest_ip_label"/></span>
 				</div>
 
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_dest_port" onclick="enableAssociatedField(this,'dest_port', '')"  />
-						<label id="dest_port_label" for="dest_port"><%~ DstPort %>:</label>
+						<label id="dest_port_label" for="use_dest_port"><%~ DstPort %>:</label>
 					</span>
-					<span class="col-xs-7"><input class="form-control" type="text" id="dest_port" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" /></span>
+					<span class="col-xs-7"><input class="form-control" type="text" id="dest_port" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" aria-labelledby="dest_port_label"/></span>
 				</div>
 
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_max_pktsize" onclick="enableAssociatedField(this,'max_pktsize', '')"  />
-						<label id="max_pktsize_label" for="max_pktsize"><%~ MaxPktLen %>:</label>
+						<label id="max_pktsize_label" for="use_max_pktsize"><%~ MaxPktLen %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<input type="text" id="max_pktsize" class="form-control" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" />
+						<input type="text" id="max_pktsize" class="form-control" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" aria-labelledby="max_pktsize_label"/>
 						<em><%~ byt %></em>
 					</span>
 				</div>
@@ -114,10 +116,10 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_min_pktsize" onclick="enableAssociatedField(this,'min_pktsize', '')"  />
-						<label id="min_pktsize_label" for="min_pktsize"><%~ MinPktLen %>:</label>
+						<label id="min_pktsize_label" for="use_min_pktsize"><%~ MinPktLen %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<input type="text" id="min_pktsize" class="form-control" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" />
+						<input type="text" id="min_pktsize" class="form-control" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" aria-labelledby="min_pktsize_label"/>
 						<em><%~ byt %></em>
 					</span>
 				</div>
@@ -125,10 +127,10 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_transport_protocol" onclick="enableAssociatedField(this,'transport_protocol', '')"  />
-						<label id="transport_protocol_label" for="transport_protocol"><%~ TrProto %>:</label>
+						<label id="transport_protocol_label" for="use_transport_protocol"><%~ TrProto %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<select id="transport_protocol" class="form-control"/>
+						<select id="transport_protocol" class="form-control" aria-labelledby="transport_protocol_label">
 							<option value="TCP">TCP</option>
 							<option value="UDP">UDP</option>
 							<option value="ICMP">ICMP</option>
@@ -140,10 +142,10 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_connbytes_kb" onclick="enableAssociatedField(this,'connbytes_kb', '')"  />
-						<label id="connbytes_kb_label" for="connbytes_kb"><%~ Conreach %>:</label>
+						<label id="connbytes_kb_label" for="use_connbytes_kb"><%~ Conreach %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<input class="form-control" type="text" id="connbytes_kb" onkeyup="proofreadNumericRange(this,0,4194303)" size="17" maxlength="28" />
+						<input class="form-control" type="text" id="connbytes_kb" onkeyup="proofreadNumericRange(this,0,4194303)" size="17" maxlength="28" aria-labelledby="connbytes_kb_label"/>
 						<em><%~ KBy %></em>
 					</span>
 				</div>
@@ -151,10 +153,10 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_app_protocol" onclick="enableAssociatedField(this,'app_protocol', '')" />
-						<label id="app_protocol_label" for="app_protocol"><%~ AppProto %>:</label>
+						<label id="app_protocol_label" for="use_app_protocol"><%~ AppProto %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<select id="app_protocol" class="form-control" >
+						<select id="app_protocol" class="form-control" aria-labelledby="app_protocol_label">
 						<%
 						sed -e "s/#.*//" -e "s/\([^ ]* \)\(.*\)/<option value='\1'>\2<\/option>/" /etc/l7-protocols/l7index
 						%>
@@ -168,7 +170,7 @@
 						<label id="comment_rule_label" for="use_comment_rule"><%~ Comment %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<input class="form-control" type="text" id="comment_rule" size="17" maxlength="25" />
+						<input class="form-control" type="text" id="comment_rule" size="17" maxlength="25" aria-labelledby="comment_rule_label"/>
 					</span>
 				</div>
 
@@ -245,17 +247,19 @@
 				<div><%~ BandMin %>:</div>
 				<div class="indent">
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" name="min_radio" id="min_radio1" onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" /></span>
-						<label class="col-xs-11" for="min_radio1"><%~ BandMinNo %></label>
+						<span class="col-xs-12">
+							<input type="radio" name="min_radio" id="min_radio1" onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" />
+							<label for="min_radio1"><%~ BandMinNo %></label>
+						</span>
 					</div>
 					<div class="row form-group">
-						<span class="col-xs-1">
+						<span class="col-xs-5">
 							<input type="radio" name="min_radio" id="min_radio2" onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" />
+							<label id="min_bandwidth_label" for="min_radio2"><%~ BandMin %>:</label>
 						</span>
 
-						<span class="col-xs-11">
-							<label id="min_bandwidth_label" for="min_radio2"><%~ BandMin %>:</label>
-							<input type="text" id="min_bandwidth" class="form-control" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" />
+						<span class="col-xs-7">
+							<input type="text" id="min_bandwidth" class="form-control" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" aria-labelledby="min_bandwidth_label"/>
 							<em><%~ Kbs %></em>
 						</span>
 					</div>
@@ -264,16 +268,18 @@
 				<div><%~ BandMax %>:</div>
 				<div class="indent">
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" name="max_radio" id="max_radio1" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" /></span>
-						<label class="col-xs-11" for="max_radio1"><%~ BandMaxNo %></label>
+						<span class="col-xs-12">
+							<input type="radio" name="max_radio" id="max_radio1" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" />
+							<label for="max_radio1"><%~ BandMaxNo %></label>
+						</span>
 					</div>
 					<div class="row form-group">
-						<span class="col-xs-1">
+						<span class="col-xs-5">
 							<input type="radio" name="max_radio" id="max_radio2" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" />
-						</span>
-						<span class="col-xs-11">
 							<label id="max_bandwidth_label" for="max_radio2"><%~ BandMax %>:</label>
-							<input type="text" id="max_bandwidth" class="form-control" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" />
+						</span>
+						<span class="col-xs-7">
+							<input type="text" id="max_bandwidth" class="form-control" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" aria-labelledby="max_bandwidth_label"/>
 							<em><%~ Kbs %></em>
 						</span>
 					</div>
@@ -282,12 +288,16 @@
 				<div><%~ MinRTT %>:</div>
 				<div class="indent">
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" name="rtt_radio" id="rtt_radio1"/></span>
-						<label class="col-xs-11" for="max_radio1"><%~ ActRTT %></label>
+						<span class="col-xs-12">
+							<input type="radio" name="rtt_radio" id="rtt_radio1"/>
+							<label for="rtt_radio1"><%~ ActRTT %></label>
+						</span>
 					</div>
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" name="rtt_radio" id="rtt_radio2" /></span>
-						<label class="col-xs-11" for="max_radio2"><%~ OptiWAN %></label>
+						<span class="col-xs-12">
+							<input type="radio" name="rtt_radio" id="rtt_radio2" />
+							<label for="rtt_radio2"><%~ OptiWAN %></label>
+						</span>
 					</div>
 				</div>
 
@@ -306,23 +316,29 @@
 
 			<div class="panel-body">
 				<div class="row form-group" id="qos_monitor_container">
-					<span class="col-xs-1"><input type="checkbox" id="qos_monenabled" onclick="setQosEnabled()"/></span>
-					<label class="col-xs-11" id="qos_monenabled_label" for="qos_monenabled"><%~ ACCOn %></label>
-				</div>
-
-				<div class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="use_ptarget_ip" onclick="enableAssociatedField(this, 'ptarget_ip', currentWanGateway)"/></span>
-					<span class="col-xs-11">
-						<label for="ptarget_ip" id="ptarget_ip_label"><%~ ACC_Pt %>:</label>
-						<input type="text" name="ptarget_ip" id="ptarget_ip" class="form-control" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" />
+					<span class="col-xs-12">
+						<input type="checkbox" id="qos_monenabled" onclick="setQosEnabled()"/>
+						<label id="qos_monenabled_label" for="qos_monenabled"><%~ ACCOn %></label>
 					</span>
 				</div>
 
 				<div class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="use_auto_pinglimit" onclick="enableAssociatedField(this, 'pinglimit', 85)"/></span>
-					<span class="col-xs-11">
-						<label for="pinglimit" id="pinglimit_label"><%~ ACC_con %>:</label>
-						<input type="text" name="pinglimit" id="pinglimit" class="form-control" onkeyup="proofreadNumericRange(this, 10, 250)" size="4" maxlength="4" />
+					<span class="col-xs-6">
+						<input type="checkbox" id="use_ptarget_ip" onclick="enableAssociatedField(this, 'ptarget_ip', currentWanGateway)"/>
+						<label for="use_ptarget_ip" id="ptarget_ip_label"><%~ ACC_Pt %>:</label>
+					</span>
+					<span class="col-xs-6">
+						<input type="text" name="ptarget_ip" id="ptarget_ip" class="form-control" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" aria-labelledby="ptarget_ip_label"/>
+					</span>
+				</div>
+
+				<div class="row form-group">
+					<span class="col-xs-6">
+						<input type="checkbox" id="use_auto_pinglimit" onclick="enableAssociatedField(this, 'pinglimit', 85)"/>
+						<label for="use_auto_pinglimit" id="pinglimit_label"><%~ ACC_con %>:</label>
+					</span>
+					<span class="col-xs-6">
+						<input type="text" name="pinglimit" id="pinglimit" class="form-control" onkeyup="proofreadNumericRange(this, 10, 250)" size="4" maxlength="4" aria-labelledby="pinglimit_label"/>
 					</span>
 				</div>
 

--- a/package/gargoyle/files/www/qos_edit_class.sh
+++ b/package/gargoyle/files/www/qos_edit_class.sh
@@ -29,15 +29,19 @@
 				<div><label><%~ BandMin %>:</label></div>
 				<div class="indent">
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" name="min_radio" id="min_radio1"  onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" /></span>
-						<label class="col-xs-11" for="min_radio1"><%~ BandMinNo %></label>
+						<span class="col-xs-12">
+							<input type="radio" name="min_radio" id="min_radio1"  onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" />
+							<label for="min_radio1"><%~ BandMinNo %></label>
+						</span>
 					</div>
 
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" name="min_radio"  id="min_radio2" onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" /></span>
-						<span class="col-xs-11">
+						<span class="col-xs-5">
+							<input type="radio" name="min_radio"  id="min_radio2" onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" />
 							<label id="min_bandwidth_label" for="min_radio2"><%~ BandMin %>:</label>
-							<input type="text" class="form-control" id="min_bandwidth" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" />
+						</span>
+						<span class="col-xs-7">
+							<input type="text" class="form-control" id="min_bandwidth" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10"  aria-labelledby="min_bandwidth_label"/>
 							<em><%~ Kbs %></em>
 						</span>
 					</div>
@@ -47,15 +51,19 @@
 				<div><label><%~ BandMax %>:</label></div>
 				<div class="indent">
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" name="max_radio"  id="max_radio1" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" /></span>
-						<label class="col-xs-11" for="max_radio1"><%~ BandMaxNo %></label>
+						<span class="col-xs-12">
+							<input type="radio" name="max_radio"  id="max_radio1" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" />
+							<label for="max_radio1"><%~ BandMaxNo %></label>
+						</span>
 					</div>
 
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" name="max_radio"  id="max_radio2" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" /></span>
-						<span class="col-xs-11">
+						<span class="col-xs-5">
+							<input type="radio" name="max_radio"  id="max_radio2" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" />
 							<label id="max_bandwidth_label" for="max_radio2"><%~ BandMax %>:</label>
-							<input type="text" class="form-control" id="max_bandwidth" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" />
+						</span>
+						<span class="col-xs-7">
+							<input type="text" class="form-control" id="max_bandwidth" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10"  aria-labelledby="max_bandwidth_label"/>
 							<em><%~ Kbs %></em>
 						</span>
 					</div>
@@ -66,13 +74,17 @@
 					<div><label><%~ MinRTT %>:</label></div>
 					<div class="indent">
 						<div class="row form-group">
-							<span class="col-xs-1"><input type="radio" name="rtt_radio" id="rtt_radio1"/></span>
-							<label class="col-xs-11" for="rtt_radio1"><%~ ActRTT %></label>
+							<span class="col-xs-12">
+								<input type="radio" name="rtt_radio" id="rtt_radio1"/>
+								<label for="rtt_radio1"><%~ ActRTT %></label>
+							</span>
 						</div>
 
 						<div class="row form-group">
-							<span class="col-xs-1"><input type="radio" name="rtt_radio" id="rtt_radio2" /></span>
-							<label class="col-xs-11" for="rtt_radio2"><%~ OptiWAN %></label>
+							<span class="col-xs-12">
+								<input type="radio" name="rtt_radio" id="rtt_radio2" />
+								<label for="rtt_radio2"><%~ OptiWAN %></label>
+							</span>
 						</div>
 					</div>
 				</div>

--- a/package/gargoyle/files/www/qos_edit_rule.sh
+++ b/package/gargoyle/files/www/qos_edit_rule.sh
@@ -19,42 +19,42 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_source_ip" onclick="enableAssociatedField(this,'source_ip', '')" />
-						<label id="source_ip_label" for="source_ip"><%~ SrcIP %>:</label>
+						<label id="source_ip_label" for="use_source_ip"><%~ SrcIP %>:</label>
 					</span>
-					<span class="col-xs-7"><input type="text" id="source_ip" class="form-control" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" /></span>
+					<span class="col-xs-7"><input type="text" id="source_ip" class="form-control" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" aria-labelledby="source_ip_label"/></span>
 				</div>
 
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_source_port" onclick="enableAssociatedField(this,'source_port', '')"/>
-						<label id="source_port_label" for="source_port"><%~ SrcPort %>:</label>
+						<label id="source_port_label" for="use_source_port"><%~ SrcPort %>:</label>
 					</span>
-					<span class="col-xs-7"><input type="text" id="source_port" class="form-control" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" /></span>
+					<span class="col-xs-7"><input type="text" id="source_port" class="form-control" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" aria-labelledby="source_port_label"/></span>
 				</div>
 
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_dest_ip" onclick="enableAssociatedField(this,'dest_ip', '')" />
-						<label id="dest_ip_label" for="dest_ip"><%~ DstIP %>:</label>
+						<label id="dest_ip_label" for="use_dest_ip"><%~ DstIP %>:</label>
 					</span>
-					<span class="col-xs-7"><input type="text" id="dest_ip" class="form-control" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" /></span>
+					<span class="col-xs-7"><input type="text" id="dest_ip" class="form-control" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" aria-labelledby="dest_ip_label"/></span>
 				</div>
 
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_dest_port" onclick="enableAssociatedField(this,'dest_port', '')" />
-						<label id="dest_port_label" for="dest_port"><%~ DstPort %>:</label>
+						<label id="dest_port_label" for="use_dest_port"><%~ DstPort %>:</label>
 					</span>
-					<span class="col-xs-7"><input type="text" id="dest_port" class="form-control" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" /></span>
+					<span class="col-xs-7"><input type="text" id="dest_port" class="form-control" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" aria-labelledby="dest_port_label"/></span>
 				</div>
 
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_max_pktsize" onclick="enableAssociatedField(this,'max_pktsize', '')" />
-						<label id="max_pktsize_label" for="max_pktsize"><%~ MaxPktLen %>:</label>
+						<label id="max_pktsize_label" for="use_max_pktsize"><%~ MaxPktLen %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<input type="text" id="max_pktsize" class="form-control" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" />
+						<input type="text" id="max_pktsize" class="form-control" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" aria-labelledby="max_pktsize_label"/>
 						<em><%~ byt %></em>
 					</span>
 				</div>
@@ -62,10 +62,10 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_min_pktsize" onclick="enableAssociatedField(this,'min_pktsize', '')" />
-						<label id="min_pktsize_label" for="min_pktsize"><%~ MinPktLen %>:</label>
+						<label id="min_pktsize_label" for="use_min_pktsize"><%~ MinPktLen %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<input type="text" id="min_pktsize" class="form-control" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" />
+						<input type="text" id="min_pktsize" class="form-control" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" aria-labelledby="min_pktsize_label"/>
 						<em><%~ byt %></em>
 					</span>
 				</div>
@@ -73,10 +73,10 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_transport_protocol" onclick="enableAssociatedField(this,'transport_protocol', '')" />
-						<label id="transport_protocol_label" for="transport_protocol"><%~ TrProto %>:</label>
+						<label id="transport_protocol_label" for="use_transport_protocol"><%~ TrProto %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<select id="transport_protocol" class="form-control"/>
+						<select id="transport_protocol" class="form-control" aria-labelledby="transport_protocol_label">
 							<option value="TCP">TCP</option>
 							<option value="UDP">UDP</option>
 							<option value="ICMP">ICMP</option>
@@ -88,10 +88,10 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_connbytes_kb" onclick="enableAssociatedField(this,'connbytes_kb', '')" />
-						<label id="connbytes_kb_label" for="connbytes_kb"><%~ Conreach %>:</label>
+						<label id="connbytes_kb_label" for="use_connbytes_kb"><%~ Conreach %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<input type="text" id="connbytes_kb" class="form-control" onkeyup="proofreadNumeric(this)" size="17" maxlength="28" />
+						<input type="text" id="connbytes_kb" class="form-control" onkeyup="proofreadNumeric(this)" size="17" maxlength="28" aria-labelledby="connbytes_kb_label"/>
 						<em><%~ KBy %></em>
 					</span>
 				</div>
@@ -99,10 +99,10 @@
 				<div class="row form-group">
 					<span class="col-xs-5">
 						<input type="checkbox" id="use_app_protocol" onclick="enableAssociatedField(this,'app_protocol', '')" />
-						<label id="app_protocol_label" for="app_protocol"><%~ AppProto %>:</label>
+						<label id="app_protocol_label" for="use_app_protocol"><%~ AppProto %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<select id="app_protocol" class="form-control">
+						<select id="app_protocol" class="form-control" aria-labelledby="app_protocol_label">
 						<%
 						sed -e '/^#/ d' -e "s/\([^ ]* \)\(.*\)/<option value='\1'>\2<\/option>/" /etc/l7-protocols/l7index
 						%>
@@ -116,13 +116,13 @@
 						<label id="comment_rule_label" for="use_comment_rule"><%~ Comment %>:</label>
 					</span>
 					<span class="col-xs-7">
-						<input class="form-control" type="text" id="comment_rule" size="17" maxlength="25" />
+						<input class="form-control" type="text" id="comment_rule" size="17" maxlength="25" aria-labelledby="comment_rule_label"/>
 					</span>
 
 				</div>
 
 				<div class="row form-group">
-					<label class="col-xs-5" id="classification_label" for="class_name" ><%~ SetClass %>:</label>
+					<label class="col-xs-5" id="classification_label" for="classification"><%~ SetClass %>:</label>
 					<span class="col-xs-7"><select id="classification" class="form-control"></select></span>
 				</div>
 			</div>

--- a/package/gargoyle/files/www/qos_upload.sh
+++ b/package/gargoyle/files/www/qos_upload.sh
@@ -35,8 +35,10 @@
 			</div>
 			<div class="panel-body">
 				<div id="qos_enabled_container" class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="qos_enabled" onclick="setQosEnabled()" /></span>
-					<label class="col-xs-11" id="qos_enabled_label" for="qos_enabled"><%~ UEnable %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="qos_enabled" onclick="setQosEnabled()" />
+						<label id="qos_enabled_label" for="qos_enabled"><%~ UEnable %></label>
+					</span>
 				</div>
 
 				<div class="row form-group">
@@ -67,49 +69,49 @@
 					<div class="row form-group">
 						<span class="col-xs-5">
 							<input type="checkbox" id="use_source_ip" onclick="enableAssociatedField(this,'source_ip', '')" />
-							<label id="source_ip_label" for="source_ip"><%~ SrcIP %>:</label>
+							<label id="source_ip_label" for="use_source_ip"><%~ SrcIP %>:</label>
 						</span>
-						<span class="col-xs-7"><input class="form-control" type="text" id="source_ip" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" /></span>
+						<span class="col-xs-7"><input class="form-control" type="text" id="source_ip" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" aria-labelledby="source_ip_label"/></span>
 					</div>
 					<div class="row form-group">
 						<span class="col-xs-5">
 							<input type="checkbox" id="use_source_port" onclick="enableAssociatedField(this,'source_port', '')"/>
-							<label id="source_port_label" for="source_port"><%~ SrcPort %>:</label>
+							<label id="source_port_label" for="use_source_port"><%~ SrcPort %>:</label>
 						</span>
-						<span class="col-xs-7"><input type="text" id="source_port" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" /></span>
+						<span class="col-xs-7"><input type="text" id="source_port" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" aria-labelledby="source_port_label"/></span>
 					</div>
 					<div class="row form-group">
 						<span class="col-xs-5">
 							<input type="checkbox"  id="use_dest_ip" onclick="enableAssociatedField(this,'dest_ip', '')" />
-							<label id="dest_ip_label" for="dest_ip"><%~ DstIP %>:</label>
+							<label id="dest_ip_label" for="use_dest_ip"><%~ DstIP %>:</label>
 						</span>
-						<span class="col-xs-7"><input type="text" id="dest_ip" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" /></span>
+						<span class="col-xs-7"><input type="text" id="dest_ip" onkeyup="proofreadIpRange(this)" size="17" maxlength="31" aria-labelledby="dest_ip_label"/></span>
 					</div>
 					<div class="row form-group">
 						<span class="col-xs-5">
 							<input type="checkbox"  id="use_dest_port" onclick="enableAssociatedField(this,'dest_port', '')"  />
-							<label id="dest_port_label" for="dest_port"><%~ DstPort %>:</label>
+							<label id="dest_port_label" for="use_dest_port"><%~ DstPort %>:</label>
 						</span>
-						<span class="col-xs-7"><input type="text" id="dest_port" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" /></span>
+						<span class="col-xs-7"><input type="text" id="dest_port" onkeyup="proofreadPortOrPortRange(this)" size="17" maxlength="11" aria-labelledby="dest_port_label"/></span>
 					</div>
 
 					<div class="row form-group">
 						<span class="col-xs-5">
 							<input type="checkbox"  id="use_max_pktsize" onclick="enableAssociatedField(this,'max_pktsize', '')"  />
-							<label id="max_pktsize_label" for="max_pktsize"><%~ MaxPktLen %>:</label>
+							<label id="max_pktsize_label" for="use_max_pktsize"><%~ MaxPktLen %>:</label>
 						</span>
 						<span class="col-xs-7">
-							<input type="text" id="max_pktsize" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" />
+							<input type="text" id="max_pktsize" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" aria-labelledby="max_pktsize_label"/>
 							<em><%~ byt %></em>
 						</span>
 					</div>
 					<div class="row form-group">
 						<span class="col-xs-5">
 							<input type="checkbox"  id="use_min_pktsize" onclick="enableAssociatedField(this,'min_pktsize', '')"  />
-							<label id="min_pktsize_label" for="min_pktsize"><%~ MinPktLen %>:</label>
+							<label id="min_pktsize_label" for="use_min_pktsize"><%~ MinPktLen %>:</label>
 						</span>
 						<span class="col-xs-7">
-							<input type="text" id="min_pktsize" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" />
+							<input type="text" id="min_pktsize" onkeyup="proofreadNumericRange(this,1,1500)" size="17" maxlength="4" aria-labelledby="min_pktsize_label"/>
 							<em><%~ byt %></em>
 						</span>
 					</div>
@@ -117,10 +119,10 @@
 					<div class="row form-group">
 						<span class="col-xs-5">
 							<input type="checkbox"  id="use_transport_protocol" onclick="enableAssociatedField(this,'transport_protocol', '')"  />
-							<label id="transport_protocol_label" for="transport_protocol"><%~ TrProto %>:</label>
+							<label id="transport_protocol_label" for="use_transport_protocol"><%~ TrProto %>:</label>
 						</span>
 						<span class="col-xs-7">
-							<select class="rightcolumn" id="transport_protocol"/>
+							<select class="rightcolumn" id="transport_protocol" aria-labelledby="transport_protocol_label">
 								<option value="TCP">TCP</option>
 								<option value="UDP">UDP</option>
 								<option value="ICMP">ICMP</option>
@@ -132,10 +134,10 @@
 					<div class="row form-group">
 						<span class="col-xs-5">
 							<input type="checkbox"  id="use_connbytes_kb" onclick="enableAssociatedField(this,'connbytes_kb', '')"  />
-							<label id="connbytes_kb_label" for="connbytes_kb"><%~ Conreach %>:</label>
+							<label id="connbytes_kb_label" for="use_connbytes_kb"><%~ Conreach %>:</label>
 						</span>
 						<span class="col-xs-7">
-							<input class="rightcolumn" type="text" id="connbytes_kb" onkeyup="proofreadNumericRange(this,0,4194303)" size="17" maxlength="28" />
+							<input class="rightcolumn" type="text" id="connbytes_kb" onkeyup="proofreadNumericRange(this,0,4194303)" size="17" maxlength="28" aria-labelledby="connbytes_kb_label"/>
 							<em><%~ KBy %></em>
 						</span>
 					</div>
@@ -143,10 +145,10 @@
 					<div class="row form-group">
 						<span class="col-xs-5">
 							<input type="checkbox"  id="use_app_protocol" onclick="enableAssociatedField(this,'app_protocol', '')" />
-							<label id="app_protocol_label" for="app_protocol"><%~ AppProto %>:</label>
+							<label id="app_protocol_label" for="use_app_protocol"><%~ AppProto %>:</label>
 						</span>
 						<span class="col-xs-7">
-							<select class="rightcolumn" id="app_protocol">
+							<select class="rightcolumn" id="app_protocol" aria-labelledby="app_protocol_label">
 							<%
 							sed -e "s/#.*//" -e "s/\([^ ]* \)\(.*\)/<option value='\1'>\2<\/option>/" /etc/l7-protocols/l7index
 							%>
@@ -160,7 +162,7 @@
 							<label id="comment_rule_label" for="use_comment_rule"><%~ Comment %>:</label>
 						</span>
 						<span class="col-xs-7">
-							<input class="form-control" type="text" id="comment_rule" size="17" maxlength="25" />
+							<input class="form-control" type="text" id="comment_rule" size="17" maxlength="25" aria-labelledby="comment_rule_label"/>
 						</span>
 					</div>
 
@@ -229,14 +231,18 @@
 					<div><%~ BandMin %>:</div>
 					<div class="indent">
 						<div class="row form-group">
-							<span class="col-xs-1"><input type="radio" name="min_radio" id="min_radio1" onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" /></span>
-							<label class="col-xs-11" for="min_radio1"><%~ BandMinNo %></label>
+							<span class="col-xs-12">
+								<input type="radio" name="min_radio" id="min_radio1" onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" />
+								<label for="min_radio1"><%~ BandMinNo %></label>
+							</span>
 						</div>
 						<div class="row form-group">
-							<span class="col-xs-1"><input type="radio" name="min_radio" id="min_radio2" onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" /></span>
-							<span class="col-xs-11">
+							<span class="col-xs-5">
+								<input type="radio" name="min_radio" id="min_radio2" onclick="enableAssociatedField(document.getElementById('min_radio2'),'min_bandwidth', '')" />
 								<label id="min_bandwidth_label" for="min_radio2"><%~ BandMin %>:</label>
-								<input type="text" class="rightcolumn" id="min_bandwidth" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" />
+							</span>
+							<span class="col-xs-7">
+								<input type="text" class="form-control" id="min_bandwidth" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" aria-labelledby="min_bandwidth_label"/>
 								<em><%~ Kbs %></em>
 							</span>
 						</div>
@@ -245,14 +251,18 @@
 					<div><%~ BandMax %>:</div>
 					<div class="indent">
 						<div class="row form-group">
-							<span class="col-xs-1"><input type="radio" name="max_radio" id="max_radio1" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" /></span>
-							<label class="col-xs-11" for="max_radio1"><%~ BandMaxNo %></label>
+							<span class="col-xs-12">
+								<input type="radio" name="max_radio" id="max_radio1" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" />
+								<label for="max_radio1"><%~ BandMaxNo %></label>
+							</span>
 						</div>
 						<div class="row form-group">
-							<span class="col-xs-1"><input type="radio" name="max_radio" id="max_radio2" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" /></span>
-							<span class="col-xs-11">
+							<span class="col-xs-5">
+								<input type="radio" name="max_radio" id="max_radio2" onclick="enableAssociatedField(document.getElementById('max_radio2'),'max_bandwidth', '')" />
 								<label id="max_bandwidth_label" for="max_radio2"><%~ BandMax %>:</label>
-								<input type="text" class="rightcolumn" id="max_bandwidth" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" />
+							</span>
+							<span class="col-xs-7">
+								<input type="text" class="form-control" id="max_bandwidth" onkeyup="proofreadNumeric(this)"  size="10" maxlength="10" aria-labelledby="max_bandwidth_label"/>
 								<em><%~ Kbs %></em>
 							</span>
 						</div>

--- a/package/gargoyle/files/www/themes/Gargoyle/internal.css
+++ b/package/gargoyle/files/www/themes/Gargoyle/internal.css
@@ -380,6 +380,22 @@ select.select_disabled
 {
 	color: #aaa
 }
+input[type="radio"],
+input[type="checkbox"]
+{
+	vertical-align: text-bottom;
+}
+input[type="radio"] + label,
+input[type="checkbox"] + label
+{
+	vertical-align: initial !important;
+	display: inline;
+}
+input[type="radio"]:enabled + label:hover,
+input[type="checkbox"]:enabled + label:hover
+{
+	cursor: pointer;
+}
 #bottom_button_container
 {
 	margin-top: 10px;

--- a/package/gargoyle/files/www/webmon.sh
+++ b/package/gargoyle/files/www/webmon.sh
@@ -33,8 +33,10 @@
 
 			<div class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-1"><input type="checkbox" id="webmon_enabled" class="" onclick="setWebmonEnabled()" /></span>
-					<label class="col-xs-11" id="webmon_enabled_label" for="webmon_enabled"><%~ EMon %></label>
+					<span class="col-xs-12">
+						<input type="checkbox" id="webmon_enabled" onclick="setWebmonEnabled()" />
+						<label id="webmon_enabled_label" for="webmon_enabled"><%~ EMon %></label>
+					</span>
 				</div>
 
 				<div>

--- a/package/plugin-gargoyle-adblock/files/www/ablock.sh
+++ b/package/plugin-gargoyle-adblock/files/www/ablock.sh
@@ -26,8 +26,10 @@
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-1"><input id="adblock_enable" type="checkbox" /></span>
-					<label class="col-xs-11" id="adblock_enable_label" for="adblock_enable"><%~ ADBLOCKEn %></label>
+					<span class="col-xs-12">
+						<input id="adblock_enable" type="checkbox" />
+						<label id="adblock_enable_label" for="adblock_enable"><%~ ADBLOCKEn %></label>
+					</span>
 				</div>
 
 				<div class="row form-group">
@@ -39,8 +41,10 @@
 				</div>
 
 				<div class="row form-group">
-					<label id="adblock_transparent_label" class="col-xs-5" for="adblock_transparent"><%~ ADBLOCKTrans %>:</label>
-					<span class="col-xs-7"><input id="adblock_transparent" type="checkbox" /></span>
+					<span class="col-xs-12">
+						<input id="adblock_transparent" type="checkbox" />
+						<label id="adblock_transparent_label" for="adblock_transparent"><%~ ADBLOCKTrans %></label>
+					</span>
 				</div>
 
 				<div id="adblock_help" class="row">
@@ -53,8 +57,10 @@
 				<div class="internal_divider"></div>
 
 				<div class="row form-group">
-					<label class="col-xs-5" id="adblock_exempten_label" for="adblock_exempten"><%~ ADBLOCKExemptEn %>:</label>
-					<span class="col-xs-7"><input id="adblock_exempten" type="checkbox" /></span>
+					<span class="col-xs-12">
+						<input id="adblock_exempten" type="checkbox" />
+						<label id="adblock_exempten_label" for="adblock_exempten"><%~ ADBLOCKExemptEn %>:</label>
+					</span>
 				</div>
 
 				<div class="form-group">

--- a/package/plugin-gargoyle-minidlna/files/www/minidlna.sh
+++ b/package/plugin-gargoyle-minidlna/files/www/minidlna.sh
@@ -26,8 +26,10 @@
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-1"><input id="dlna_enable" type="checkbox" /></span>
-					<label class="col-xs-11" id="dlna_enable_label" for="dlna_enable"><%~ DLNAEn %></label>
+					<span class="col-xs-12">
+						<input id="dlna_enable" type="checkbox" />
+						<label id="dlna_enable_label" for="dlna_enable"><%~ DLNAEn %></label>
+					</span>
 				</div>
 
 				<div class="row form-group">
@@ -43,8 +45,10 @@
 				</div>
 
 				<div class="row form-group">
-					<span class="col-xs-1"><input id="dlna_strict" type="checkbox" /></span>
-					<label class="col-xs-11" id="dlna_strict_label" for="dlna_strict"><%~ DLNAStr %>:</label>
+					<span class="col-xs-12">
+						<input id="dlna_strict" type="checkbox" />
+						<label id="dlna_strict_label" for="dlna_strict"><%~ DLNAStr %></label>
+					</span>
 				</div>
 
 				<div class="internal_divider"></div>

--- a/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
+++ b/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
@@ -250,8 +250,10 @@
 						</div>
 						<div id="openvpn_client_ta_key_file_container">
 							<div class="row form-group">
-								<span class="col-xs-1"><input type='checkbox' id='openvpn_client_use_ta_key_file' name='use_ta_key_file' onclick='enableAssociatedField(this, "openvpn_client_ta_key_file", "")' /></span>
-								<label class="col-xs-11" id='openvpn_client_use_ta_key_file_label' for='openvpn_client_use_ta_key_file'><%~ UseTAK %></label>
+								<span class="col-xs-12">
+									<input type='checkbox' id='openvpn_client_use_ta_key_file' name='use_ta_key_file' onclick='enableAssociatedField(this, "openvpn_client_ta_key_file", "")' />
+									<label id='openvpn_client_use_ta_key_file_label' for='openvpn_client_use_ta_key_file'><%~ UseTAK %></label>
+								</span>
 							</div>
 							<div class="row form-group">
 								<label class="col-xs-5" id="openvpn_client_ta_key_file_label" for="openvpn_client_use_ta_key_file"><%~ TAKeyF %>:</label>
@@ -337,8 +339,10 @@
 
 						<div id="openvpn_client_ta_key_text_container">
 							<div class="row form-group">
-								<span class="col-xs-1"><input type='checkbox' id='openvpn_client_use_ta_key_text' name='use_ta_key_text' onclick='enableAssociatedField(this, "openvpn_client_ta_key_text", "");enableAssociatedField(this, "openvpn_client_ta_direction", "1");updateClientConfigTextFromControls()' /></span>
-								<label class="col-xs-11" id='openvpn_client_use_ta_key_text_label' for='openvpn_client_use_ta_key_text'><%~ UseTAK %></label>
+								<span class="col-xs-12">
+									<input type='checkbox' id='openvpn_client_use_ta_key_text' name='use_ta_key_text' onclick='enableAssociatedField(this, "openvpn_client_ta_key_text", "");enableAssociatedField(this, "openvpn_client_ta_direction", "1");updateClientConfigTextFromControls()' />
+									<label id='openvpn_client_use_ta_key_text_label' for='openvpn_client_use_ta_key_text'><%~ UseTAK %></label>
+								</span>
 							</div>
 							<div class="row form-group">
 								<label class="col-xs-5" for="openvpn_client_ta_direction"><%~ TADir %>:</label>

--- a/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
+++ b/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
@@ -208,12 +208,16 @@
 			<div class="panel-body">
 				<form id='openvpn_client_form' enctype="multipart/form-data" method="post" action="utility/openvpn_upload_client.sh" target="client_add_target">
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" id="openvpn_client_config_upload" name="client_config_mode" onclick="setClientVisibility(document)" /></span>
-						<label class="col-xs-11" for="openvpn_client_config_upload"><%~ UpCfgF %></label>
+						<span class="col-xs-12">
+							<input type="radio" id="openvpn_client_config_upload" name="client_config_mode" onclick="setClientVisibility(document)" />
+							<label for="openvpn_client_config_upload"><%~ UpCfgF %></label>
+						</span>
 					</div>
 					<div class="row form-group">
-						<span class="col-xs-1"><input type="radio" id="openvpn_client_config_manual" name="client_config_mode" onclick="setClientVisibility(document)" /></span>
-						<label class="col-xs-11" for="openvpn_client_config_manual"><%~ CfgMan %></label>
+						<span class="col-xs-12">
+							<input type="radio" id="openvpn_client_config_manual" name="client_config_mode" onclick="setClientVisibility(document)" />
+							<label for="openvpn_client_config_manual"><%~ CfgMan %></label>
+						</span>
 					</div>
 
 					<div id="openvpn_client_file_controls">

--- a/package/plugin-gargoyle-openvpn/files/www/templates/openvpn_allowed_client_template
+++ b/package/plugin-gargoyle-openvpn/files/www/templates/openvpn_allowed_client_template
@@ -41,8 +41,10 @@
 	<span style="clear:both"></span>
 </div>
 <div id="openvpn_allowed_client_prefer_vpngateway_container" class="row form-group" >
-	<label class="col-xs-5" id='openvpn_allowed_client_prefer_vpngateway_label' for='openvpn_allowed_client_prefer_vpngateway'><%~ PrefVPNGtwy %>:</label>
-	<span class="col-xs-7"><input type="checkbox" id="openvpn_allowed_client_prefer_vpngateway"></span>
+	<span class="col-xs-12">
+		<input type="checkbox" id="openvpn_allowed_client_prefer_vpngateway">
+		<label id='openvpn_allowed_client_prefer_vpngateway_label' for='openvpn_allowed_client_prefer_vpngateway'><%~ PrefVPNGtwy %></label>
+	</span>
 </div>
 
 <input class="form-control" style="display:none" id="openvpn_allowed_client_initial_id" />

--- a/package/plugin-gargoyle-ping-watchdog/files/www/ping_watchdog.sh
+++ b/package/plugin-gargoyle-ping-watchdog/files/www/ping_watchdog.sh
@@ -15,8 +15,10 @@
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-1"><input type='checkbox' id='ping_watchdog_enable' onchange="unlockFields();"/></span>
-					<label class="col-xs-11" for='ping_watchdog_enable' id='ping_watchdog_enable_label'><%~ EnbP %></label>
+					<span class="col-xs-12">
+						<input type='checkbox' id='ping_watchdog_enable' onchange="unlockFields();"/>
+						<label for='ping_watchdog_enable' id='ping_watchdog_enable_label'><%~ EnbP %></label>
+					</span>
 				</div>
 
 				<div class="row form-group">

--- a/package/plugin-gargoyle-webcam/files/www/webcam.sh
+++ b/package/plugin-gargoyle-webcam/files/www/webcam.sh
@@ -50,13 +50,17 @@ var webcams = [];
 
 			<div class="panel-body">
 				<div class="row form-group">
-					<span class="col-xs-1"><input id="webcam_enable" type="checkbox" onchange='updateWebcamWanAccess()'/></span>
-					<label class="col-xs-11" id="webcam_enable_label" for="webcam_enable"><%~ EnWebC %></label>
+					<span class="col-xs-12">
+						<input id="webcam_enable" type="checkbox" onchange='updateWebcamWanAccess()'/>
+						<label id="webcam_enable_label" for="webcam_enable"><%~ EnWebC %></label>
+					</span>
 				</div>
 
 				<div class="row form-group">
-					<label class="col-xs-5" id="webcam_wan_access_label" for="webcam_wan_access"><%~ EnRAWebC %>:</label>
-					<span class="col-xs-7"><input id="webcam_wan_access" type="checkbox"/></span>
+					<span class="col-xs-12">
+						<input id="webcam_wan_access" type="checkbox"/>
+						<label id="webcam_wan_access_label" for="webcam_wan_access"><%~ EnRAWebC %>:</label>
+					</span>
 				</div>
 
 				<div class="row form-group">
@@ -75,8 +79,10 @@ var webcams = [];
 				</div>
 
 				<div class="row form-group">
-					<label class="col-xs-5" id="webcam_yuv_label" for="webcam_yuv"><%~ WebCYUYV %>:</label>
-					<span class="col-xs-7"><input id="webcam_yuv" type="checkbox"/></span>
+					<span class="col-xs-12">
+						<input id="webcam_yuv" type="checkbox"/>
+						<label id="webcam_yuv_label" for="webcam_yuv"><%~ WebCYUYV %>:</label>
+					</span>
 				</div>
 
 				<div class="row form-group">


### PR DESCRIPTION
## Changelog
- Remove the gap between these elements for better readability/scan and improved user interaction
- Rearrange checkbox/label order on some pages for consistency throughout the system
- Fix checkbox/label vertical alignment and label word wrap on mobile view (see last screenshot below)
- Minor HTML formatting fixes

## Screenshots
| Before  | After |
| ------------- | ------------- |
|![b8a2d31c-2ab7-4481-961a-810b6e2d0fd5](https://user-images.githubusercontent.com/22578839/34920209-23eff2f2-f956-11e7-97fc-129b5750a038.png)				|![3544459d-31c3-45c2-99c6-315e75a9302b](https://user-images.githubusercontent.com/22578839/34920208-23cded92-f956-11e7-8771-68be0f4c3fa3.png)				|
|![f5671e8f-c310-4d17-a6c9-f760f6b5c5b4](https://user-images.githubusercontent.com/22578839/34920246-db5cde8c-f956-11e7-8869-6f12cfae1089.png)				|![9d5de2b7-a580-44e2-8253-e540db1a7117](https://user-images.githubusercontent.com/22578839/34920245-db3e080e-f956-11e7-8177-e1222d780211.png) 				|
|![0caecbcb-6ed4-45ba-82ac-81363305b0f4](https://user-images.githubusercontent.com/22578839/34920583-009d357a-f95c-11e7-9b31-1af18224445e.png)				|![3ff99487-d9c7-4944-84f4-0f36996cc0ee](https://user-images.githubusercontent.com/22578839/34920582-007d686c-f95c-11e7-9c73-c30f295154b6.png)				|
|![16de6ea4-5ece-4bc1-9e0a-34f8e87b61b0](https://user-images.githubusercontent.com/22578839/34920399-3e97fbec-f959-11e7-8066-a50fe8abaeba.png)				|![b1e67c63-5aa2-4f74-989b-07c10d127eb9](https://user-images.githubusercontent.com/22578839/34920398-3e781296-f959-11e7-86d6-672b045522c6.png)				|
