### PR TITLE
escape dollar sign

### DIFF
--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -2471,7 +2471,7 @@ function confirmPassword(confirmText, validatedFunc, invalidFunc)
 				{
 					setControlsEnabled(false, true, UI.VPass);
 
-					var commands = "gargoyle_session_validator -p \"" + confirmWindow.document.getElementById("password").value + "\" -a \"dummy.browser\" -i \"127.0.0.1\""
+					var commands = "gargoyle_session_validator -p \"" + (confirmWindow.document.getElementById("password").value)..replace('$','\\$') + "\" -a \"dummy.browser\" -i \"127.0.0.1\""
 					var param = getParameterDefinition("commands", commands) + "&" + getParameterDefinition("hash", document.cookie.replace(/^.*hash=/,"").replace(/[\t ;]+.*$/, ""));
 					var stateChangeFunction = function(req)
 					{

--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -2471,7 +2471,7 @@ function confirmPassword(confirmText, validatedFunc, invalidFunc)
 				{
 					setControlsEnabled(false, true, UI.VPass);
 
-					var commands = "gargoyle_session_validator -p \"" + (confirmWindow.document.getElementById("password").value)..replace('$','\\$') + "\" -a \"dummy.browser\" -i \"127.0.0.1\""
+					var commands = "gargoyle_session_validator -p \"" + (confirmWindow.document.getElementById("password").value).replace('$','\\$') + "\" -a \"dummy.browser\" -i \"127.0.0.1\""
 					var param = getParameterDefinition("commands", commands) + "&" + getParameterDefinition("hash", document.cookie.replace(/^.*hash=/,"").replace(/[\t ;]+.*$/, ""));
 					var stateChangeFunction = function(req)
 					{

--- a/package/gargoyle/files/www/password_confirm.sh
+++ b/package/gargoyle/files/www/password_confirm.sh
@@ -9,7 +9,6 @@
 	gargoyle_header_footer -m -c "common.css"
 %>
 
-<h1 class="page-header">Password</h1>
 <div id="edit_container" class="row">
 	<div class="col-lg-6">
 		<div class="panel panel-default">


### PR DESCRIPTION
for password with dollar sign (like abc123'$ABC).

```
root@Gargoyle:~# gargoyle_session_validator -p "abc123'$ABC" -a "dummy.browser" -i "127.0.0.1"
echo "invalid" ;exit
root@Gargoyle:~# gargoyle_session_validator -p "abc123'\$ABC" -a "dummy.browser" -i "127.0.0.1"
echo "Set-Cookie:hash=76458A6F6D703A7B227E9A79CDBD20E85BAB8C4D3EB2A332EA28AEE04B717B66; Path=/;"; echo "Set-Cookie:exp=1552322477; Path=/;";
```