### PR TITLE
Add common CSS class for all "Add" buttons and some minor fixes

### DIFF
--- a/package/gargoyle/files/www/access.sh
+++ b/package/gargoyle/files/www/access.sh
@@ -191,7 +191,7 @@
 					<label class="col-xs-5"><%~ SSHName %>:</label>
 					<span class="col-xs-7">
 						<input type="text" id="public_key_name" name="public_key_name" value="" class="form-control" />
-						<button class="btn btn-default" id="add_key" name="add_key" onclick="addKey()"><%~ Add %></button>
+						<button class="btn btn-default btn-add" id="add_key" name="add_key" onclick="addKey()"><%~ Add %></button>
 					</span>
 				</div>
 

--- a/package/gargoyle/files/www/access.sh
+++ b/package/gargoyle/files/www/access.sh
@@ -221,7 +221,6 @@
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
 
-<span id="update_container"><%~ WaitSettings %></span>
 
 
 <script>

--- a/package/gargoyle/files/www/access.sh
+++ b/package/gargoyle/files/www/access.sh
@@ -223,7 +223,6 @@
 
 <span id="update_container"><%~ WaitSettings %></span>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/bandwidth.sh
+++ b/package/gargoyle/files/www/bandwidth.sh
@@ -249,7 +249,6 @@
 	</div>
 </div>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/bandwidth_distribution.sh
+++ b/package/gargoyle/files/www/bandwidth_distribution.sh
@@ -97,7 +97,6 @@
 
 </div>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -169,7 +169,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						<span id="bridge_dns_custom_container">
 							<div class="second_row_right_column">
 								<input type="text" id="add_bridge_dns" onkeyup="proofreadIp(this)" class="form-control" size="20" maxlength="17" />
-								<button class="btn btn-default" id="add_bridge_dns_button" onclick="addDns('bridge')"><%~ Add %></button>
+								<button class="btn btn-default btn-add" id="add_bridge_dns_button" onclick="addDns('bridge')"><%~ Add %></button>
 							</div>
 							<div id="bridge_dns_table_container" class="second_row_right_column form-group"></div>
 						</span>
@@ -373,7 +373,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<label class="col-xs-5"  for="bridge_wds_label" id="bridge_wds_label"><%~ OWDS %>:</label>
 					<span class="col-xs-7">
 						<input type="text" id="add_bridge_wds_mac" class="form-control" onkeyup="proofreadMac(this)" size="20" maxlength="17"/>
-						<button class="btn btn-default" id="add_bridge_wds_mac_button" onclick="addMacToWds('bridge')"><%~ Add %></button>
+						<button class="btn btn-default btn-add" id="add_bridge_wds_mac_button" onclick="addMacToWds('bridge')"><%~ Add %></button>
 						<div id="bridge_wds_mac_table_container" class="second_row_right_column form-group"></div>
 					</span>
 				</div>
@@ -622,7 +622,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						</select>
 						<div id="lan_dns_custom_container" class="second_row_right_column">
 							<input  type="text" id="add_lan_dns" class="form-control" onkeyup="proofreadIp(this)" size="20" maxlength="17" />
-							<button class="btn btn-default" id="add_lan_dns_button" onclick="addDns('lan')"><%~ Add %></button>
+							<button class="btn btn-default btn-add" id="add_lan_dns_button" onclick="addDns('lan')"><%~ Add %></button>
 							<div id="lan_dns_table_container" class="form-group second_row_right_column"></div>
 						</div>
 					</span>
@@ -769,7 +769,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						<div class="second_row_right_column"><em><%~ FltrInfo %></em></div>
 						<div class="second_row_right_column">
 							<input type="text" id="add_mac" class="form-control" onkeyup="proofreadMac(this)" size="20" maxlength="17"/>
-							<button class="btn btn-default" id="add_mac_button" onclick="addMacToFilter()"><%~ Add %></button>
+							<button class="btn btn-default btn-add" id="add_mac_button" onclick="addMacToFilter()"><%~ Add %></button>
 						</div>
 						<div id="mac_table_container" class="form-group second_row_right_column"></div>
 
