### PR TITLE
Fix image copy looking in wrong directory + others

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GARGOYLE_VERSION:=1.10.X (Built $(shell echo "`date -u +%Y%m%d-%H%M` git@`git log -1 --pretty=format:%h`"))
+GARGOYLE_VERSION:=1.11.X (Built $(shell echo "`date -u +%Y%m%d-%H%M` git@`git log -1 --pretty=format:%h`"))
 V=99
 FULL_BUILD=false
 CUSTOM_TEMPLATE=ar71xx

--- a/build.sh
+++ b/build.sh
@@ -709,7 +709,7 @@ for target in $targets ; do
 	
 	#copy images to images/target directory
 	mkdir -p "$top_dir/images/$target"
-	arch=$(ls bin)
+	arch=$(ls bin/targets)
 	image_files=$(find "bin/targets/$arch/" 2>/dev/null)
 	if [ ! -e "$targets_dir/$target/profiles/$default_profile/profile_images"  ]  ; then 
 		for imf in $image_files ; do
@@ -802,7 +802,6 @@ for target in $targets ; do
 
 		#copy packages to build/target directory
 		mkdir -p "$top_dir/built/$target/$profile_name"
-		arch=$(ls bin)
 		package_base_dir=$(find bin -name "base")
 		package_files=$(find "$package_base_dir" -name "*.ipk")
 		index_files=$(find "$package_base_dir" -name "Packa*")
@@ -824,6 +823,7 @@ for target in $targets ; do
 
 
 		#copy relevant images for which this profile applies
+		arch=$(ls bin/targets)
 		profile_images=$(cat "$targets_dir/$target/profiles/$profile_name/profile_images" 2>/dev/null)
 		for pi in $profile_images ; do
 			candidates=$(find "bin/targets/$arch/" 2>/dev/null | grep "$pi" )

--- a/package/gargoyle/files/usr/lib/gargoyle/switchinfo.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/switchinfo.sh
@@ -6,17 +6,9 @@
 
 [ -e /sbin/swconfig ] || exit 0
 
-board=""
-if [ -e /lib/ar71xx.sh ]; then
-	. /lib/ar71xx.sh
-	board=$(ar71xx_board_name)
-elif [ -e /lib/mvebu.sh ]; then
-	. /lib/mvebu.sh
-	board=$(mvebu_board_name)
-elif [ -e /lib/ramips.sh ]; then
-	. /lib/ramips.sh
-	board=$(ramips_board_name)
-fi
+target=$(grep "DISTRIB_TARGET" /etc/openwrt_release | sed 's/^.*='\''//' | cut -d\/ -f1)
+. "/lib/$target.sh"
+board=$(cat /tmp/sysinfo/board_name)
 
 # PORTS="LAN1 LAN2 LAN3 LAN4"
 

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -572,7 +572,6 @@ for target in $targets ; do
 
 		#copy packages to build/target directory
 		mkdir -p "$top_dir/built/$target/$profile_name"
-		arch=$(ls bin)
 		package_base_dir=$(find bin -name "base")
 		package_files=$(find "$package_base_dir" -name "*.ipk")
 		index_files=$(find "$package_base_dir" -name "Packa*")
@@ -587,7 +586,7 @@ for target in $targets ; do
 	
 		#copy images to images/target directory
 		mkdir -p "$top_dir/images/$target"
-		arch=$(ls bin)
+		arch=$(ls bin/targets)
 		image_files=$(find "bin/targets/$arch/" 2>/dev/null)
 		if [ ! -e "$targets_dir/$target/profiles/$default_profile/profile_images"  ]  ; then 
 			for imf in $image_files ; do
@@ -682,7 +681,6 @@ for target in $targets ; do
 
 			#copy packages to build/target directory
 			mkdir -p "$top_dir/built/$target/$profile_name"
-			arch=$(ls bin)
 			package_base_dir=$(find bin -name "base")
 			package_files=$(find "$package_base_dir" -name "*.ipk")
 			index_files=$(find "$package_base_dir" -name "Packa*")
@@ -700,6 +698,7 @@ for target in $targets ; do
 			fi
 
 			#copy relevant images for which this profile applies
+			arch=$(ls bin/targets)
 			profile_images=$(cat $targets_dir/$target/profiles/$profile_name/profile_images 2>/dev/null)
 			for pi in $profile_images ; do
 				candidates=$(find "bin/targets/$arch/" 2>/dev/null | grep "$pi" )


### PR DESCRIPTION
Think we need to look in `bin/targets` rather than `bin`.
```bash
$ ls bin
packages\ntargets
```

`find: 'bin/targets/packages\ntargets/': No such file or directory`

Think this still works with multiple profiles being built (have not tried yet)

Fixes 049465778bfe0c88e49665c690f666a28dc224b8 and 263ec07987a05720a857e3238a88f64ce3f9e1d7

---------------------------------
Bump the build number, and fix switchinfo and make it target generic (still need to define the board names for the port numbers)