### PR TITLE
Improve button element styling flexibility on tables

### DIFF
--- a/package/gargoyle-i18n/files/www/js/i18n.js
+++ b/package/gargoyle-i18n/files/www/js/i18n.js
@@ -83,8 +83,8 @@ function createInstallButton(type)
 	if (type == 1)
 	{
 		inButton.style.marginLeft = "0px";
-		inButton.value = UI.Install;
-		inButton.className="btn btn-default";
+		inButton.textContent = UI.Install;
+		inButton.className = "btn btn-default btn-install";
 		inButton.onclick = installLang;
 	}
 	else

--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -689,14 +689,30 @@ function setChildText(parentId, text, color, isBold, fontSize, controlDocument)
 function createInput(type, controlDocument)
 {
 	controlDocument = controlDocument == null ? document : controlDocument;
-	try
+
+	if(type == "button")
 	{
-		inp = controlDocument.createElement('input');
-		inp.type = type;
+		try
+		{
+			inp = controlDocument.createElement('button');
+			inp.type = type;
+		}
+		catch(e)
+		{
+			inp = controlDocument.createElement('<button type="button"></button>');
+		}
 	}
-	catch(e)
+	else
 	{
-		inp = controlDocument.createElement('<input type="' + type + '" />');
+		try
+		{
+			inp = controlDocument.createElement('input');
+			inp.type = type;
+		}
+		catch(e)
+		{
+			inp = controlDocument.createElement('<input type="' + type + '" />');
+		}
 	}
 	return inp;
 }

--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -1009,8 +1009,7 @@ function setElementEnabled(element, enabled, defaultValue)
 		}
 		else if(element.type == "button")
 		{
-			var activeClassName = element.className.replace(/_button.*$/, "_button");
-			element.className=activeClassName;
+			element.classList.remove("disabled");
 		}
 	}
 	else
