### PR TITLE
Rewrite Switchinfo + Openvpn Updates

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/switchinfo.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/switchinfo.sh
@@ -2,94 +2,63 @@
 
 #
 # (c) 2013 Cezary Jackiewicz, http://eko.one.pl
+# (c) 2018 Michael Gray
 #
 
 [ -e /sbin/swconfig ] || exit 0
+[ -e /usr/share/libubox/jshn.sh ] || exit 0
+[ -e /etc/board.json ] || exit 0
 
-target=$(grep "DISTRIB_TARGET" /etc/openwrt_release | sed 's/^.*='\''//' | cut -d\/ -f1)
-. "/lib/$target.sh"
-board=$(cat /tmp/sysinfo/board_name)
+. /usr/share/libubox/jshn.sh
 
-# PORTS="LAN1 LAN2 LAN3 LAN4"
+# ports.push(["LAN#","STATUS"]);
 
-case "$board" in
-gl-inet)
-	PORTS="1";;
-routerstation-pro)
-	PORTS="4 3 2";;
-tl-mr3220 | \
-tl-mr3420 | \
-tl-wr1043nd | \
-tl-wr741nd | \
-tl-wr841n-v7)
-	PORTS="1 2 3 4";;
-tl-mr3220-v2 | \
-tl-mr3420-v2 | \
-tl-wr741nd-v4 | \
-tl-wr841n-v8)
-	PORTS="2 3 4 1";;
-archer-c5 | \
-archer-c7 | \
-tl-wdr4300)
-	PORTS="2 3 4 5";;
-dir-835-a1 | \
-tl-wdr3500 | \
-tl-wr841n-v9 | \
-tl-wr1043nd-v2 | \
-wndr4300)
-        PORTS="4 3 2 1";;
-armada-xp-linksys-mamba | \
-armada-385-linksys-caiman | \
-armada-385-linksys-cobra | \
-armada-385-linksys-shelby | \
-armada-385-linksys-rango | \
-wndr3700 | \
-wrt160nl | \
-wzr-hp-g300nh)
-	PORTS="3 2 1 0";;
-mpr-a2)
-	PORTS="0";;
-rut5xx)
-	PORTS="3 2 1";;
-px4885 | \
-wt3020)
-	PORTS="4";;
-*)
-	PORTS="";;
-esac
+json_load_file "/etc/board.json"
+json_get_keys BOARDKEYS
+SWITCHTEST=$(echo $BOARDKEYS | grep "switch")
+[ -n "$SWITCHTEST" ] || exit 0
+
+json_select switch
+json_get_keys SWITCHKEYS
+#handle only a single switch for now
+SWITCHID=$(echo $SWITCHKEYS | grep "switch" | cut -d " " -f1)
+[ -n "$SWITCHID" ] || exit 0
+
+json_select $SWITCHID
+json_select ports
+json_get_keys PORTS
+[ -n "$PORTS" ] || exit 0
 
 IFLAN=$(awk '/default_lan_if/ {print $2}' /etc/gargoyle_default_ifs)
 VLAN=$(echo $IFLAN | cut -f2 -d.)
 [ "$VLAN" = "$IFLAN" ] && VLAN=""
 
-counter=0
-for P in $PORTS; do
-	counter=$((counter + 1))
-	[ "$P" = "-1" ] && continue
-	[ -n "$VLAN" ] && {
-		PVID=$(swconfig dev switch0 port $P get pvid)
-		[ "$PVID" != "$VLAN" ] && continue
-	}
-	LINK=$(swconfig dev switch0 port $P get link | cut -f2,3 -d" ")
-	case "$LINK" in
-		"link:down") STATUS="-";;
-		"link:up speed:1000baseT") STATUS="1Gbps";;
-		"link:up speed:100baseT") STATUS="100Mbps";;
-		"link:up speed:10baseT") STATUS="10Mbps";;
-		"1000") STATUS="1Gbps";;
-		"100") STATUS="100Mbps";;
-		"10") STATUS="10Mbps";;
-		"0") STATUS="-";;
-		"1") STATUS=$(i18n conn);;
-		*) STATUS="?";;
-	esac
-	case "$counter" in
-		1) PORT="LAN1";;
-		2) PORT="LAN2";;
-		3) PORT="LAN3";;
-		4) PORT="LAN4";;
-	esac
-	echo "ports.push([\"$PORT\",\"$STATUS\"]);"
+for PORT in $PORTS; do
+	json_select $PORT
+	json_get_var PHYSICAL index
+	json_get_var LOGICAL num
+	json_select ..
+	if [ -n "$PHYSICAL" ] && [ -n "$LOGICAL" ] ; then
+		[ "$P" = "-1" ] && continue
+		[ -n "$VLAN" ] && {
+			PVID=$(swconfig dev $SWITCHID port $LOGICAL get pvid)
+			[ "$PVID" != "$VLAN" ] && continue
+		}
+		LINK=$(swconfig dev switch0 port $LOGICAL get link | cut -f2,3 -d" ")
+		case "$LINK" in
+			"link:down") STATUS="-";;
+			"link:up speed:1000baseT") STATUS="1Gbps";;
+			"link:up speed:100baseT") STATUS="100Mbps";;
+			"link:up speed:10baseT") STATUS="10Mbps";;
+			"1000") STATUS="1Gbps";;
+			"100") STATUS="100Mbps";;
+			"10") STATUS="10Mbps";;
+			"0") STATUS="-";;
+			"1") STATUS=$(i18n conn);;
+			*) STATUS="?";;
+		esac
+		echo "ports.push([\"LAN$PHYSICAL\",\"$STATUS\"]);"
+	fi
 done
 
 exit 0