@@ -1005,7 +1005,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<label  class="col-xs-5" for="wifi_wds_label" id="wifi_wds_label"><%~ OWDS %>:</label>
 					<span class="col-xs-7">
 						<input type="text" id="add_wifi_wds_mac" class="form-control" onkeyup="proofreadMac(this)" size="20" maxlength="17"/>
-						<button class="btn btn-default" id="add_wifi_wds_mac_button" onclick="addMacToWds('wifi')"><%~ Add %></button>
+						<button class="btn btn-default btn-add" id="add_wifi_wds_mac_button" onclick="addMacToWds('wifi')"><%~ Add %></button>
 						<div id="wifi_wds_mac_table_container" class="second_row_right_column form-group"></div>
 					</span>
 				</div>

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -1106,7 +1106,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 </div>
 <iframe id="reboot_test" onload="reloadPage()" style="display:none"></iframe>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/connlimits.sh
+++ b/package/gargoyle/files/www/connlimits.sh
@@ -66,7 +66,6 @@
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/ddns.sh
+++ b/package/gargoyle/files/www/ddns.sh
@@ -94,7 +94,6 @@
 
 <span id="update_container" ><%~ WaitSettings %></span>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/ddns.sh
+++ b/package/gargoyle/files/www/ddns.sh
@@ -92,7 +92,6 @@
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
 
-<span id="update_container" ><%~ WaitSettings %></span>
 
 
 <script>

--- a/package/gargoyle/files/www/ddns.sh
+++ b/package/gargoyle/files/www/ddns.sh
@@ -66,7 +66,7 @@
 				</div>
 
 				<div class="row form-group">
-					<span class="col-xs-12"><button id="add_service_button" class="btn btn-default" onclick="addDdnsService()"><%~ AddDDNS %></button></span>
+					<span class="col-xs-12"><button id="add_service_button" class="btn btn-default btn-add" onclick="addDdnsService()"><%~ AddDDNS %></button></span>
 				</div>
 
 				<div class="row form-group">

--- a/package/gargoyle/files/www/dhcp.sh
+++ b/package/gargoyle/files/www/dhcp.sh
@@ -154,7 +154,6 @@ for (etherIndex in etherData)
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/identification.sh
+++ b/package/gargoyle/files/www/identification.sh
@@ -42,7 +42,6 @@
 	<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
-<span id="update_container"><%~ WaitSettings %></span>
 
 
 

--- a/package/gargoyle/files/www/identification.sh
+++ b/package/gargoyle/files/www/identification.sh
@@ -45,7 +45,6 @@
 <span id="update_container"><%~ WaitSettings %></span>
 
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/js/qos.js
+++ b/package/gargoyle/files/www/js/qos.js
@@ -1026,7 +1026,7 @@ function createRuleTableCommentButton(commentStr)
 	commentRuleButton.onclick = doRuleTableComment;
 	if (commentStr == "")
 	{
-		commentRuleButton.disabled = true;
+		setElementEnabled(commentRuleButton, false);
 		commentRuleButton.textContent = "N/A"
 	}
 

--- a/package/gargoyle/files/www/plugins.sh
+++ b/package/gargoyle/files/www/plugins.sh
@@ -92,7 +92,7 @@
 							<span class="col-xs-7"><input type="text" id="add_source_url" class="form-control" /></span>
 						</div>
 
-						<button id="add_source_button" class="btn btn-default" onclick="addPluginSource()"><%~ APSrc %></button>
+						<button id="add_source_button" class="btn btn-default btn-add" onclick="addPluginSource()"><%~ APSrc %></button>
 					</div>
 				</div>
 			</div>

--- a/package/gargoyle/files/www/port_forwarding.sh
+++ b/package/gargoyle/files/www/port_forwarding.sh
@@ -152,7 +152,6 @@
 </div>
 <span id="update_container" ><%~ WaitSettings %></span>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/port_forwarding.sh
