### PR TITLE
Update msmtp to 1.6.6. Fixes compile issue on some targets. Bump to 18.06.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ set_version_variables()
 	# set precise commit in repo to use 
 	# you can set this to an alternate commit 
 	# or empty to checkout latest 
-	openwrt_commit="75e4d2d18c0c6a604cc9bf7bce2d6023fcedc78a"
+	openwrt_commit="70255e3d624cd393612069aae0a859d1acbbeeae"
 	openwrt_abbrev_commit=$( echo "$openwrt_commit" | cut -b 1-7 )
 	
 

--- a/build.sh
+++ b/build.sh
@@ -691,9 +691,10 @@ for target in $targets ; do
 		mkdir -p "$top_dir/Distribution/Images/$target-$default_profile"
 	fi
 
-	#copy packages to built/target directory
-	mkdir -p "$top_dir/built/$target/$default_profile"
-	package_base_dir=$(find bin -name "base")
+	#copy packages to build/target directory
+	pkg_arch=$(grep "CONFIG_TARGET_ARCH_PACKAGES" .config | sed 's/^.*="\(.*\)"/\1/g')
+	mkdir -p "$top_dir/built/$target/$profile_name"
+	package_base_dir=$(find "bin/packages/$pkg_arch" -name "base")
 	package_files=$(find "$package_base_dir" -name "*.ipk")
 	index_files=$(find "$package_base_dir" -name "Packa*")
 	if [ -n "$package_files" ] && [ -n "$index_files" ] ; then
@@ -812,8 +813,9 @@ for target in $targets ; do
 		fi
 
 		#copy packages to build/target directory
+		pkg_arch=$(grep "CONFIG_TARGET_ARCH_PACKAGES" .config | sed 's/^.*="\(.*\)"/\1/g')
 		mkdir -p "$top_dir/built/$target/$profile_name"
-		package_base_dir=$(find bin -name "base")
+		package_base_dir=$(find "bin/packages/$pkg_arch" -name "base")
 		package_files=$(find "$package_base_dir" -name "*.ipk")
 		index_files=$(find "$package_base_dir" -name "Packa*")
 		if [ -n "$package_files" ] && [ -n "$index_files" ] ; then

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ set_version_variables()
 	# set precise commit in repo to use 
 	# you can set this to an alternate commit 
 	# or empty to checkout latest 
-	openwrt_commit="70255e3d624cd393612069aae0a859d1acbbeeae"
+	openwrt_commit="55bbd8293c9f6e8f8814e0788df4ee9fb3671a09"
 	openwrt_abbrev_commit=$( echo "$openwrt_commit" | cut -b 1-7 )
 	
 

--- a/build.sh
+++ b/build.sh
@@ -598,7 +598,7 @@ for target in $targets ; do
 	if [ "$target" = "custom" ] ; then
 		if [ ! -d "$openwrt_package_dir" ] ; then
 			
-			git clone https://github.com/openwrt/"$packages_branch".git "$openwrt_package_dir"
+			git clone https://github.com/openwrt/packages.git "$openwrt_package_dir"
 			cd "$openwrt_package_dir"
 			if [ -n "$packages_branch" ] ; then
 				git checkout "$packages_branch"

--- a/build.sh
+++ b/build.sh
@@ -27,13 +27,13 @@ set_version_variables()
 	#openwrt branch
 	branch_name="18.06"
 	branch_id="openwrt-18.06"
-	packages_branch="packages"
+	packages_branch="openwrt-18.06"
 
 
 	# set precise commit in repo to use 
 	# you can set this to an alternate commit 
 	# or empty to checkout latest 
-	openwrt_commit="6c075777d5afdeef7516e5125526b3f2c406f453"
+	openwrt_commit="2a8d8adfb0a9e9a9b84793c1400bef6509c2690b"
 	openwrt_abbrev_commit=$( echo "$openwrt_commit" | cut -b 1-7 )
 	
 

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ set_version_variables()
 	# set precise commit in repo to use 
 	# you can set this to an alternate commit 
 	# or empty to checkout latest 
-	openwrt_commit="2a8d8adfb0a9e9a9b84793c1400bef6509c2690b"
+	openwrt_commit="75e4d2d18c0c6a604cc9bf7bce2d6023fcedc78a"
 	openwrt_abbrev_commit=$( echo "$openwrt_commit" | cut -b 1-7 )
 	
 

--- a/package/gargoyle-firewall-util/files/gargoyle_firewall_util.sh
+++ b/package/gargoyle-firewall-util/files/gargoyle_firewall_util.sh
@@ -620,8 +620,8 @@ isolate_guest_networks()
 
 					#Only allow DHCP/DNS access to router for anyone on guest network
 					ebtables -t filter -A INPUT -i "$lif" -p ARP -j ACCEPT
-					ebtables -t filter -A INPUT -i "$lif" -p IPV4 --ip-protocol UDP --ip-destination-port 53 -j ACCEPT
-					ebtables -t filter -A INPUT -i "$lif" -p IPV4 --ip-protocol UDP --ip-destination-port 67 -j ACCEPT
+					ebtables -t filter -A INPUT -i "$lif" -p IPV4 --ip-protocol udp --ip-destination-port 53 -j ACCEPT
+					ebtables -t filter -A INPUT -i "$lif" -p IPV4 --ip-protocol udp --ip-destination-port 67 -j ACCEPT
 					ebtables -t filter -A INPUT -i "$lif" -p IPV4 --ip-destination $lan_ip -j DROP
 
 				fi

