### PR TITLE
Fix restore_quotas (and probably set_bw)

### DIFF
--- a/package/gargoyle-firewall-util/src/restore_quotas.c
+++ b/package/gargoyle-firewall-util/src/restore_quotas.c
@@ -761,7 +761,7 @@ int main(int argc, char** argv)
 			}
 			if(cron_line_found)
 			{
-				fopen(crontab_file_path, "w");
+				crontab_file = fopen(crontab_file_path, "w");
 				for(line_index=0; line_index < num_lines; line_index++)
 				{
 					if(strcmp(cron_lines[line_index], crontab_line) != 0)

--- a/package/libiptbwctl/src/ipt_bwctl.c
+++ b/package/libiptbwctl/src/ipt_bwctl.c
@@ -1018,12 +1018,13 @@ ip_bw* load_usage_from_file(char* in_file_path, unsigned long* num_ips, time_t* 
 		{
 			ip_bw next;
 			struct in_addr ipaddr;
-			int valid = inet_aton(data_parts[data_part_index], &ipaddr);
-			if(!valid)
+			if(data_part_index == 0)
 			{
 				sscanf(data_parts[data_part_index], "%ld", last_backup);
 				//printf("last_backup = %ld\n", *last_backup);
+				data_part_index++;
 			}
+			int valid = inet_aton(data_parts[data_part_index], &ipaddr);
 			data_part_index++;
 
 			if(valid && data_index < num_data_parts)


### PR DESCRIPTION
This seems to have been broken since the dawn of time? The epoch timestring at the beginning of all files read by this function are (unexpectedly) interpetted as valid ip addrs, and so the last backup is never stored. The index also always appears to have been off by 1, and was leading to a segfault as the array went out of bounds.
Make an assumption that the first part of the file is ALWAYS a timestring, and fix the index issue