+++ b/package/gargoyle/files/www/port_forwarding.sh
@@ -150,7 +150,6 @@
 	<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
-<span id="update_container" ><%~ WaitSettings %></span>
 
 
 <script>

--- a/package/gargoyle/files/www/qos_distribution.sh
+++ b/package/gargoyle/files/www/qos_distribution.sh
@@ -90,7 +90,6 @@
 	</div>
 </div>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/qos_download.sh
+++ b/package/gargoyle/files/www/qos_download.sh
@@ -181,7 +181,7 @@
 
 
 				<div id="add_rule_container" class="row form-group">
-					<span class="col-xs-12"><button id="add_rule_button" class="btn btn-default" onclick="addClassificationRule()" ><%~ AddRule %></button></span>
+					<span class="col-xs-12"><button id="add_rule_button" class="btn btn-default btn-add" onclick="addClassificationRule()" ><%~ AddRule %></button></span>
 				</div>
 			</div>
 		</div>
@@ -302,7 +302,7 @@
 				</div>
 
 				<div class="row form-group" id="add_class_container">
-					<span class="col-xs-12"><button id="add_class_button" class="btn btn-default" onclick="addServiceClass()" ><%~ AddSvcCls %></button></span>
+					<span class="col-xs-12"><button id="add_class_button" class="btn btn-default btn-add" onclick="addServiceClass()" ><%~ AddSvcCls %></button></span>
 				</div>
 			</div>
 		</div>

--- a/package/gargoyle/files/www/qos_download.sh
+++ b/package/gargoyle/files/www/qos_download.sh
@@ -398,7 +398,6 @@
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
 
-<span id="update_container" ><%~ WaitSettings %></span>
 
 
 <script>

--- a/package/gargoyle/files/www/qos_download.sh
+++ b/package/gargoyle/files/www/qos_download.sh
@@ -400,7 +400,6 @@
 
 <span id="update_container" ><%~ WaitSettings %></span>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/qos_upload.sh
+++ b/package/gargoyle/files/www/qos_upload.sh
@@ -172,7 +172,7 @@
 					</div>
 
 					<div id="add_rule_container" class="row form-group">
-						<span class="col-xs-12"><button id="add_rule_button" class="btn btn-default" onclick="addClassificationRule()" ><%~ AddRule %></button></span>
+						<span class="col-xs-12"><button id="add_rule_button" class="btn btn-default btn-add" onclick="addClassificationRule()" ><%~ AddRule %></button></span>
 					</div>
 				</div>
 			</div>
@@ -269,7 +269,7 @@
 					</div>
 
 					<div class="row form-group" id="add_class_container">
-						<span class="col-xs-12"><button id="add_class_button" class="btn btn-default" onclick="addServiceClass()"><%~ AddSvcCls %></button></span>
+						<span class="col-xs-12"><button id="add_class_button" class="btn btn-default btn-add" onclick="addServiceClass()"><%~ AddSvcCls %></button></span>
 					</div>
 				</div>
 			</div>

--- a/package/gargoyle/files/www/qos_upload.sh
+++ b/package/gargoyle/files/www/qos_upload.sh
@@ -281,7 +281,6 @@
 	<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
-<span id="update_container"><%~ WaitSettings %></span>
 
 
 <script>

--- a/package/gargoyle/files/www/qos_upload.sh
+++ b/package/gargoyle/files/www/qos_upload.sh
@@ -283,7 +283,6 @@
 </div>
 <span id="update_container"><%~ WaitSettings %></span>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/quotas.sh
+++ b/package/gargoyle/files/www/quotas.sh
@@ -61,7 +61,6 @@
 	<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
-<span id="update_container" ><%~ WaitSettings %></span>
 
 
 <script>