--- a/package/gargoyle/files/www/js/overview.js
+++ b/package/gargoyle/files/www/js/overview.js
@@ -243,6 +243,8 @@ function resetData()
 		{
 			portsTableData.push( [ ports[idx][0], ports[idx][1] ] );
 		}
+		var tableSortFun = function(a,b){ return a[0] == b[0] ? 0 : (a[0] < b[0] ? -1 : 1); }
+		portsTableData.sort(tableSortFun);
 
 		var portsTable=createTable(portsColumns, portsTableData, 'ports_table', false, false);
 		var tableContainer = document.getElementById('ports_table_container');

--- a/package/plugin-gargoyle-openvpn/files/usr/lib/gargoyle/openvpn.sh
+++ b/package/plugin-gargoyle-openvpn/files/usr/lib/gargoyle/openvpn.sh
@@ -117,17 +117,14 @@ create_server_conf()
 	if [ "$openvpn_protocol" = "tcp" ] ; then openvpn_protocol="tcp-server" ; fi
 
 	openvpn_cipher="$7"
-	if [ -z "$openvpn_cipher" ] ; then openvpn_cipher="BF-CBC" ; fi
-	openvpn_keysize="$8"
-	if [ -z "$openvpn_keysize" ] && [ "$openvpn_cipher" = "BF-CBC" ] ; then openvpn_keysize="128" ; fi
-	if [ -n "$openvpn_keysize" ] ; then openvpn_keysize="keysize               $openvpn_keysize" ; fi
+	if [ -z "$openvpn_cipher" ] ; then openvpn_cipher="AES-256-CBC" ; fi
 
 
-	openvpn_client_to_client=$(load_def "$9" "client-to-client" "false")
-	openvpn_duplicate_cn=$(load_def "${10}" "duplicate-cn" "false")
-	openvpn_pool="${11}"
-	openvpn_redirect_gateway=$(load_def "${12}" "push \"redirect-gateway def1\"" "true")
-	openvpn_regenerate_cert="${13}"
+	openvpn_client_to_client=$(load_def "$8" "client-to-client" "false")
+	openvpn_duplicate_cn=$(load_def "${9}" "duplicate-cn" "false")
+	openvpn_pool="${10}"
+	openvpn_redirect_gateway=$(load_def "${11}" "push \"redirect-gateway def1\"" "true")
+	openvpn_regenerate_cert="${12}"
 
 	if [ -n "$openvpn_pool" ] ; then
 		openvpn_pool="ifconfig-pool $openvpn_pool"
@@ -218,7 +215,6 @@ $openvpn_duplicate_cn
 $openvpn_pool
 
 cipher                $openvpn_cipher
-$openvpn_keysize
 
 dev                   tun
 keepalive             25 180
@@ -282,12 +278,9 @@ create_allowed_client_conf()
 	openvpn_port=$(     awk ' $1 ~ /port/      { print $2 } ' /etc/openvpn/server.conf )
 	openvpn_netmask=$(  awk ' $1 ~ /ifconfig/  { print $3 } ' /etc/openvpn/server.conf )
 	openvpn_cipher=$(   awk ' $1 ~ /cipher/    { print $2 } ' /etc/openvpn/server.conf )
-	openvpn_keysize=$(  awk ' $1 ~ /keysize/   { print $2 } ' /etc/openvpn/server.conf )
 	if [ "$openvpn_protocol" = "tcp-server" ] ; then
 		openvpn_protocol="tcp-client"
 	fi
