### PR TITLE
Fix popup window centering on edit pages

### DIFF
--- a/package/gargoyle/files/www/js/bandwidth.js
+++ b/package/gargoyle/files/www/js/bandwidth.js
@@ -864,17 +864,7 @@ function expand(name)
 		expWindow = null;
 	}
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-	expWindow= window.open("bandwidth_expand.sh", name + " "+bndwS.BPlot, "width=850,height=650,left=" + xCoor + ",top=" + yCoor );
+	expWindow = openPopupWindow("bandwidth_expand.sh", name + " " + bndwS.BPlot, 730, 630);
 	expandedWindows[name] = expWindow;
 
 	var runOnWindowLoad = function(name)

--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -2427,18 +2427,7 @@ function confirmPassword(confirmText, validatedFunc, invalidFunc)
 		}
 		catch(e){}
 	}
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-	var wlocation = "password_confirm.sh";
-	confirmWindow = window.open(wlocation, "password", "width=560,height=260,left=" + xCoor + ",top=" + yCoor );
+	confirmWindow = openPopupWindow("password_confirm.sh", "password", 560, 260);
 
 	var okButton = createInput("button", confirmWindow.document);
 	var cancelButton = createInput("button", confirmWindow.document);
@@ -2489,7 +2478,6 @@ function confirmPassword(confirmText, validatedFunc, invalidFunc)
 					runAjax("POST", "utility/run_commands.sh", param, stateChangeFunction);
 
 				}
-				confirmWindow.moveTo(xCoor,yCoor);
 				confirmWindow.focus();
 				updateDone = true;
 			}
@@ -2980,3 +2968,10 @@ function sidebar()
 	}
 }
 
+function openPopupWindow(url, name, width, height)
+{
+	var xCoor = (window.outerWidth - width)/2;
+	var yCoor = (window.outerHeight - height)/2;
+
+	return window.open(url, name, "width=" + width + ",height=" + height + ",left=" + xCoor + ",top=" + yCoor);
+}

--- a/package/gargoyle/files/www/js/ddns.js
+++ b/package/gargoyle/files/www/js/ddns.js
@@ -851,21 +851,8 @@ function editServiceTableRow()
 		catch(e){}
 	}
 
-	var xCoor;
-	var yCoor;
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
 	//editServiceWindow is global so we can close it above if it is left open
-	editServiceWindow = window.open("ddns_edit_service.sh", "edit", "width=560,height=510,left=" + xCoor + ",top=" + yCoor );
+	editServiceWindow = openPopupWindow("ddns_edit_service.sh", "edit", 560, 510);
 
 	var saveButton = createInput("button", editServiceWindow.document);
 	var closeButton = createInput("button", editServiceWindow.document);
@@ -942,7 +929,6 @@ function editServiceTableRow()
 					}
 				}
 
-				editServiceWindow.moveTo(xCoor,yCoor);
 				editServiceWindow.focus();
 				update_done = true;
 			}

--- a/package/gargoyle/files/www/js/dhcp.js
+++ b/package/gargoyle/files/www/js/dhcp.js
@@ -392,18 +392,7 @@ function editStatic()
 		catch(e){}
 	}
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
-	editStaticWindow = window.open("static_ip_edit.sh", "edit", "width=560,height=220,left=" + xCoor + ",top=" + yCoor );
+	editStaticWindow = openPopupWindow("static_ip_edit.sh", "edit", 560, 220);
 
 	saveButton = createInput("button", editStaticWindow.document);
 	closeButton = createInput("button", editStaticWindow.document);
@@ -454,7 +443,6 @@ function editStatic()
 
 					}
 				}
-				editStaticWindow.moveTo(xCoor,yCoor);
 				editStaticWindow.focus();
 				updateDone = true;
 			}

--- a/package/gargoyle/files/www/js/port_forwarding.js
+++ b/package/gargoyle/files/www/js/port_forwarding.js
@@ -636,20 +636,8 @@ function editForward(isSingle, triggerElement)
 	}
 
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
-
 	var editLocation = isSingle ? "single_forward_edit.sh" : "multi_forward_edit.sh";