--- a/package/gargoyle/files/www/quotas.sh
+++ b/package/gargoyle/files/www/quotas.sh
@@ -40,7 +40,7 @@
 					<span class="col-xs-12">
 						<span id="add_quota_label" style="text-decoration:underline"><%~ AddQuota %>:</span>
 						<%in templates/quotas_template %>
-						<button id="add_quota_button" class="btn btn-default" onclick="addNewQuota()"><%~ AddQuota %></button>
+						<button id="add_quota_button" class="btn btn-default btn-add" onclick="addNewQuota()"><%~ AddQuota %></button>
 					</span>
 				</div>
 

--- a/package/gargoyle/files/www/reboot.sh
+++ b/package/gargoyle/files/www/reboot.sh
@@ -111,7 +111,6 @@
 
 <iframe id="reboot_test" onload="reloadPage()" style="display:none" ></iframe>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 	resetData();

--- a/package/gargoyle/files/www/restriction.sh
+++ b/package/gargoyle/files/www/restriction.sh
@@ -29,7 +29,7 @@
 					<span class="col-xs-12">
 						<span id="add_rule_label" style="text-decoration:underline" ><%~ NRRule %>:</span>
 						<%in templates/restriction_template %>
-						<button id="add_restriction_button" class="btn btn-default" onclick="addNewRule('restriction_rule', 'rule_')"><%~ ANRule %></button>
+						<button id="add_restriction_button" class="btn btn-default btn-add" onclick="addNewRule('restriction_rule', 'rule_')"><%~ ANRule %></button>
 					</span>
 				</div>
 
@@ -54,7 +54,7 @@
 					<span class="col-xs-12">
 						<span id="add_exception_label" style="text-decoration:underline"><%~ NExcp %>:</span>
 						<%in templates/whitelist_template %>
-						<button id="add_restriction_button" class="btn btn-default" onclick="addNewRule('whitelist_rule', 'exception_')"><%~ ANRule %></button>
+						<button id="add_restriction_button" class="btn btn-default btn-add" onclick="addNewRule('whitelist_rule', 'exception_')"><%~ ANRule %></button>
 					</span>
 				</div>
 

--- a/package/gargoyle/files/www/restriction.sh
+++ b/package/gargoyle/files/www/restriction.sh
@@ -74,7 +74,6 @@
 	<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
-<span id="update_container" ><%~ WaitSettings %></span>
 
 
 <script>

--- a/package/gargoyle/files/www/routing.sh
+++ b/package/gargoyle/files/www/routing.sh
@@ -77,7 +77,6 @@
 	<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
-<span id="update_container" ><%~ WaitSettings %></span>
 
 <iframe id="reboot_test" onload="reloadPage()" style="display:none" ></iframe>
 

--- a/package/gargoyle/files/www/routing.sh
+++ b/package/gargoyle/files/www/routing.sh
@@ -81,7 +81,6 @@
 
 <iframe id="reboot_test" onload="reloadPage()" style="display:none" ></iframe>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/templates/multi_forward_template
+++ b/package/gargoyle/files/www/templates/multi_forward_template
@@ -13,6 +13,6 @@
 						<td><input type='text' id='addr_sp' size='5' onkeyup='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></td>
 						<td><input type='text' id='addr_ep' size='5' onkeyup='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></td>
 						<td><input type='text' id='addr_ip' size='15' onkeyup='proofreadIp(this)' maxLength='15' class='form-control' /></td>
-						<td><button type='button' id='addr_button' class='btn btn-default' onclick='addPortfRangeRule()'><%~ Add %></button></td>
+						<td><button type='button' id='addr_button' class='btn btn-default btn-add' onclick='addPortfRangeRule()'><%~ Add %></button></td>
 					</tr>
 				</table>

--- a/package/gargoyle/files/www/templates/quotas_template
+++ b/package/gargoyle/files/www/templates/quotas_template
@@ -41,7 +41,7 @@
 		<div style="padding:0px;margin-top:0px;margin-bottom:0px">
 			<span class="col-xs-offset-5 col-xs-7">
 				<input type='text' id='add_ip' onkeyup='proofreadMultipleIps(this)' style="width:250px;" class='form-control' />