-	if [ -z "$openvpn_keysize" ] && [ "$openvpn_cipher" = "BF-CBC" ] ; then openvpn_keysize="128" ; fi
-	if [ -n "$openvpn_keysize" ] ; then openvpn_keysize="keysize               $openvpn_keysize" ; fi
 
 	
 	openvpn_regenerate_cert="$6"
@@ -408,7 +401,6 @@ topology        subnet
 verb            3
 
 cipher          $openvpn_cipher
-$openvpn_keysize
 
 ca              ca.crt
 cert            $openvpn_client_id.crt
@@ -641,7 +633,7 @@ regenerate_server_and_allowed_clients_from_uci()
 	. /lib/functions.sh
 	config_load "openvpn_gargoyle"
 	
-	server_vars="internal_ip internal_mask port proto cipher keysize client_to_client duplicate_cn redirect_gateway subnet_access regenerate_credentials subnet_ip subnet_mask pool"
+	server_vars="internal_ip internal_mask port proto cipher client_to_client duplicate_cn redirect_gateway subnet_access regenerate_credentials subnet_ip subnet_mask pool"
 	for var in $server_vars ; do
 		config_get "$var" "server" "$var"
 	done
@@ -655,7 +647,6 @@ regenerate_server_and_allowed_clients_from_uci()
 				"$subnet_mask"             \
 				"$proto"                   \
 				"$cipher"                  \
-				"$keysize"                 \
 				"$client_to_client"        \
 				"$duplicate_cn"            \
 				"$pool"                    \

--- a/package/plugin-gargoyle-openvpn/files/www/js/openvpn.js
+++ b/package/plugin-gargoyle-openvpn/files/www/js/openvpn.js
@@ -168,17 +168,7 @@ function saveChanges()
 
 			
 			var cipher = getSelectedValue(prefix + "cipher")
-			if(cipher.match(/:/))
-			{
-				var cipherParts = cipher.split(/:/)
-				cipher = cipherParts[0]
-				var keysize = cipherParts[1]
-				uci.set("openvpn_gargoyle", "server", "keysize", keysize)
-			}
-			else
-			{
-				uci.remove("openvpn_gargoyle", "server", "keysize")
-			}
+			uci.remove("openvpn_gargoyle", "server", "keysize")	//Leave in to ensure option is removed. Deprecated in Openvpn 2.4
 			uci.set("openvpn_gargoyle", "server", "cipher", cipher);
 		}
 		if(openvpnConfig == "client")
@@ -427,13 +417,10 @@ function resetData()
 
 	
 	var serverCipher  = uciOriginal.get("openvpn_gargoyle", "server", "cipher")
-	var serverKeysize = uciOriginal.get("openvpn_gargoyle", "server", "keysize")
 	if(serverCipher == "")
 	{
 		serverCipher = "AES-256-CBC"
-		serverKeysize = ""
 	}
-	serverCipher = serverKeysize == "" ? serverCipher : serverCipher + ":" + serverKeysize
 
 	setSelectedValue("openvpn_server_protocol", getServerVarWithDefault("proto", "udp"))
 	setSelectedValue("openvpn_server_cipher", serverCipher)
@@ -543,7 +530,6 @@ function updateClientControlsFromConfigText()
 	var port         = null;
 	var proto        = null;
 	var cipher       = null;
-	var keysize      = null;
 	var taDirection = null;
 
 	var portFrom = "undefined";
@@ -580,10 +566,6 @@ function updateClientControlsFromConfigText()
 		{
 			cipher = lineParts[1] != null ? lineParts[1] : cipher;
 		}
-		else if(lineParts[0].toLowerCase() == "keysize")
-		{
-			keysize = lineParts[1] != null ? lineParts[1] : keysize;
-		}
 		else if(lineParts[0].toLowerCase() == "tls-auth")
 		{
 			taDirection = lineParts[2] != null ? lineParts[2] : "";
@@ -604,12 +586,7 @@ function updateClientControlsFromConfigText()
 	}
 	if(cipher != null)
 	{
-		if(cipher == "BF-CBC" && (keysize == "128" || keysize == "256" || keysize == null))
-		{
-			keysize = keysize == null ? "128" : keysize
-			setSelectedValue("openvpn_client_cipher", cipher + ":" + keysize)
-		}
-		else if(cipher == "AES-128-CBC" || cipher == "AES-256-CBC")
+		if(cipher == "AES-128-CBC" || cipher == "AES-256-CBC" || cipher == "AES-128-GCM" || cipher == "AES-256-GCM")
 		{
 			setSelectedValue("openvpn_client_cipher", cipher)
 		}
@@ -617,7 +594,6 @@ function updateClientControlsFromConfigText()
 		{
 			setSelectedValue("openvpn_client_cipher", "other")
 			document.getElementById("openvpn_client_cipher_other").value = cipher
-			document.getElementById("openvpn_client_key_other").value = keysize == null ? "" : keysize
 		}
 	}
 	if(taDirection != null)
