### PR TITLE
Fix page loading for several pages

### DIFF
--- a/package/gargoyle/files/www/port_forwarding.sh
+++ b/package/gargoyle/files/www/port_forwarding.sh
@@ -6,7 +6,7 @@
 	# itself remain covered by the GPL.
 	# See http://gargoyle-router.com/faq.html#qfoss for more information
 	eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time"  )
-	gargoyle_header_footer -h -s "firewall" -p "portforwarding" -c "internal.css" -j "gs_sortable.js port_forwarding.js table.js" -z "port.js" gargoyle -i firewall network dropbear upnpd
+	gargoyle_header_footer -h -s "firewall" -p "portforwarding" -c "internal.css" -j "gs_sortable.js port_forwarding.js table.js" -z "port.js" -i firewall gargoyle network dropbear upnpd
 %>
 
 <script>

--- a/package/gargoyle/files/www/qos_download.sh
+++ b/package/gargoyle/files/www/qos_download.sh
@@ -6,7 +6,7 @@
 	# itself remain covered by the GPL.
 	# See http://gargoyle-router.com/faq.html#qfoss for more information
 	eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time"  )
-	gargoyle_header_footer -h -s "firewall" -p "qosdownload" -c "internal.css" -j "qos.js table.js" -z "qos.js" qos_gargoyle firewall gargoyle -i qos_gargoyle
+	gargoyle_header_footer -h -s "firewall" -p "qosdownload" -c "internal.css" -j "qos.js table.js" -z "qos.js" -i firewall gargoyle qos_gargoyle
 %>
 
 

--- a/package/gargoyle/files/www/qos_upload.sh
+++ b/package/gargoyle/files/www/qos_upload.sh
@@ -6,7 +6,7 @@
 	# itself remain covered by the GPL.
 	# See http://gargoyle-router.com/faq.html#qfoss for more information
 	eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time"  )
-	gargoyle_header_footer -h -s "firewall" -p "qosupload" -c "internal.css" -j "qos.js table.js" -z "qos.js" qos_gargoyle firewall gargoyle -i qos_gargoyle
+	gargoyle_header_footer -h -s "firewall" -p "qosupload" -c "internal.css" -j "qos.js table.js" -z "qos.js" -i firewall gargoyle qos_gargoyle
 %>
 
 <script>

--- a/package/gargoyle/files/www/wol.sh
+++ b/package/gargoyle/files/www/wol.sh
@@ -6,7 +6,7 @@
 	# itself remain covered by the GPL.
 	# See http://gargoyle-router.com/faq.html#qfoss for more information
 	eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time"  )
-	gargoyle_header_footer -h -s "status" -p "wol" -c "internal.css" -j "wol.js table.js gs_sortable.js" -z "wol.js" gargoyle -i -n dhcp wireless
+	gargoyle_header_footer -h -s "status" -p "wol" -c "internal.css" -j "wol.js table.js gs_sortable.js" -z "wol.js" -n dhcp wireless -i gargoyle
 %>
 
 <script>

--- a/package/gargoyle/files/www/wol.sh
+++ b/package/gargoyle/files/www/wol.sh
@@ -6,7 +6,7 @@
 	# itself remain covered by the GPL.
 	# See http://gargoyle-router.com/faq.html#qfoss for more information
 	eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time"  )
-	gargoyle_header_footer -h -s "status" -p "wol" -c "internal.css" -j "wol.js table.js gs_sortable.js" -z "wol.js" -n dhcp wireless -i gargoyle
+	gargoyle_header_footer -h -s "status" -p "wol" -c "internal.css" -j "wol.js table.js gs_sortable.js" -z "wol.js" -n -i dhcp wireless gargoyle
 %>
 
 <script>

--- a/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
+++ b/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
@@ -6,7 +6,7 @@
 	# itself remain covered by the GPL.
 	# See http://gargoyle-router.com/faq.html#qfoss for more information
 	eval $( gargoyle_session_validator -c "$COOKIE_hash" -e "$COOKIE_exp" -a "$HTTP_USER_AGENT" -i "$REMOTE_ADDR" -r "login.sh" -t $(uci get gargoyle.global.session_timeout) -b "$COOKIE_browser_time"  )
-	gargoyle_header_footer -h -s "connection" -p "openvpn" -c "internal.css" -j "openvpn.js table.js" -z "openvpn.js" openvpn_gargoyle ddns_gargoyle uhttpd dropbear firewall tor gargoyle -i
+	gargoyle_header_footer -h -s "connection" -p "openvpn" -c "internal.css" -j "openvpn.js table.js" -z "openvpn.js" -i openvpn_gargoyle ddns_gargoyle uhttpd dropbear firewall tor gargoyle
 %>
 
 <script>


### PR DESCRIPTION
gargoyle_header_footer -i switch now seems to be location sensitive. Ensure that the list of UCI config files to load is listed last.
Perhaps this was always wrong, and some compiler magic let it slide.