-				<button type="button" class="btn btn-default" id="add_ip_button" onclick='addAddressesToTable(document,"add_ip","quota_ip_table_container","quota_ip_table",false,3,true,250)'><%~ Add %></button>
+				<button type="button" class="btn btn-default btn-add" id="add_ip_button" onclick='addAddressesToTable(document,"add_ip","quota_ip_table_container","quota_ip_table",false,3,true,250)'><%~ Add %></button>
 			</span>
 		</div>
 		<div style="padding:0px;margin-top:0px;margin-bottom:5px;">

--- a/package/gargoyle/files/www/templates/restriction_template
+++ b/package/gargoyle/files/www/templates/restriction_template
@@ -18,7 +18,7 @@
 	<div class="col-xs-offset-5 col-xs-7" id="rule_applies_to_table_container"></div>
 	<div class="col-xs-offset-5 col-xs-7">
 		<input type='text' id='rule_applies_to_addr' size='30' onkeyup='proofreadMultipleIpsOrMacs(this)' class='form-control' />
-		<button type="button" class="btn btn-default" id="rule_add_applies_to_addr" onclick='addAddressesToTable(document,"rule_applies_to_addr","rule_applies_to_table_container","rule_applies_to_table",true)'><%~ Add %></button>
+		<button type="button" class="btn btn-default btn-add" id="rule_add_applies_to_addr" onclick='addAddressesToTable(document,"rule_applies_to_addr","rule_applies_to_table_container","rule_applies_to_table",true)'><%~ Add %></button>
 	</div>
 	<div class="col-xs-offset-5 col-xs-7">
 		<em><%~ HstAddr %></em>
@@ -86,7 +86,7 @@
 		<div class="col-xs-offset-5 col-xs-7" id="rule_remote_ip_table_container"></div>
 		<div class="col-xs-offset-5 col-xs-7">
 			<input type='text' id='rule_remote_ip' size='30' onkeyup='proofreadMultipleIps(this)' class='form-control' />
-			<button type="button" class="btn btn-default" id="rule_add_remote_ip" onclick='addAddressesToTable(document,"rule_remote_ip","rule_remote_ip_table_container","rule_remote_ip_table",false)'><%~ Add %></button>
+			<button type="button" class="btn btn-default btn-add" id="rule_add_remote_ip" onclick='addAddressesToTable(document,"rule_remote_ip","rule_remote_ip_table_container","rule_remote_ip_table",false)'><%~ Add %></button>
 		</div>
 	</div>
 
@@ -189,7 +189,7 @@
 				<option value="url_domain_regex"><%~ DmRgx %>:</option>
 			</select>
 			<input type='text' id='rule_url_match' size='30' class='form-control' />
-			<button type="button" class="btn btn-default" id="rule_add_url_match" onclick='addUrlToTable(document, "rule_url_match", "rule_url_match_type", "rule_url_match_table_container", "rule_url_match_table")'><%~ Add %></button>
+			<button type="button" class="btn btn-default btn-add" id="rule_add_url_match" onclick='addUrlToTable(document, "rule_url_match", "rule_url_match_type", "rule_url_match_table_container", "rule_url_match_table")'><%~ Add %></button>
 		</div>
 	</div>
 </div>

--- a/package/gargoyle/files/www/templates/single_forward_template
+++ b/package/gargoyle/files/www/templates/single_forward_template
@@ -13,6 +13,6 @@
 						<td><input type='text' id='add_fp' size='5' onkeyup='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></td>
 						<td><input type='text' id='add_ip' size='15' onkeyup='proofreadIp(this)' maxLength='15' class='form-control' /></td>
 						<td><input type='text' id='add_dp' size='5' onkeyup='proofreadNumeric(this,1,65535)' maxLength='5' class='form-control' /></td>
