### PR TITLE
preserve timestamp while copying gargoyle packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -543,7 +543,7 @@ for target in $targets ; do
 			fi
 		done
 		IFS="$IFS_ORIG"
-		cp -r "$package_dir/$gp" "$target-src/package"
+		cp -pr "$package_dir/$gp" "$target-src/package"
 	done
 
 

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -491,7 +491,7 @@ for target in $targets ; do
 				fi
 			done
 			IFS="$IFS_ORIG"
-			cp -r "$package_dir/$gp" "$target-src/package"
+			cp -pr "$package_dir/$gp" "$target-src/package"
 		done
 	
 


### PR DESCRIPTION
This patch avoids rebuliding of copied gargoyle packages while rebulding and saves time [ PS: I'm new to this and correct me if I'm wrong ]