### PR TITLE
Update set_kernel_timezone to fix intermittent fails

### DIFF
--- a/package/libiptbwctl/src/ipt_bwctl.c
+++ b/package/libiptbwctl/src/ipt_bwctl.c
@@ -1332,18 +1332,17 @@ int get_minutes_west(time_t now)
 void set_kernel_timezone(void)
 {
 	time_t now;
-	struct timeval tv;
-	struct timezone old_tz;
-	struct timezone new_tz;
+	struct timezone tz;
+
+	/* Workaround warp_clock on first invocation */
+	memset(&tz, 0, sizeof(tz));
+	syscall(SYS_settimeofday, NULL, &tz);
+	memset(&tz, 0, sizeof(tz));
 
 	time(&now);
-	new_tz.tz_minuteswest = get_minutes_west(now);
-	new_tz.tz_dsttime = 0;
-
-	/* Get tv to pass to settimeofday(2) to be sure we avoid hour-sized warp */
-	/* (see gettimeofday(2) man page, or /usr/src/linux/kernel/time.c) */
-	gettimeofday(&tv, &old_tz);
+	tz.tz_minuteswest = get_minutes_west(now);
+	tz.tz_dsttime = 0;
 
 	/* set timezone */
-	settimeofday(&tv, &new_tz);
+	syscall(SYS_settimeofday, NULL, &tz);
 }

--- a/package/libiptbwctl/src/ipt_bwctl.h
+++ b/package/libiptbwctl/src/ipt_bwctl.h
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <sys/sem.h> 
 #include <sys/time.h>
+#include <sys/syscall.h>
 #define BANDWIDTH_QUERY_LENGTH		16384
 
 /* socket id parameters (for userspace i/o) */


### PR DESCRIPTION
Sometimes set_kernel_timezone doesn't seem to actually do anything... this was raised in the forum here:
https://www.gargoyle-router.com/phpbb/viewtopic.php?f=6&t=11955

A test scenario which produces the bug (most of the time...) was raised here:
https://www.gargoyle-router.com/phpbb/viewtopic.php?f=6&t=11955&start=10#p52776

This fix seems to make set_kernel_timezone more reliable. I can't pick why or how though, so am cautious of including it into the code without more user testing.

@ericpaulbishop , i'd appreciate an opinion on this one if you've got some time please.