-						<td><button type="button" id="add_button" class="btn btn-default" onclick="addPortfRule()"><%~ Add %></button></td>
+						<td><button type="button" id="add_button" class="btn btn-default btn-add" onclick="addPortfRule()"><%~ Add %></button></td>
 					</tr>
 				</table>

--- a/package/gargoyle/files/www/templates/static_ip_template
+++ b/package/gargoyle/files/www/templates/static_ip_template
@@ -9,6 +9,6 @@
 						<td><input type='text' id='add_host' size='15' class='form-control' /></td>
 						<td><input type='text' id='add_mac' size='20' onkeyup='proofreadMac(this)' maxLength='17' class='form-control' /></td>
 						<td><input type='text' id='add_ip' size='20' onkeyup='proofreadIp(this)' maxLength='15' class='form-control' /></td>
-						<td><button type='button' id='add_button' class='btn btn-default' onclick='addStatic()'><%~ Add %></button></td>
+						<td><button type='button' id='add_button' class='btn btn-default btn-add' onclick='addStatic()'><%~ Add %></button></td>
 					</tr>
 				</table>

--- a/package/gargoyle/files/www/templates/static_route_template
+++ b/package/gargoyle/files/www/templates/static_route_template
@@ -9,6 +9,6 @@
 						<td><input type='text' id='add_dest' size='26' onkeyup='proofreadRouteIp(this)' maxLength='35' class='form-control' /></td>
 						<td><select id='add_iface' class='form-control'><option value="wan">WAN</option><option value="lan">LAN</option></select></td>
 						<td><input type='text' id='add_gateway' size='20' onkeyup='proofreadGatewayIp(this)' maxLength='15' class='form-control' /></td>
-						<td><button type='button' id='add_button' class='btn btn-default' onclick='addStaticRoute()'><%~ Add %></button></td>
+						<td><button type='button' id='add_button' class='btn btn-default btn-add' onclick='addStaticRoute()'><%~ Add %></button></td>
 					</tr>
 				</table>

--- a/package/gargoyle/files/www/templates/whitelist_template
+++ b/package/gargoyle/files/www/templates/whitelist_template
@@ -18,7 +18,7 @@
 	<div class="col-xs-offset-5 col-xs-7" id="exception_applies_to_table_container"></div>
 	<div class="col-xs-offset-5 col-xs-7">
 		<input type='text' id='exception_applies_to_addr' size='30' onkeyup='proofreadMultipleIpsOrMacs(this)' class='form-control' />
-		<button type="button" class="btn btn-default" id="exception_add_applies_to_addr" onclick='addAddressesToTable(document,"exception_applies_to_addr","exception_applies_to_table_container","exception_applies_to_table",true)'><%~ Add %></button>
+		<button type="button" class="btn btn-default btn-add" id="exception_add_applies_to_addr" onclick='addAddressesToTable(document,"exception_applies_to_addr","exception_applies_to_table_container","exception_applies_to_table",true)'><%~ Add %></button>
 	</div>
 	<div class="col-xs-offset-5 col-xs-7">
 		<em><%~ HstAddr %></em>
@@ -86,7 +86,7 @@
 		<div class="col-xs-offset-5 col-xs-7" id="exception_remote_ip_table_container"></div>
 		<div class="col-xs-offset-5 col-xs-7">
 			<input type='text' id='exception_remote_ip' size='30' onkeyup='proofreadMultipleIps(this)' class='form-control' />
-			<button type="button" class="btn btn-default" id="exception_add_remote_ip" onclick='addAddressesToTable(document,"exception_remote_ip","exception_remote_ip_table_container","exception_remote_ip_table",false)'><%~ Add %></button>
+			<button type="button" class="btn btn-default btn-add" id="exception_add_remote_ip" onclick='addAddressesToTable(document,"exception_remote_ip","exception_remote_ip_table_container","exception_remote_ip_table",false)'><%~ Add %></button>
 		</div>
 	</div>
 