@@ -1029,8 +1028,7 @@ function setElementEnabled(element, enabled, defaultValue)
 		}
 		else if(element.type == "button")
 		{
-			var activeClassName = element.className.replace(/_button.*$/, "_button");
-			element.className= activeClassName + " disabled";
+			element.classList.add("disabled");
 		}
 		else if(element.type == "file")
 		{

--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -2446,10 +2446,10 @@ function confirmPassword(confirmText, validatedFunc, invalidFunc)
 	var okButton = createInput("button", confirmWindow.document);
 	var cancelButton = createInput("button", confirmWindow.document);
 
-	okButton.value         = UI.OK;
-	okButton.className     = "btn btn-default";
-	cancelButton.value     = UI.Cancel;
-	cancelButton.className = "btn btn-default";
+	okButton.textContent   = UI.OK;
+	okButton.className     = "btn btn-primary";
+	cancelButton.textContent = UI.Cancel;
+	cancelButton.className = "btn btn-warning";
 
 
 	runOnEditorLoaded = function ()
@@ -2775,7 +2775,7 @@ function query(queryHeader, queryText, buttonNameList, continueFunction )
 	for(bIndex=0; bIndex < buttonNameList.length ; bIndex++)
 	{
 		b           = createInput("button", document);
-		b.value     = buttonNameList[bIndex];
+		b.textContent = buttonNameList[bIndex];
 		b.className = "btn btn-default"
 		b.onclick   = function()
 		{

--- a/package/gargoyle/files/www/js/ddns.js
+++ b/package/gargoyle/files/www/js/ddns.js
@@ -217,8 +217,8 @@ function resetData()
 		enabledCheckbox.id = section;
 		ddnsTableData.push( [domain, lastUpdate, enabledCheckbox, createEditButton(), createForceUpdateButton()]);
 
-		ddnsTableData[ ddnsTableData.length-1][4].disabled = enabledCheckbox.checked ? false : true;
-		ddnsTableData[ ddnsTableData.length-1][4].className = enabledCheckbox.checked ? "btn btn-default" : "btn btn-default disabled" ;
+		var row = ddnsTableData[ddnsTableData.length-1][4];
+		setElementEnabled(row, enabledCheckbox.checked);
 		ddnsEnabledData.push(enabledCheckbox.checked);
  	}
 	var ddnsTable=createTable(columnNames, ddnsTableData, "ddns_table", true, false, removeServiceProviderCallback);
@@ -714,8 +714,8 @@ function setRowEnabled()
 	var enabledRow=this.parentNode.parentNode;
 	var enabledDomain = enabledRow.firstChild.firstChild.data;
 
-	enabledRow.childNodes[4].firstChild.disabled   = this.checked ? false : true;
-	enabledRow.childNodes[4].firstChild.className = this.checked ? "btn btn-default" : "btn btn-default disabled" ;
+	var row = enabledRow.childNodes[4].firstChild;
+	setElementEnabled(row, enabled);
 
 	var section = enabledRow.childNodes[2].firstChild.id;
 	uci.set("ddns_gargoyle", section, "enabled", enabled);

--- a/package/gargoyle/files/www/js/ddns.js
+++ b/package/gargoyle/files/www/js/ddns.js
@@ -693,8 +693,8 @@ function createEnabledCheckbox()
 function createEditButton()
 {
 	editButton = createInput("button");
-	editButton.value = UI.Edit;
-	editButton.className="btn btn-default";
+	editButton.textContent = UI.Edit;
+	editButton.className = "btn btn-default btn-edit";
 	editButton.onclick = editServiceTableRow;
 	return editButton;
 }
@@ -702,8 +702,8 @@ function createEditButton()
 function createForceUpdateButton()
 {
 	updateButton = createInput("button");
-	updateButton.value = DyDNS.ForceU;
-	updateButton.className="btn btn-default";
+	updateButton.textContent = DyDNS.ForceU;
+	updateButton.className = "btn btn-default btn-update";
 	updateButton.onclick = forceUpdateForRow;
 	return updateButton;
 }
@@ -856,9 +856,9 @@ function editServiceTableRow()
 
 	var saveButton = createInput("button", editServiceWindow.document);
 	var closeButton = createInput("button", editServiceWindow.document);
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default";
-	closeButton.value = UI.CDiscardChanges;
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
 	closeButton.className = "btn btn-warning";
 
 	//load provider data for this row

--- a/package/gargoyle/files/www/js/dhcp.js
+++ b/package/gargoyle/files/www/js/dhcp.js
@@ -122,8 +122,8 @@ function saveChanges()
 function createEditButton()
 {
 	var editButton = createInput("button");
-	editButton.value = UI.Edit;
-	editButton.className="btn btn-default";
+	editButton.textContent = UI.Edit;
+	editButton.className = "btn btn-default btn-edit";
 	editButton.onclick = editStatic;
 	return editButton;
 }
@@ -396,9 +396,9 @@ function editStatic()
 
 	saveButton = createInput("button", editStaticWindow.document);
 	closeButton = createInput("button", editStaticWindow.document);
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default";
-	closeButton.value = UI.CDiscardChanges;
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
 	closeButton.className = "btn btn-warning";
 
 	editRow=this.parentNode.parentNode;

--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -343,8 +343,7 @@ function resetData()
 				button.value = UI.Uninstall;
 				if( pkgData["Install-Destination"] == "root" )
 				{
-					button.disabled = true;
-					button.className = "btn btn-default disabled"
+					setElementEnabled(button, false);
 				}
 				else
 				{
@@ -360,8 +359,7 @@ function resetData()
 				}
 				else
 				{
-					button.disabled = true;
-					button.className = "btn btn-default disabled"
+					setElementEnabled(button, false);
 				}
 			}
 

--- a/package/gargoyle/files/www/js/plugins.js
+++ b/package/gargoyle/files/www/js/plugins.js
@@ -305,8 +305,8 @@ function resetData()
 		else
 		{
 			remove = createInput("button");
-			remove.className = "btn btn-default"
-			remove.value=UI.Remove
+			remove.className = "btn btn-default btn-remove";
+			remove.textContent = UI.Remove;
 			remove.onclick = removePluginSource;
 		}
 		sourceTableData.push( [name + "\n" + url, remove] );
@@ -340,7 +340,8 @@ function resetData()
 			button.className="btn btn-default";
 			if (enabledCheckbox.checked)
 			{
-				button.value = UI.Uninstall;
+				button.textContent = UI.Uninstall;
+				button.className += " btn-uninstall";
 				if( pkgData["Install-Destination"] == "root" )
 				{
 					setElementEnabled(button, false);
@@ -352,7 +353,8 @@ function resetData()
 			}
 			else
 			{
-				button.value = UI.Install;
+				button.textContent = UI.Install;
+				button.className += " btn-install";
 				if( pkgData["Can-Install" ] )
 				{
 					button.onclick = installPackage;

--- a/package/gargoyle/files/www/js/port_forwarding.js
+++ b/package/gargoyle/files/www/js/port_forwarding.js
@@ -615,8 +615,8 @@ function setDmzEnabled()
 function createEditButton(isSingle)
 {
 	var editButton = createInput("button");
-	editButton.value = UI.Edit;
-	editButton.className="btn btn-default";
+	editButton.textContent = UI.Edit;
+	editButton.className = "btn btn-default btn-edit";
 	editButton.onclick = isSingle ? function(){ editForward(true, this); } : function(){ editForward(false, this); } ;
 	return editButton;
 }
@@ -641,9 +641,9 @@ function editForward(isSingle, triggerElement)
 
 	saveButton = createInput("button", editForwardWindow.document);
 	closeButton = createInput("button", editForwardWindow.document);
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default";
-	closeButton.value = UI.CDiscardChanges;
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
 	closeButton.className = "btn btn-warning";
 
 	editRow=triggerElement.parentNode.parentNode;

--- a/package/gargoyle/files/www/js/qos.js
+++ b/package/gargoyle/files/www/js/qos.js
@@ -847,8 +847,8 @@ function removeServiceClassCallback(table, row)
 function createRuleTableEditButton()
 {
 	editRuleButton = createInput("button");
-	editRuleButton.value = UI.Edit;
-	editRuleButton.className="btn btn-default";
+	editRuleButton.textContent = UI.Edit;
+	editRuleButton.className = "btn btn-default btn-edit";
 	editRuleButton.onclick = editRuleTableRow;
 
 	return editRuleButton;
@@ -884,9 +884,9 @@ function editRuleTableRow()
 		saveButton = editRuleWindow.createElement('<button type="button"></button>');
 		closeButton = editRuleWindow.createElement('<button type="button"></button>');
 	}
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default";
-	closeButton.value = UI.CDiscardChanges;
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
 	closeButton.className = "btn btn-warning";
 
 
@@ -1021,13 +1021,13 @@ function createRuleTableCommentButton(commentStr)
 	commentRuleSpan.className="popup";
 
 	commentRuleButton = createInput("button");
-	commentRuleButton.value = "?";
-	commentRuleButton.className="btn btn-default";
+	commentRuleButton.textContent = "?";
+	commentRuleButton.className = "btn btn-default btn-comment";
 	commentRuleButton.onclick = doRuleTableComment;
 	if (commentStr == "")
 	{
 		commentRuleButton.disabled = true;
-		commentRuleButton.value = "N/A"
+		commentRuleButton.textContent = "N/A"
 	}
 
 	commentSpan = document.createElement("span");
@@ -1050,8 +1050,8 @@ function doRuleTableComment()
 function createClassTableEditButton(rowIndex)
 {
 	editClassButton = createInput("button");
-	editClassButton.value = UI.Edit;
-	editClassButton.className="btn btn-default";
+	editClassButton.textContent = UI.Edit;
+	editClassButton.className = "btn btn-default btn-edit";
 	editClassButton.onclick = editClassTableRow;
 	editClassButton.id = "" + rowIndex;
 
@@ -1090,9 +1090,9 @@ function editClassTableRow()
 		closeButton = editClassWindow.createElement('<button type="button"></button>');
 	}
 
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default";
-	closeButton.value = UI.CDiscardChanges;
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
 	closeButton.className = "btn btn-warning";
 
 	editClassWindowRow=this.parentNode.parentNode;

--- a/package/gargoyle/files/www/js/qos.js
+++ b/package/gargoyle/files/www/js/qos.js
@@ -874,15 +874,15 @@ function editRuleTableRow()
 	try
 	{
 
-		saveButton = editRuleWindow.document.createElement('input');
+		saveButton = editRuleWindow.document.createElement('button');
 		saveButton.type= 'button';
-		closeButton = editRuleWindow.document.createElement('input');
+		closeButton = editRuleWindow.document.createElement('button');
 		closeButton.type= 'button';
 	}
 	catch(e)
 	{
-		saveButton = editRuleWindow.createElement('<input type="button" />');
-		closeButton = editRuleWindow.createElement('<input type="button" />');
+		saveButton = editRuleWindow.createElement('<button type="button"></button>');
+		closeButton = editRuleWindow.createElement('<button type="button"></button>');
 	}
 	saveButton.value = UI.CApplyChanges;
 	saveButton.className = "btn btn-default";
@@ -1079,15 +1079,15 @@ function editClassTableRow()
 	editClassWindow = openPopupWindow("qos_edit_class.sh", "test", 560, 500);
 	try
 	{
-		saveButton = editClassWindow.document.createElement('input');
+		saveButton = editClassWindow.document.createElement('button');
 		saveButton.type= 'button';
-		closeButton = editClassWindow.document.createElement('input');
+		closeButton = editClassWindow.document.createElement('button');
 		closeButton.type= 'button';
 	}
 	catch(e)
 	{
-		saveButton = editClassWindow.createElement('<input type="button" />');
-		closeButton = editClassWindow.createElement('<input type="button" />');
+		saveButton = editClassWindow.createElement('<button type="button"></button>');
+		closeButton = editClassWindow.createElement('<button type="button"></button>');
 	}
 
 	saveButton.value = UI.CApplyChanges;

--- a/package/gargoyle/files/www/js/quotas.js
+++ b/package/gargoyle/files/www/js/quotas.js
@@ -1101,8 +1101,7 @@ function createEditButton(enabled)
 	editButton.className="btn btn-default";
 	editButton.onclick = editQuota;
 
-	editButton.className = enabled ? "btn btn-default" : "btn btn-default disabled" ;
-	editButton.disabled  = enabled ? false : true;
+	setElementEnabled(editButton, enabled);
 
 	return editButton;
 }
@@ -1111,8 +1110,8 @@ function setRowEnabled()
 	enabled= this.checked ? "1" : "0";
 	enabledRow=this.parentNode.parentNode;
 
-	enabledRow.childNodes[rowCheckIndex+1].firstChild.disabled  = this.checked ? false : true;
-	enabledRow.childNodes[rowCheckIndex+1].firstChild.className = this.checked ? "btn btn-default" : "btn btn-default disabled" ;
+	var row = enabledRow.childNodes[rowCheckIndex+1].firstChild;
+	setElementEnabled(row, enabled);
 
 	var idStr = this.id;
 	var ids = idStr.split(/\./);

--- a/package/gargoyle/files/www/js/quotas.js
+++ b/package/gargoyle/files/www/js/quotas.js
@@ -1097,8 +1097,8 @@ function createEnabledCheckbox(enabled)
 function createEditButton(enabled)
 {
 	editButton = createInput("button");
-	editButton.value = UI.Edit;
-	editButton.className="btn btn-default";
+	editButton.textContent = UI.Edit;
+	editButton.className = "btn btn-default btn-edit";
 	editButton.onclick = editQuota;
 
 	setElementEnabled(editButton, enabled);
@@ -1157,9 +1157,9 @@ function editQuota()
 
 	var saveButton = createInput("button", editQuotaWindow.document);
 	var closeButton = createInput("button", editQuotaWindow.document);
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default";
-	closeButton.value = UI.CDiscardChanges;
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
 	closeButton.className = "btn btn-warning";
 
 	var editRow=this.parentNode.parentNode;

--- a/package/gargoyle/files/www/js/restrictions.js
+++ b/package/gargoyle/files/www/js/restrictions.js
@@ -255,8 +255,7 @@ function createEditButton(enabled, ruleType, rulePrefix)
 	editButton.className="btn btn-default";
 	editButton.onclick = editRule;
 
-	editButton.className = enabled ? "btn btn-default" : "btn btn-default disabled" ;
-	editButton.disabled  = enabled ? false : true;
+	setElementEnabled(editButton, enabled);
 
 	return editButton;
 }
@@ -266,8 +265,8 @@ function setRowEnabled()
 	enabledRow=this.parentNode.parentNode;
 	enabledId = this.id;
 
-	enabledRow.childNodes[2].firstChild.disabled  = this.checked ? false : true;
-	enabledRow.childNodes[2].firstChild.className = this.checked ? "btn btn-default" : "btn btn-default disabled" ;
+	var row = enabledRow.childNodes[2].firstChild;
+	setElementEnabled(row, enabled);
 
 	uci.set(pkg, enabledId, "enabled", enabled);
 }

--- a/package/gargoyle/files/www/js/restrictions.js
+++ b/package/gargoyle/files/www/js/restrictions.js
@@ -251,8 +251,8 @@ function createEnabledCheckbox(enabled)
 function createEditButton(enabled, ruleType, rulePrefix)
 {
 	editButton = createInput("button");
-	editButton.value = UI.Edit;
-	editButton.className="btn btn-default";
+	editButton.textContent = UI.Edit;
+	editButton.className = "btn btn-default btn-edit";
 	editButton.onclick = editRule;
 
 	setElementEnabled(editButton, enabled);
@@ -309,9 +309,9 @@ function editRule()
 
 	saveButton = createInput("button", editRuleWindow.document);
 	closeButton = createInput("button", editRuleWindow.document);
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default";
-	closeButton.value = UI.CDiscardChanges;
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
 	closeButton.className = "btn btn-warning";
 
 	editRuleSectionId = editRow.childNodes[1].firstChild.id;

--- a/package/gargoyle/files/www/js/routing.js
+++ b/package/gargoyle/files/www/js/routing.js
@@ -139,8 +139,8 @@ function resetData()
 function createEditButton()
 {
 	var editButton = createInput("button");
-	editButton.value = UI.Edit;
-	editButton.className="btn btn-default";
+	editButton.textContent = UI.Edit;
+	editButton.className = "btn btn-default btn-edit";
 	editButton.onclick = editStaticRoute;
 	return editButton;
 }
@@ -270,9 +270,9 @@ function editStaticRoute()
 
 	saveButton = createInput("button", editStaticWindow.document);
 	closeButton = createInput("button", editStaticWindow.document);
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default";
-	closeButton.value = UI.CDiscardChanges;
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
 	closeButton.className = "btn btn-warning";
 
 	editRow=this.parentNode.parentNode;

--- a/package/gargoyle/files/www/js/table.js
+++ b/package/gargoyle/files/www/js/table.js
@@ -265,8 +265,7 @@ function setRowClasses(table, enabled)
 			cellContent=cells[cellIndex].firstChild;
 			if(cellContent.type == "button" )
 			{
-				cellContent.disabled = (enabled == false);
-				cellContent.className = (enabled == false) ? "btn btn-default disabled" : "btn btn-default";
+				setElementEnabled(cellContent, enabled);
 			}
 		}
 		rowIndex++;

--- a/package/gargoyle/files/www/js/table.js
+++ b/package/gargoyle/files/www/js/table.js
@@ -119,8 +119,8 @@ function addTableRow(table, rowData, rowsAreRemovable, rowsAreMovable, rowRemove
 	if(rowsAreRemovable)
 	{
 		cellContent = createInput("button", controlDocument);
-		cellContent.value = UI.Remove;
-		cellContent.className="btn btn-default";
+		cellContent.textContent = UI.Remove;
+		cellContent.className = "btn btn-default btn-remove";
 		cellContent.onclick= function() { row = this.parentNode.parentNode; table=row.parentNode.parentNode; removeThisCellsRow(this); rowRemoveCallback(table,row); };
 		cell = controlDocument.createElement('td');
 		cell.className=table.id + '_column_' + cellIndex;
@@ -131,8 +131,8 @@ function addTableRow(table, rowData, rowsAreRemovable, rowsAreMovable, rowRemove
 	if(rowsAreMovable)
 	{
 		cellContent = createInput("button", controlDocument);
-		cellContent.value = String.fromCharCode(8593);
-		cellContent.className="btn btn-default";
+		cellContent.textContent = String.fromCharCode(8593);
+		cellContent.className = "btn btn-default btn-move-up";
 		cellContent.onclick= function() { moveThisCellsRowUp(this); rowMoveCallback(this, "up"); };
 		cell = controlDocument.createElement('td');
 		cell.className=table.id + '_column_' + cellIndex;
@@ -141,8 +141,8 @@ function addTableRow(table, rowData, rowsAreRemovable, rowsAreMovable, rowRemove
 		cellIndex++;
 
 		cellContent = createInput("button", controlDocument);
-		cellContent.value = String.fromCharCode(8595);
-		cellContent.className="btn btn-default";
+		cellContent.textContent = String.fromCharCode(8595);
+		cellContent.className = "btn btn-default btn-move-down";
 		cellContent.onclick= function() { moveThisCellsRowDown(this); rowMoveCallback(this, "down"); };
 		cell = controlDocument.createElement('td');
 		cell.className=table.id + '_column_' + cellIndex;

--- a/package/gargoyle/files/www/js/themes.js
+++ b/package/gargoyle/files/www/js/themes.js
@@ -12,7 +12,7 @@ var thmS=new Object(); //part of i18n
 function createUseButton()
 {
 	var useButton = createInput("button");
-	useButton.value = UI.Select;
+	useButton.textContent = UI.Select;
 	useButton.className="btn btn-default";
 	useButton.onclick = useTheme;
 	return useButton;

--- a/package/gargoyle/files/www/js/webmon.js
+++ b/package/gargoyle/files/www/js/webmon.js
@@ -260,8 +260,7 @@ function setWebmonEnabled()
 		element.style.color = !enabled ? "#AAAAAA" : "#000000";
 	}
 	var addButton = document.getElementById('add_ip_button');
-	addButton.className = enabled ? "btn btn-default" : "btn btn-default disabled";
-	addButton.disabled = !enabled;
+	setElementEnabled(addButton, enabled);
 
 	addIpTable = document.getElementById('ip_table_container').firstChild;
 	if(addIpTable != null)

--- a/package/gargoyle/files/www/js/wol.js
+++ b/package/gargoyle/files/www/js/wol.js
@@ -82,7 +82,7 @@ function getHostname(ip)
 function createWakeUpButton()
 {
 	var WakeUpButton = createInput("button");
-	WakeUpButton.value = wolS.WkUp;
+	WakeUpButton.textContent = wolS.WkUp;
 	WakeUpButton.className="btn btn-default";
 	WakeUpButton.onclick = wakeHost;
 	return WakeUpButton;

--- a/package/plugin-gargoyle-initd/files/www/js/initd.js
+++ b/package/plugin-gargoyle-initd/files/www/js/initd.js
@@ -74,7 +74,7 @@ function createEnabledCheckbox()
 function createStartButton()
 {
 	var startButton = createInput("button");
-	startButton.value = "Start";
+	startButton.textContent = "Start";
 	startButton.className="btn btn-primary";
 	startButton.onclick = startService;
 	return startButton;
@@ -83,7 +83,7 @@ function createStartButton()
 function createResetButton()
 {
 	var restartButton = createInput("button");
-	restartButton.value = "Restart";
+	restartButton.textContent = "Restart";
 	restartButton.className="btn btn-warning";
 	restartButton.onclick = restartService;
 	return restartButton;
@@ -92,7 +92,7 @@ function createResetButton()
 function createStopButton()
 {
 	var stopButton = createInput("button");
-	stopButton.value = "Stop";
+	stopButton.textContent = "Stop";
 	stopButton.className="btn btn-danger";
 	stopButton.onclick = stopService;
 	return stopButton;

--- a/package/plugin-gargoyle-openvpn/files/www/js/openvpn.js
+++ b/package/plugin-gargoyle-openvpn/files/www/js/openvpn.js
@@ -729,10 +729,10 @@ function createAllowedClientControls(haveDownload)
 
 	var enabledCheck = createInput("checkbox")
 	enabledCheck.onclick = toggleAcEnabled;
-	var downloadButtonMulti = haveDownload ? createButton(ovpnS.Dload, "btn btn-default", downloadAcMulti, false) : createButton(ovpnS.Dload, "btn btn-default disabled", function(){ return; }, true ) ;
-	var downloadButtonSingle = haveDownload ? createButton(ovpnS.Dload, "btn btn-default", downloadAcSingle, false) : createButton(ovpnS.Dload, "btn btn-default disabled", function(){ return; }, true ) ;
+	var downloadButtonMulti = haveDownload ? createButton(ovpnS.Dload, "btn-download", downloadAcMulti, false) : createButton(ovpnS.Dload, "btn-download disabled", function(){ return; }, true ) ;
+	var downloadButtonSingle = haveDownload ? createButton(ovpnS.Dload, "btn-download", downloadAcSingle, false) : createButton(ovpnS.Dload, "btn-download disabled", function(){ return; }, true ) ;
 
-	var editButton     = createButton(UI.Edit,     "btn btn-default", editAc, false)
+	var editButton = createButton(UI.Edit, "btn-edit", editAc, false)
 
 	return [enabledCheck, downloadButtonMulti, downloadButtonSingle, editButton]
 }
@@ -740,8 +740,8 @@ function createAllowedClientControls(haveDownload)
 function createButton(text, cssClass, actionFunction, disabled)
 {
 	var button = createInput("button")
-	button.value = text
-	button.className=cssClass
+	button.textContent = text
+	button.className = "btn btn-default " + cssClass
 	button.onclick = actionFunction
 	button.disabled = disabled
 	return button;
@@ -1297,10 +1297,10 @@ function editAc()
 	
 	var saveButton = createInput("button", editAcWindow.document);
 	var closeButton = createInput("button", editAcWindow.document);
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default btn-lg";
-	closeButton.value = UI.CDiscardChanges;
-	closeButton.className = "btn btn-default btn-lg";
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
+	closeButton.className = "btn btn-warning";
 
 	var editRow=this.parentNode.parentNode;
 	var editId = editRow.childNodes[1].firstChild.id;

--- a/package/plugin-gargoyle-usb-storage/files/www/js/usb_storage.js
+++ b/package/plugin-gargoyle-usb-storage/files/www/js/usb_storage.js
@@ -467,10 +467,10 @@ function editUser()
 	var okButton = createInput("button", editUserWindow.document);
 	var cancelButton = createInput("button", editUserWindow.document);
 
-	okButton.value         = usbSStr.ChPass;
-	okButton.className     = "btn btn-default";
-	cancelButton.value     = UI.Cancel;
-	cancelButton.className = "btn btn-default";
+	okButton.textContent   = usbSStr.ChPass;
+	okButton.className     = "btn btn-primary";
+	cancelButton.textContent = UI.Cancel;
+	cancelButton.className = "btn btn-warning";
 
 
 	editShareUserRow=this.parentNode.parentNode;
@@ -1213,8 +1213,8 @@ function setSharePaths(controlDocument)
 function createEditButton( editFunction )
 {
 	editButton = createInput("button");
-	editButton.value = UI.Edit;
-	editButton.className="btn btn-default";
+	editButton.textContent = UI.Edit;
+	editButton.className = "btn btn-default btn-edit";
 	editButton.onclick = editFunction;
 	editButton.disabled  = false ;
 
@@ -1259,10 +1259,10 @@ function editShare()
 
 	var saveButton = createInput("button", editShareWindow.document);
 	var closeButton = createInput("button", editShareWindow.document);
-	saveButton.value = UI.CApplyChanges;
-	saveButton.className = "btn btn-default btn-lg";
-	closeButton.value = UI.CDiscardChanges;
-	closeButton.className = "btn btn-default btn-lg";
+	saveButton.textContent = UI.CApplyChanges;
+	saveButton.className = "btn btn-primary";
+	closeButton.textContent = UI.CDiscardChanges;
+	closeButton.className = "btn btn-warning";
 
 	editRow=this.parentNode.parentNode;
 	editName=editRow.childNodes[0].firstChild.data;


### PR DESCRIPTION
This PR focus on improving styling flexibility for button elements which are dynamically created/generated inside tables via JavaScript, since currently there's no easy way to reference/style those buttons if wanted/needed (i.e. on themes).

## Changelog
- Switch button element declaration inside JS files from `<input type="button"/>` to `<button></button>`. Advantages described below:

>Buttons created with the BUTTON element function just like buttons created with the INPUT element, but they offer richer rendering possibilities: the BUTTON element may have content. For example, a BUTTON element that contains an image functions like and may resemble an INPUT element whose type is set to “image”, but the BUTTON element type allows content.

- Update save/close JS buttons CSS classes names of edit pages for consistency with other pages.

- Add custom CSS classes names to common button elements (e.g. `btn-edit, btn-remove`, etc) found in various tables throughout the system. 
    - Adding these custom classes would allow to easily address style changes to a specific button, going from setting a different background/border/hover or even the addition of good-looking icon fonts (e.g. FontAwesome, Noun Project, etc). This could be easily done using only CSS and pseudo-classes.  


### Example
```css
btn-edit:before
{
    font-family:FontAwesome;
    display:inline-block;
    width:1.28571429em;
    content: "\f015";
}
```

## Screenshots examples
![0fbf0747-d04d-4c00-b698-90d5a8fb78d3](https://user-images.githubusercontent.com/22578839/36079454-1f32cea4-0f6a-11e8-909a-656869e32d17.png)
![d2f11f23-4b6f-40ad-ae3a-c653e03ab9f6](https://user-images.githubusercontent.com/22578839/36100444-70b0bab0-0fed-11e8-8e29-8a3f80c8a73b.png)
![a8da8da6-a349-4f31-b71e-a8109660c372](https://user-images.githubusercontent.com/22578839/36100563-cccf3e7a-0fed-11e8-96d1-e309affd2486.png)