-	editForwardWindow = window.open(editLocation, "edit", "width=560,height=220,left=" + xCoor + ",top=" + yCoor );
+	editForwardWindow = openPopupWindow(editLocation, "edit", 560, 220);
 
 	saveButton = createInput("button", editForwardWindow.document);
 	closeButton = createInput("button", editForwardWindow.document);
@@ -729,7 +717,6 @@ function editForward(isSingle, triggerElement)
 						editForwardWindow.close();
 					}
 				}
-				editForwardWindow.moveTo(xCoor,yCoor);
 				editForwardWindow.focus();
 				updateDone = true;
 			}

--- a/package/gargoyle/files/www/js/qos.js
+++ b/package/gargoyle/files/www/js/qos.js
@@ -869,19 +869,8 @@ function editRuleTableRow()
 	}
 
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
+	editRuleWindow = openPopupWindow("qos_edit_rule.sh", "test", 560, 530);
 
-
-	editRuleWindow = window.open("qos_edit_rule.sh", "test", "width=560,height=530,left=" + xCoor + ",top=" + yCoor );
 	try
 	{
 
@@ -1013,7 +1002,6 @@ function editRuleTableRow()
 						editRuleWindow.close();
 					}
 				}
-				editRuleWindow.moveTo(xCoor,yCoor);
 				editRuleWindow.focus();
 				update_done = true;
 			}
@@ -1088,19 +1076,7 @@ function editClassTableRow()
 	}
 
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
-
-	editClassWindow = window.open("qos_edit_class.sh", "test", "width=560,height=500,left=" + xCoor + ",top=" + yCoor );
+	editClassWindow = openPopupWindow("qos_edit_class.sh", "test", 560, 500);
 	try
 	{
 		saveButton = editClassWindow.document.createElement('input');
@@ -1257,7 +1233,6 @@ function editClassTableRow()
 					}
 				}
 
-				editClassWindow.moveTo(xCoor,yCoor);
 				editClassWindow.focus();
 				update_done = true;
 			}

--- a/package/gargoyle/files/www/js/quotas.js
+++ b/package/gargoyle/files/www/js/quotas.js
@@ -1154,19 +1154,7 @@ function editQuota()
 	}
 
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
-
-	editQuotaWindow = window.open("quotas_edit.sh", "edit", "width=560,height=600,left=" + xCoor + ",top=" + yCoor );
+	editQuotaWindow = openPopupWindow("quotas_edit.sh", "edit", 560, 600);
 
 	var saveButton = createInput("button", editQuotaWindow.document);
 	var closeButton = createInput("button", editQuotaWindow.document);
@@ -1249,7 +1237,6 @@ function editQuota()
 						editQuotaWindow.close();
 					}
 				}
-				editQuotaWindow.moveTo(xCoor,yCoor);
 				editQuotaWindow.focus();
 				updateDone = true;
 

--- a/package/gargoyle/files/www/js/restrictions.js
+++ b/package/gargoyle/files/www/js/restrictions.js
@@ -305,19 +305,8 @@ function editRule()
 	}
 
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
-
-	editRuleWindow = window.open(editRuleType == "restriction_rule" ? "restriction_edit_rule.sh" : "whitelist_edit_rule.sh", "edit", "width=560,height=600,left=" + xCoor + ",top=" + yCoor );
+	editRuleType = editRuleType == "restriction_rule" ? "restriction_edit_rule.sh" : "whitelist_edit_rule.sh";
+	editRuleWindow = openPopupWindow(editRuleType, "edit", 560, 600);
 
 	saveButton = createInput("button", editRuleWindow.document);
 	closeButton = createInput("button", editRuleWindow.document);
@@ -364,7 +353,6 @@ function editRule()
 					}
 
 				}
-				editRuleWindow.moveTo(xCoor,yCoor);
 				editRuleWindow.focus();
 				updateDone = true;
 

--- a/package/gargoyle/files/www/js/routing.js
+++ b/package/gargoyle/files/www/js/routing.js
@@ -266,19 +266,7 @@ function editStaticRoute()
 	}
 
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
-
-	editStaticWindow = window.open("static_route_edit.sh", "edit", "width=560,height=180,left=" + xCoor + ",top=" + yCoor );
+	editStaticWindow = openPopupWindow("static_route_edit.sh", "edit", 560, 180);
 
 	saveButton = createInput("button", editStaticWindow.document);
 	closeButton = createInput("button", editStaticWindow.document);
