### PR TITLE
Disable Layer7 Protocol UI elements interaction

### DIFF
--- a/package/gargoyle/files/www/themes/Gargoyle/internal.css
+++ b/package/gargoyle/files/www/themes/Gargoyle/internal.css
@@ -396,6 +396,22 @@ input[type="checkbox"]:enabled + label:hover
 {
 	cursor: pointer;
 }
+/* Disable Controls / Block events  */
+#rule_app_protocol_label,
+#rule_app_protocol_type,
+#exception_app_protocol_label,
+#exception_app_protocol_type,
+#use_app_protocol:enabled,
+#app_protocol_label,
+#app_protocol
+{
+	pointer-events: none;
+	touch-action: none;
+	user-select: none;
+	opacity: 0.5;
+	border-color: #ccc;
+	box-shadow: none;
+}
 #bottom_button_container
 {
 	margin-top: 10px;


### PR DESCRIPTION
Even though it's been extensively advised not to use Layer7 Protocol for now (due to a guaranteed router bootloop), [every now and then someone pops up in the forum reporting/asking for help](https://www.gargoyle-router.com/phpbb/viewtopic.php?f=14&t=11502#p48859) (mostly unaware new users).    

This simple CSS rule could prevent users from accidentally shooting themselves in the foot (bricking their routers), at least for now. Since it's all done via CSS, it shouldn't break any functionality and can be enabled/disabled in a heartbeat, whenever necessary. Works for both Desktop/Mobile versions.

```css
/* Disable Controls / Block events  */
#rule_app_protocol_label,
#rule_app_protocol_type,
#exception_app_protocol_label,
#exception_app_protocol_type,
#use_app_protocol:enabled,
#app_protocol_label,
#app_protocol
{
    pointer-events: none;
    touch-action: none;
    user-select: none;
    opacity: 0.5;
    border-color: #ccc;
    box-shadow: none;
}
```

## QoS Download/Upload
![d19d48e7-8136-4c1c-a04f-387ba4567816](https://user-images.githubusercontent.com/22578839/37181427-b4958bc6-230b-11e8-81da-6b28583bc666.png)
## Restrictions
![e366c22d-2317-4224-afc0-902851cb8e7f](https://user-images.githubusercontent.com/22578839/37181484-f5074c6c-230b-11e8-83fd-af6c9a8acbdc.png)
---
This could also be applied to the "Attempt to Preserve Settings" checkbox option, but since I've seen some people taking the risk and using this option even on big updates (when highly advised not to), I'll just leave as it is.
![fb7cefe0-5679-4ebb-97c0-7021c52b0ac5](https://user-images.githubusercontent.com/22578839/37181665-acd07634-230c-11e8-92b5-874725bbab38.png)