@@ -188,7 +188,7 @@
 				<option value="url_domain_regex"><%~ DmRgx %>:</option>
 			</select>
 			<input type='text' id='exception_url_match' size='30' class='form-control' />
-			<button type="button" class="btn btn-default" id="exception_add_url_match" onclick='addUrlToTable(document, "exception_url_match", "exception_url_match_type", "exception_url_match_table_container", "exception_url_match_table")'><%~ Add %></button>
+			<button type="button" class="btn btn-default btn-add" id="exception_add_url_match" onclick='addUrlToTable(document, "exception_url_match", "exception_url_match_type", "exception_url_match_table_container", "exception_url_match_table")'><%~ Add %></button>
 		</div>
 	</div>
 </div>

--- a/package/gargoyle/files/www/themes.sh
+++ b/package/gargoyle/files/www/themes.sh
@@ -36,7 +36,6 @@
 	</div>
 </div>
 
-<span id="update_container" ><%~ WaitSettings %></span>
 
 <script>
 <!--

--- a/package/gargoyle/files/www/time.sh
+++ b/package/gargoyle/files/www/time.sh
@@ -102,7 +102,6 @@
 </div>
 <span id="update_container" ><%~ WaitSettings %></span>
 
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/time.sh
+++ b/package/gargoyle/files/www/time.sh
@@ -100,7 +100,6 @@
 	<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
-<span id="update_container" ><%~ WaitSettings %></span>
 
 
 <script>

--- a/package/gargoyle/files/www/webmon.sh
+++ b/package/gargoyle/files/www/webmon.sh
@@ -149,7 +149,6 @@
 		</div>
 	</div>
 </div>
-<!-- <br /><textarea style="margin-left:20px;" rows=30 cols=60 id="output"></textarea> -->
 
 <script>
 <!--

--- a/package/gargoyle/files/www/webmon.sh
+++ b/package/gargoyle/files/www/webmon.sh
@@ -64,7 +64,7 @@
 						<div class="row form-group">
 							<span class="col-xs-12">
 								<input type="text" id="add_ip" onkeyup="proofreadMultipleIps(this)" size="30" />
-								<button class="btn btn-default" id="add_ip_button" onclick="addAddressesToTable(document, 'add_ip', 'ip_table_container', 'ip_table', false, 3, 1, 250)"><%~ Add %></button>
+								<button class="btn btn-default btn-add" id="add_ip_button" onclick="addAddressesToTable(document, 'add_ip', 'ip_table_container', 'ip_table', false, 3, 1, 250)"><%~ Add %></button>
 							</span>
 							<em class="col-xs-12"><%~ SpcIP %></em>
 						</div>

--- a/package/plugin-gargoyle-minidlna/files/www/minidlna.sh
+++ b/package/plugin-gargoyle-minidlna/files/www/minidlna.sh
@@ -77,7 +77,7 @@
 					</div>
 
 					<div class="row form-group">
-						<span class="col-xs-12"><button id="add_share_button" class="btn btn-default" onclick="addNewMediaDir()"><%~ Add %></button></span>
+						<span class="col-xs-12"><button id="add_share_button" class="btn btn-default btn-add" onclick="addNewMediaDir()"><%~ Add %></button></span>
 					</div>
 				</div>
 

--- a/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
+++ b/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
@@ -190,7 +190,7 @@
 				<div class="row form-group">
 					<div class="col-xs-12"><%in /www/templates/openvpn_allowed_client_template %></div>
 					<div class="col-xs-12">
-						<button id='openvpn_allowed_client_add' class='btn btn-default' onclick='addAc()'><%~ Add %></button>
+						<button id='openvpn_allowed_client_add' class='btn btn-default btn-add' onclick='addAc()'><%~ Add %></button>
 					</div>
 				</div>
 			</div>