--- a/package/gpkg/files/opkg.gpkg.tmp
+++ b/package/gpkg/files/opkg.gpkg.tmp
@@ -1,8 +1,8 @@
-src/gz %d_%v_base %U/base
-src/gz %d_%v_management %U/management
-src/gz %d_%v_packages %U/packages
-src/gz %d_%v_routing %U/routing
-src/gz %d_%v_telephony %U/telephony
+src/gz %d_%v_base %U/packages/%A/base
+src/gz %d_%v_management %U/packages/%A/management
+src/gz %d_%v_packages %U/packages/%A/packages
+src/gz %d_%v_routing %U/packages/%A/routing
+src/gz %d_%v_telephony %U/packages/%A/telephony
 
 src/gz gargoyle http://www.gargoyle-router.com/packages/gargoyle-%G/%T/%F
 

--- a/package/msmtp/Makefile
+++ b/package/msmtp/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2009 David Cooper <dave@kupesoft.com>
-# Copyright (C) 2009-2015 OpenWrt.org
+# Copyright (C) 2009-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp
-PKG_VERSION:=1.6.2
+PKG_VERSION:=1.6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/msmtp
-PKG_MD5SUM:=3baca93c7e5f1aa9d36a2e5b38739ab9
+PKG_HASH:=da15db1f62bd0201fce5310adb89c86188be91cd745b7cb3b62b81a501e7fb5e
 
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
@@ -26,10 +26,12 @@ PKG_INSTALL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/msmtp/Default
   SECTION:=mail
   CATEGORY:=Mail
+  DEPENDS:=$(INTL_DEPENDS)
   TITLE:=Simple sendmail SMTP forwarding
   URL:=http://msmtp.sourceforge.net/
 endef
@@ -44,7 +46,7 @@ endef
 
 define Package/msmtp
 $(call Package/msmtp/Default)
-  DEPENDS+= +libopenssl
+  DEPENDS+= +libopenssl +ca-bundle
   TITLE+= (with SSL support)
   VARIANT:=ssl
 endef
@@ -69,9 +71,21 @@ $(call Package/msmtp/Default/description)
  This package is built without SSL support.
 endef
 
+define Package/msmtp-mta
+$(call Package/msmtp/Default)
+  TITLE+= (as MTA)
+  DEPENDS+=@(PACKAGE_msmtp||PACAKGE_msmtp-nossl)
+endef
+
+define Package/msmtp-mta/description
+$(call Package/msmtp/Default/description)
+ This package add a link from sendmail to msmtp
+ and is built with SSL support.
+endef
+
 define Package/msmtp-queue
 $(call Package/msmtp/Default)
-  DEPENDS+= +bash
+  DEPENDS+= +bash @(PACKAGE_msmtp||PACKAGE_msmtp-nossl)
   TITLE+= (queue scripts)
 endef
 
@@ -112,23 +126,14 @@ define Package/msmtp/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/msmtp $(1)/usr/bin/
 endef
 
-define Package/msmtp/postinst
-	[ -e $${IPKG_INSTROOT}/usr/sbin/sendmail ] || {
-		mkdir -p $${IPKG_INSTROOT}/usr/sbin
-		ln -sf ../bin/msmtp $${IPKG_INSTROOT}/usr/sbin/sendmail
-	}
-endef
-
-define Package/msmtp/prerm
-	[ "../bin/msmtp" = "$(readlink -qs $${IPKG_INSTROOT}/usr/sbin/sendmail)" ] && {
-		rm -f $${IPKG_INSTROOT}/usr/sbin/sendmail
-	}
+define Package/msmtp-mta/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/lib
+	ln -sf ../bin/msmtp $(1)/usr/sbin/sendmail
+	ln -sf ../bin/msmtp $(1)/usr/lib/sendmail
 endef
 
 Package/msmtp-nossl/conffiles = $(Package/msmtp/conffiles)
 Package/msmtp-nossl/install = $(Package/msmtp/install)
-Package/msmtp-nossl/postinst = $(Package/msmtp/postinst)
-Package/msmtp-nossl/prerm = $(Package/msmtp/prerm)
 
 define Package/msmtp-queue/install
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -139,3 +144,5 @@ endef
 $(eval $(call BuildPackage,msmtp))
 $(eval $(call BuildPackage,msmtp-nossl))
 $(eval $(call BuildPackage,msmtp-queue))
+$(eval $(call BuildPackage,msmtp-mta))
+

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -583,8 +583,9 @@ for target in $targets ; do
 
 
 		#copy packages to build/target directory
+		pkg_arch=$(grep "CONFIG_TARGET_ARCH_PACKAGES" .config | sed 's/^.*="\(.*\)"/\1/g')
 		mkdir -p "$top_dir/built/$target/$profile_name"
-		package_base_dir=$(find bin -name "base")
+		package_base_dir=$(find "bin/packages/$pkg_arch" -name "base")
 		package_files=$(find "$package_base_dir" -name "*.ipk")
 		index_files=$(find "$package_base_dir" -name "Packa*")
 		if [ -n "$package_files" ] && [ -n "$index_files" ] ; then
@@ -704,8 +705,9 @@ for target in $targets ; do
 			fi
 
 			#copy packages to build/target directory
+			pkg_arch=$(grep "CONFIG_TARGET_ARCH_PACKAGES" .config | sed 's/^.*="\(.*\)"/\1/g')
 			mkdir -p "$top_dir/built/$target/$profile_name"
-			package_base_dir=$(find bin -name "base")
+			package_base_dir=$(find "bin/packages/$pkg_arch" -name "base")
 			package_files=$(find "$package_base_dir" -name "*.ipk")
 			index_files=$(find "$package_base_dir" -name "Packa*")
 			if [ -n "$package_files" ] && [ -n "$index_files" ] ; then


### PR DESCRIPTION
- Update msmtp to 1.6.6 to fix some compile issues
- Bump to 18.06.1 release (probably need to bump again to pull in dropbear CVE fix)
- Properly fix gpkg sources for Openwrt repos

Closes #766 