### PR TITLE
Update git repo address for obfsproxy

### DIFF
--- a/package/obfsproxy/Makefile
+++ b/package/obfsproxy/Makefile
@@ -10,7 +10,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/obfsproxy-legacy
 PKG_FIXUP:=autoreconf
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://git.torproject.org/pluggable-transports/obfsproxy-legacy.git
+PKG_SOURCE_URL:=https://github.com/isislovecruft/obfsproxy-legacy.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=obfsproxy-0.1.4
 PKG_SOURCE_SUBDIR:=obfsproxy-legacy


### PR DESCRIPTION
Update the git repo address for obfpsproxy-legacy since the
previous location does not exists anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ericpaulbishop/gargoyle/824)
<!-- Reviewable:end -->
