### PR TITLE
Fix node.js versin variable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -344,7 +344,7 @@ if [ "$js_compress" = "true" ] || [ "$js_compress" = "TRUE" ] || [ "$js_compress
 			cd "$top_dir"
 			git clone git://github.com/nodejs/node.git
 			cd node
-			git checkout "$node_tag"
+			git checkout "$node_version_tag"
 			./configure 
 			make
 			mkdir bin

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -335,7 +335,7 @@ if [ "$js_compress" = "true" ] || [ "$js_compress" = "TRUE" ] || [ "$js_compress
 			cd "$top_dir"
 			git clone git://github.com/nodejs/node.git
 			cd node
-			git checkout "$node_tag"
+			git checkout "$node_version_tag"
 			./configure 
 			make
 			mkdir bin


### PR DESCRIPTION
I'm not sure, but I think the variable $node_tag should be replaced with $node_version_tag.