### PR TITLE
Fix: switch section search

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/switchinfo.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/switchinfo.sh
@@ -15,7 +15,7 @@
 
 json_load_file "/etc/board.json"
 json_get_keys BOARDKEYS
-SWITCHTEST=$(echo $BOARDKEYS | grep "switch")
+SWITCHTEST=$(echo $BOARDKEYS | grep "\"switch\":")
 [ -n "$SWITCHTEST" ] || exit 0
 
 json_select switch


### PR DESCRIPTION
Some devices do not have "switch" section, but have "gpioswitch" section, ex Mikrotik 912:
```
{
	"model": {
		"id": "rb-912uag-2hpnd",
		"name": "Mikrotik RouterBOARD 912UAG-2HPnD"
	},
	"network": {
		"lan": {
			"ifname": "eth0",
			"protocol": "static"
		}
	},
	"gpioswitch": {
		"usb_power_switch": {
			"name": "USB Power Switch",
			"pin": 61,
			"default": 1
		}
	}
}
```
This causes incorrect switch detection and errors like:
```

WARNING: Variable 'switch' does not exist or is not an array/object
WARNING: Variable 'ports' does not exist or is not an array/object
WARNING: Variable 'id' does not exist or is not an array/object
WARNING: Variable 'name' does not exist or is not an array/object

```
Fix this by explicitly searching for the "switch" section.