### PR TITLE
Fix custom ntp servers order not being respected

### DIFF
--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -548,12 +548,10 @@ function UCIContainer()
 				var matches = oldValue.length == newValue.length;
 				if(matches)
 				{
-					var sortedOld = oldValue.sort()
-					var sortedNew = newValue.sort()
-					var sortedIndex;
-					for(sortedIndex=0; matches && sortedIndex <sortedOld.length; sortedIndex++)
+					var matchIndex;
+					for(matchIndex=0; matches && matchIndex < oldValue.length; matchIndex++)
 					{
-						matches = sortedOld[sortedIndex] == sortedNew[sortedIndex] ? true : false
+						matches = oldValue[matchIndex] == newValue[matchIndex] ? true : false
 					}
 				}
 				if(matches)

--- a/package/gargoyle/files/www/js/time.js
+++ b/package/gargoyle/files/www/js/time.js
@@ -201,7 +201,8 @@ function resetData()
 	{
 		for(serverIndex=tzServers.length; serverIndex < 3; serverIndex++)
 		{
-			document.getElementById("server" + (1+sectionIndex)).value = (2-serverIndex) + ".pool.ntp.org"
+			document.getElementById("server" + (1+sectionIndex)).value = (serverIndex) + ".pool.ntp.org";
+			sectionIndex += 1;
 		}
 	}
 
@@ -238,7 +239,7 @@ function updateServerList()
 		}
 		else
 		{
-			var regionServer = ((3-serverIndex) + "." + region + ".pool.ntp.org").replace(/\.global\./, ".")
+			var regionServer = ((serverIndex-1) + "." + region + ".pool.ntp.org").replace(/\.global\./, ".")
 			setElementEnabled( document.getElementById("server" + serverIndex), false, regionServer);
 		}
 	}


### PR DESCRIPTION
While checking if the previous list value matched the new one, the variables were being mutated and the sort operation was applying to the original variables, resulting in ordered lists every time.
This is not always helpful behaviour.
Change the behaviour to create unordered lists, and if we want them ordered it is up to us to order them before creating the list.