--- a/package/plugin-gargoyle-ping-watchdog/files/www/ping_watchdog.sh
+++ b/package/plugin-gargoyle-ping-watchdog/files/www/ping_watchdog.sh
@@ -81,7 +81,6 @@
 	<button id="save_button" class="btn btn-primary btn-lg" onclick="saveChanges()"><%~ SaveChanges %></button>
 	<button id="reset_button" class="btn btn-warning btn-lg" onclick="resetData()"><%~ Reset %></button>
 </div>
-<span id="update_container"><%~ WaitSettings %></span>
 
 <script>
 <!--

--- a/package/plugin-gargoyle-usb-storage/files/www/templates/usb_storage_template
+++ b/package/plugin-gargoyle-usb-storage/files/www/templates/usb_storage_template
@@ -55,7 +55,7 @@
 			<option value="R/O"><%~ AROn %></option>
 			<option value="R/W"><%~ ARWr %></option>
 		</select>
-		<button class="btn btn-default" id="add_user_access" onclick='addUserAccess()'><%~ Add %></button>
+		<button class="btn btn-default btn-add" id="add_user_access" onclick='addUserAccess()'><%~ Add %></button>
 	</span>
 	<div id="user_access_table_container" class="col-xs-offset-5 col-xs-7"></div>
 </div>
@@ -83,7 +83,7 @@
 <div id="nfs_ip_container" class="row form-group">
 	<span class="col-xs-offset-5 col-xs-7">
 		<input type='text' id='nfs_ip' size='30' onkeyup='proofreadIpRange(this)' class="form-control" />
-		<button class="btn btn-default" id="add_nfs_ip" onclick='addAddressesToTable(document,"nfs_ip","nfs_ip_table_container","nfs_ip_table",false, 2, true, "")'><%~ Add %></button>
+		<button class="btn btn-default btn-add" id="add_nfs_ip" onclick='addAddressesToTable(document,"nfs_ip","nfs_ip_table_container","nfs_ip_table",false, 2, true, "")'><%~ Add %></button>
 	</span>
 	<span class="col-xs-offset-5 col-xs-7"><em><%~ IPSub %></em></span>
 	<div id="nfs_ip_table_container" class="col-xs-offset-5 col-xs-7"></div>

--- a/package/plugin-gargoyle-usb-storage/files/www/usb_storage.sh
+++ b/package/plugin-gargoyle-usb-storage/files/www/usb_storage.sh
@@ -111,7 +111,7 @@
 					<span class="col-xs-7"><input id="user_pass_confirm" class="form-control" type="password"/></span>
 				</div>
 				<div id="user_pass_container" class="row form-group">
-					<span class="col-xs-12"><button id="add_user" class="btn btn-default" onclick="addUser()"><%~ AddU %></button></span>
+					<span class="col-xs-12"><button id="add_user" class="btn btn-default btn-add" onclick="addUser()"><%~ AddU %></button></span>
 				</div>
 
 				<div style="margin-bottom:20px;" class="row form-group">
@@ -125,7 +125,7 @@
 				<div id="sharing_add_controls_container" class="row form-group">
 					<span class="col-xs-12">
 						<%in templates/usb_storage_template %>
-						<button id="add_share_button" class="btn btn-default" onclick="addNewShare()"><%~ ADsk %></button>
+						<button id="add_share_button" class="btn btn-default btn-add" onclick="addNewShare()"><%~ ADsk %></button>
 					</span>
 				</div>
 				<div class="internal_divider"></div>


### PR DESCRIPTION
Since there are currently **~30+** "Add" buttons spread throughout the system (among pages and templates), assigning a common CSS class (i.e. `btn-add`) would make it easier to apply a distinct style and maintain the look & feel consistency through them all. 

This goes in line with the recently added custom CSS classes for common table buttons (e.g. `btn-edit`, `btn-remove`, etc).

## Changelog
- Add common CSS class for all "Add" buttons inside pages and templates
- Fix disabled class not being assigned to QoS "Comment" button
- Minor clean up of unused/outdated HTML code