@@ -640,13 +616,9 @@ function updateClientConfigTextFromControls()
 	var cipher      = getSelectedValue("openvpn_client_cipher");
 	var taDirection = getSelectedValue("openvpn_client_ta_direction") == "1" ? " 1" : ""
 	
-	var cipherParts = cipher.split(/:/);
-	cipher = cipherParts[0];
-	var keysize = cipherParts[1] == null ? "" : cipherParts[1];
 	if(cipher == "other")
 	{
 		cipher  = document.getElementById("openvpn_client_cipher_other").value;
-	       	keysize = document.getElementById("openvpn_client_cipher_other").value;
 	}
 
 	var configLines = document.getElementById("openvpn_client_conf_text").value.split(/[\r\n]+/);
@@ -672,11 +644,6 @@ function updateClientConfigTextFromControls()
 			line = "cipher " + cipher
 			foundVars["cipher"] = 1
 		}
-		else if(lineParts[0].toLowerCase() == "keysize")
-		{
-			line = keysize == "" ? "" : "keysize " + keysize
-			foundVars["keysize"] = 1
-		}
 		else if(lineParts[0].toLowerCase() == "rport" || lineParts[0].toLowerCase() == "port" )
 		{
 			//specify port in remote line instead of with these directives, so get rid of these lines
@@ -698,10 +665,6 @@ function updateClientConfigTextFromControls()
 		newLines.push(line)
 	}
 
-	if(foundVars["keysize"] == null && keysize != "" && (!(defaultCipher && foundVars["cipher"] == null)) )
-	{
-		newLines.unshift("keysize " + keysize )
-	}
 	if(foundVars["cipher"] == null && (!defaultCipher) )
 	{
 		newLines.unshift("cipher " + cipher);

--- a/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
+++ b/package/plugin-gargoyle-openvpn/files/www/openvpn.sh
@@ -119,10 +119,10 @@
 					<label class="col-xs-5" for='openvpn_server_cipher' id='openvpn_server_cipher_label'><%~ OCiph %>:</label>
 					<span class="col-xs-7">
 						<select class="form-control" id='openvpn_server_cipher'>
-							<option value='BF-CBC:128'>Blowfish-CBC 128bit</option>
-							<option value='BF-CBC:256'>Blowfish-CBC 256bit</option>
 							<option value='AES-128-CBC'>AES-CBC 128bit</option>
 							<option value='AES-256-CBC'>AES-CBC 256bit</option>
+							<option value='AES-128-GCM'>AES-GCM 128bit</option>
+							<option value='AES-256-GCM'>AES-GCM 256bit</option>
 						</select>
 					</span>
 				</div>
@@ -302,7 +302,6 @@
 
 						<div id='openvpn_client_cipher_other_container' class="row form-group">
 							<span class="col-xs-7 col-xs-offset-5"><input type='text' class="form-control" onkeyup="updateClientConfigTextFromControls()" id="openvpn_client_cipher_other" />&nbsp;<em><%~ Cphr %></em></span>
-							<span class="col-xs-7 col-xs-offset-5"><input type='text' class="form-control" onkeyup="updateClientConfigTextFromControls()" id="openvpn_client_key_other" />&nbsp;<em><%~ Keyopt %></em></span>
 						</div>
 
 						<div id='openvpn_client_block_nonovpn_container' class="row form-group">


### PR DESCRIPTION
Rewrite of Switchinfo.sh to be device independent
- Should now support any device with a valid /etc/board.json file with a mapping between the logical and physical ports
- Can support > 4 LAN ports (although >9 may require more cosmetic testing, cross that bridge later)
- Admittedly have only tested on a few devices, but don't foresee any major hassles

Openvpn Updates
- Remove BlowFish ciphers. These have been found to be insecure (see SWEET32 Birthday attacks)
- Remove all references to keysize parameter (was only required with ciphers like BF)
- Set default Cipher to AES-256-CBC (should be used for backwards compatibility concerns with older clients). There is an option to allow outdated clients to negotiate the use of BF ciphers, however i have chosen not to allow this as it is to be completely removed in following updates of OpenVPN
- Add new ciphers AES-128/256-GCM (note that newer clients will negotiate with server and upgrade cipher to AES-256-GCM if capable on both ends)
