### PR TITLE
Handle devices with wan_dev network section

### DIFF
--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -25,6 +25,8 @@ var onDns  = [ "66.244.95.20", "95.211.32.162", "95.142.171.235" ]
 var ncTlds = [ ".bit" ];
 var onTlds = [ ".glue", ".parody", ".dyn", ".bbs", ".free", ".fur", ".geek", ".gopher", ".indy", ".ing", ".null", ".oss", ".micro" ];
 
+var wanMacLoc = "wan";
+
 function saveChanges()
 {
 	errorList = proofreadAll();
@@ -530,7 +532,13 @@ function saveChanges()
 					visibilityIds.push(inputIds[idIndex]+ "_container");
 				}
 
-				if(idIndex < 10 || idIndex > 28)
+				if(idIndex == 8)
+				{
+					pkgs.push('network');
+					sections.push(wanMacLoc);
+					uci.remove('network', wanMacLoc, options[idIndex]);
+				}
+				else if(idIndex < 10 || idIndex > 28)
 				{
 					pkgs.push('network');
 					sections.push('wan');
@@ -1533,6 +1541,7 @@ function localdate(ldate)
 
 function resetData()
 {
+	wanMacLoc = uciOriginal.get("network","wan_dev","macaddr") != "" ? "wan_dev" : wanMacLoc;
 	var removeChannels = [];
 	var hwAmode = "disabled";
 	var hwGmode = "disabled";
@@ -1656,9 +1665,9 @@ function resetData()
 		wanIsWireless = uciOriginal.get("network", "wan", "ifname") == wirelessIfs[wifIndex];
 	}
 
-	if(isBcm94704 && (!wanIsWireless) && uciOriginal.get("network", "wan", "macaddr") != "")
+	if(isBcm94704 && (!wanIsWireless) && uciOriginal.get("network", wanMacLoc, "macaddr") != "")
 	{
-		var currentMac = uciOriginal.get("network", "wan", "macaddr").toUpperCase();
+		var currentMac = uciOriginal.get("network", wanMacLoc, "macaddr").toUpperCase();
 		var currentStart = currentMac.substr(0, 15);
 		var currentEnd = currentMac.substr(15, 2);
 		var lanMacIndex=0;
@@ -1703,7 +1712,7 @@ function resetData()
 		networkPkgs.push('network');
 	}
 
-	networkSections = ['wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'lan', 'lan', 'lan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan'];
+	networkSections = ['wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', wanMacLoc, wanMacLoc, 'wan', 'wan', 'lan', 'lan', 'lan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan', 'wan'];
 	networkOptions  = ['username', 'password', 'demand', 'keepalive', 'keepalive', 'ipaddr', 'netmask', 'gateway', 'macaddr','macaddr', 'mtu', 'mtu', 'ipaddr', 'netmask', 'gateway', 'device', 'username', 'password', 'apn', 'pincode', 'service', 'mobile_isp'];
 
 	pppoeDemandParams = [5*60,1/60];

--- a/package/gargoyle/src/gargoyle_header_footer.c
+++ b/package/gargoyle/src/gargoyle_header_footer.c
@@ -944,6 +944,10 @@ void print_interface_vars(void)
                 {
                         uci_wan_mac=get_option_value_string(uci_to_option(e));
                 }
+                else if(get_uci_option(ctx, &e, p, "network", "wan_dev", "macaddr") == UCI_OK)
+                {
+                        uci_wan_mac=get_option_value_string(uci_to_option(e));
+                }
                 if(get_uci_option(ctx, &e, p, "network", "wan", "ifname") == UCI_OK)
                 {
                         uci_wan_if = get_option_value_string(uci_to_option(e));


### PR DESCRIPTION
@obsy can you please check this solution.
Reference:
>Add to list: on some platform default mac addresses extracted from eeprom are stored in wan_dev/lan_dev section, not wan/lan itself. "Use Custom MAC Address:" should set mac in wan_dev section (if exists).
```
network.lan=interface
network.lan.type='bridge'
network.lan.ifname='eth0.1'
network.lan.proto='static'
network.lan.ipaddr='192.168.1.1'
network.lan.netmask='255.255.255.0'
network.lan.ip6assign='60'
network.lan_dev=device
network.lan_dev.name='eth0.1'
network.lan_dev.macaddr='d4:6e:0e:d0:49:68'
network.wan_dev=device
network.wan_dev.name='eth0.2'
network.wan_dev.macaddr='d4:6e:0e:d0:49:69'
```

Couple of things i'm not sure on, and would be good if you could test/confirm:
1. Is it necessary to delete `wan_dev` sections if we delete the main `wan` section. E.g. lines [154](https://github.com/ericpaulbishop/gargoyle/blob/master/package/gargoyle/files/www/js/basic.js#L154) and [160](https://github.com/ericpaulbishop/gargoyle/blob/master/package/gargoyle/files/www/js/basic.js#L160) (and others). If the `wan_dev` section causes no issues when it is present, then we will leave it. Definitely concerned about the implications when using wireless or usb protocols for wan
2. I think `gargoyle_header_footer` also needs updating (line [945](https://github.com/ericpaulbishop/gargoyle/blob/master/package/gargoyle/src/gargoyle_header_footer.c#L945)) although it will usually work without it anyway as the mac is sourced directly from the interface. But would be good to add as an extra check. Can you please confirm it works ok as it is, and your opinion on whether it should be modified (i think yes)?
3. I've done nothing with `lan_dev`. Do you foresee anytime we need to do this?