@@ -335,7 +323,6 @@ function editStaticRoute()
 						editStaticWindow.close();
 					}
 				}
-				editStaticWindow.moveTo(xCoor,yCoor);
 				editStaticWindow.focus();
 				updateDone = true;
 			}

--- a/package/plugin-gargoyle-openvpn/files/www/js/openvpn.js
+++ b/package/plugin-gargoyle-openvpn/files/www/js/openvpn.js
@@ -1293,19 +1293,7 @@ function editAc()
 	}
 
 	
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
-
-	editAcWindow = window.open("openvpn_allowed_client_edit.sh", "edit", "width=560,height=600,left=" + xCoor + ",top=" + yCoor );
+	editAcWindow = openPopupWindow("openvpn_allowed_client_edit.sh", "edit", 560, 600);
 	
 	var saveButton = createInput("button", editAcWindow.document);
 	var closeButton = createInput("button", editAcWindow.document);
@@ -1399,7 +1387,6 @@ function editAc()
 						editAcWindow.close();
 					}
 				}
-				editAcWindow.moveTo(xCoor,yCoor);
 				editAcWindow.focus();
 				updateDone = true;
 				

--- a/package/plugin-gargoyle-usb-storage/files/www/js/usb_storage.js
+++ b/package/plugin-gargoyle-usb-storage/files/www/js/usb_storage.js
@@ -463,19 +463,7 @@ function editUser()
 	}
 
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
-
-	editUserWindow = window.open("share_user_edit.sh", "edit", "width=560,height=230,left=" + xCoor + ",top=" + yCoor );
+	editUserWindow = openPopupWindow("share_user_edit.sh", "edit", 560, 230);
 	var okButton = createInput("button", editUserWindow.document);
 	var cancelButton = createInput("button", editUserWindow.document);
 
@@ -530,7 +518,6 @@ function editUser()
 						editUserWindow.close();
 					}
 				}
-				editUserWindow.moveTo(xCoor,yCoor);
 				editUserWindow.focus();
 				updateDone = true;
 			}
@@ -1268,19 +1255,7 @@ function editShare()
 	}
 
 
-	try
-	{
-		xCoor = window.screenX + 225;
-		yCoor = window.screenY+ 225;
-	}
-	catch(e)
-	{
-		xCoor = window.left + 225;
-		yCoor = window.top + 225;
-	}
-
-
-	editShareWindow = window.open("usb_storage_edit.sh", "edit", "width=650,height=600,left=" + xCoor + ",top=" + yCoor );
+	editShareWindow = openPopupWindow("usb_storage_edit.sh", "edit", 650, 600);
 
 	var saveButton = createInput("button", editShareWindow.document);
 	var closeButton = createInput("button", editShareWindow.document);
@@ -1358,7 +1333,6 @@ function editShare()
 						editShareWindow.close();
 					}
 				}
-				editShareWindow.moveTo(xCoor,yCoor);
 				editShareWindow.focus();
 			}
 		}


### PR DESCRIPTION
An attempt to fix edit popup pages centering by making use of the `window` properties described below and some minor code changes: 

>Window.outerWidth/outerHeight gets the width/height of the outside of the browser window. It represents the width/height of the whole browser window including sidebar (if expanded), window chrome and window resizing borders/handles.

Browser compatibility should not be a problem. Although, Microsoft Edge seems to do it's own thing when it comes to window positioning, which is a known issue apparently. Works fine with every other browser I tested it with (Chromium based, Firefox, etc).

## Screenshots (Before/After)
![offcenter](https://user-images.githubusercontent.com/22578839/35712996-26361a6e-07ac-11e8-8d64-4cbc957e7741.png)
![centered](https://user-images.githubusercontent.com/22578839/35712997-265117ba-07ac-11e8-986b-2ebeb103584e.png)
![offcenter2](https://user-images.githubusercontent.com/22578839/35712995-261b8c94-07ac-11e8-9401-c6a10aa4ef9a.png)
![centered2](https://user-images.githubusercontent.com/22578839/35712994-25fd031e-07ac-11e8-94e3-bfe48f26478e.png)