### PR TITLE
Fix password validation and revelation.

### DIFF
--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -342,7 +342,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_encryption_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_encryption" id="bridge_encryption_label"><%~ Encr %>:</label>
 					<span class="col-xs-7">
-						<select id="bridge_encryption" class="form-control" onchange="setBridgeVisibility()">
+						<select id="bridge_encryption" class="form-control" onchange="setBridgeVisibility(); proofreadPass('bridge_pass', this)">
 							<option value="none"><%~ None %></option>
 							<option value="psk2">WPA2 PSK</option>
 							<option value="psk">WPA PSK</option>
@@ -359,8 +359,8 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_pass_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_pass" id="bridge_pass_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7">
-						<input type="password" id="bridge_pass" class="form-control" size="20" onkeyup="proofreadLengthRange(this,8,999)"/>
-						<input type="checkbox" id="show_bridge_pass" onclick="togglePass('bridge_pass')" />
+						<input type="password" id="bridge_pass" class="form-control" size="20" onkeyup="proofreadPass(this, 'bridge_encryption')"/>
+						<input type="checkbox" id="show_bridge_pass" onclick="togglePass('bridge_pass')" autocomplete="off"/>
 						<label for="show_bridge_pass" id="show_bridge_pass_label"><%~ rvel %></label>
 					</span>
 				</div>
@@ -872,7 +872,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_encryption2_container" class="row indent">
 					<label class="col-xs-5" for="wifi_encryption2" id="wifi_encryption2_label"><%~ Encr %>:</label>
 					<span class="col-xs-7">
-						<select class="form-control" id="wifi_encryption2" onchange="setWifiVisibility()">
+						<select class="form-control" id="wifi_encryption2" onchange="setWifiVisibility(); proofreadPass('wifi_pass2', this)">
 							<option value="none"><%~ None %></option>
 							<option value="psk2">WPA2 PSK</option>
 							<option value="psk">WPA PSK</option>
@@ -889,8 +889,8 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_pass2_container" class="row indent">
 					<label class="col-xs-5" for="wifi_pass2" id="wifi_pass2_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7">
-						<input type="password" id="wifi_pass2" class="form-control" size="20" onkeyup="proofreadLengthRange(this,8,999)"/>&nbsp;&nbsp;
-						<input type="checkbox" id="show_pass2" onclick="togglePass('wifi_pass2')"/>
+						<input type="password" id="wifi_pass2" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_encryption2')"/>&nbsp;&nbsp;
+						<input type="checkbox" id="show_pass2" onclick="togglePass('wifi_pass2')" autocomplete="off"/>
 						<label for="show_pass2" id="show_pass2_label"><%~ rvel %></label><br/>
 					</span>
 				</div>
@@ -957,7 +957,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_encryption1_container" class="row indent">
 					<label class="col-xs-5" for="wifi_encryption1" id="wifi_encryption1_label"><%~ Encr %>:</label>
 					<span class="col-xs-7" >
-						<select id="wifi_encryption1" class="form-control" onchange="setWifiVisibility()">
+						<select id="wifi_encryption1" class="form-control" onchange="setWifiVisibility(); proofreadPass('wifi_pass1', this)">
 							<option value="none"><%~ None %></option>
 							<option value="psk2">WPA2 PSK</option>
 							<option value="psk">WPA PSK</option>
@@ -971,8 +971,8 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_pass1_container" class="row indent">
 					<label class="col-xs-5" for="wifi_pass1" id="wifi_pass1_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7" >
-						<input type="password" id="wifi_pass1" class="form-control" size="20" onkeyup="proofreadLengthRange(this,8,999)"/>&nbsp;&nbsp;
-						<input type="checkbox" id="show_pass1" onclick="togglePass('wifi_pass1')"/>
+						<input type="password" id="wifi_pass1" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_encryption1')"/>&nbsp;&nbsp;
+						<input type="checkbox" id="show_pass1" onclick="togglePass('wifi_pass1')" autocomplete="off"/>
 						<label for="show_pass1" id="show_pass1_label"><%~ rvel %></label><br/>
 					</span>
 				</div>
@@ -1069,7 +1069,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<div id="wifi_guest_encryption1_container" class="row indent">
 						<label class="col-xs-5" for="wifi_guest_encryption1" id="wifi_guest_encryption1_label"><%~ Encr %>:</label>
 						<span class="col-xs-7">
-							<select class="form-control" id="wifi_guest_encryption1" onchange="setWifiVisibility()">
+							<select class="form-control" id="wifi_guest_encryption1" onchange="setWifiVisibility(); proofreadPass('wifi_guest_pass1', this)">
 								<option value="none"><%~ None %></option>
 								<option value="psk2">WPA2 PSK</option>
 								<option value="psk">WPA PSK</option>
@@ -1081,8 +1081,8 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<div id="wifi_guest_pass1_container" class="row indent">
 						<label class="col-xs-5" for="wifi_guest_pass1" id="wifi_guest_pass1_label"><%~ Pswd %>:</label>
 						<span class="col-xs-7">
-							<input type="password" id="wifi_guest_pass1" class="form-control" size="20" onkeyup="proofreadLengthRange(this,8,999)"/>&nbsp;&nbsp;
-							<input type="checkbox" id="show_guest_pass1" onclick="togglePass('wifi_guest_pass1')"/>
+							<input type="password" id="wifi_guest_pass1" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_guest_encryption1')"/>&nbsp;&nbsp;
+							<input type="checkbox" id="show_guest_pass1" onclick="togglePass('wifi_guest_pass1')" autocomplete="off"/>
 							<label for="show_guest_pass1" id="show_guest_pass1_label"><%~ rvel %></label><br/>
 						</span>
 					</div>

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -1055,12 +1055,15 @@ function setToWepKey(id, length)
 function proofreadAll()
 {
 	var vlr1 = function(text){return validateLengthRange(text,1,999);};
-	var vlr8 = function(text){return validateLengthRange(text,8,999);};
 	var vip = validateIP;
 	var vnm = validateNetMask;
 	var vm = validateMac;
 	var vn = validateNumeric;
 	var vw = validateWep;
+	var vp = function(text){ return validatePass(text, 'wifi_encryption1'); }
+	var vpg = function(text){ return validatePass(text, 'wifi_guest_encryption1'); }
+	var vp2 = function(text){ return validatePass(text, 'wifi_encryption2'); }
+	var vpb = function(text){ return validatePass(text, 'bridge_encryption'); }
 	var vtp = function(text){ return validateNumericRange(text, 0, getMaxTxPower("G")); };
 	var vtpa = function(text){ return validateNumericRange(text, 0, getMaxTxPower("A")); };
 
@@ -1080,7 +1083,7 @@ function proofreadAll()
 	{
 		var inputIds = ['wan_pppoe_user', 'wan_pppoe_pass', 'wan_pppoe_max_idle', 'wan_pppoe_reconnect_pings', 'wan_pppoe_interval', 'wan_static_ip', 'wan_static_mask', 'wan_static_gateway', 'wan_mac', 'wan_mtu', 'lan_ip', 'lan_mask', 'lan_gateway', 'wifi_txpower', 'wifi_txpower_5ghz', 'wifi_ssid1', 'wifi_pass1', 'wifi_wep1', 'wifi_guest_pass1', 'wifi_guest_wep1', 'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_pass2', 'wifi_wep2', 'wan_3g_device', 'wan_3g_apn'];
 
-		var functions= [vlr1, vlr1, vn, vn, vn, vip, vnm, vip, vm, vn, vip, vnm, vip, vtp, vtpa, vlr1, vlr8, vw, vlr8, vw, vip, vn, vlr1, vlr8, vw, vlr1, vlr1];
+		var functions= [vlr1, vlr1, vn, vn, vn, vip, vnm, vip, vm, vn, vip, vnm, vip, vtp, vtpa, vlr1, vp, vw, vpg, vw, vip, vn, vlr1, vp2, vw, vlr1, vlr1];
 
 		var optInputIds = ['wifi_ssid1a', 'wifi_guest_ssid1', 'wifi_guest_ssid1a']
 		for(index in optInputIds)
@@ -1117,7 +1120,7 @@ function proofreadAll()
 	else
 	{
 		var inputIds = ['bridge_ip', 'bridge_mask', 'bridge_gateway', 'bridge_txpower', 'bridge_ssid', 'bridge_pass', 'bridge_wep', 'bridge_broadcast_ssid'];
-		var functions = [vip, vnm, vip, vtp, vlr1,vlr8,vw,vlr1];
+		var functions = [vip, vnm, vip, vtp, vlr1,vpb,vw,vlr1];
 		var returnCodes=[];
 		var visibilityIds=[];
 		var labelIds=[];
@@ -2291,6 +2294,24 @@ function proofreadWep(input)
 	proofreadText(input, validateWep, 0);
 }
 
+function validatePass(text, encryption)
+{
+	if(getSelectedValue(encryption).match(/psk/))
+	{
+		return validateLengthRange(text, 8, 63) == 0 || (text.length == 64 && validateHex(text) == 0) ? 0 : 1;
+	}
+	else
+	{
+		return validateLengthRange(text, 8, 999);
+	}
+}
+
+function proofreadPass(input, encryption)
+{
+	input = typeof input === 'string' ? document.getElementById(input) : input;
+	encryption = typeof encryption === 'string' ? encryption : encryption.id;
+	proofreadText(input, function(text){return validatePass(text, encryption);}, 0);
+}
 
 function addTextToSingleColumnTable(textId, tableContainerId, validator, preprocessor, validReturn, duplicatesAllowed, columnName)
 {


### PR DESCRIPTION
The Wi-Fi password field is used for both encryption methods PSK(2) and WPA(2) RADIUS. Currently only its length is checked (`8 <= len <= 999`). This is fine for RADIUS but not for PSK. Using a 64-character password with non-hex characters will cause hostapd to fail and the webpage to hang.

Also a `reveal` checkbox can be inverted by checking it and then reloading the page. Due to browser's auto-completion, the checkbox will be checked again but the `togglePass` function is not aware of this, inverting the behavior of the checkbox. 

Changes:

  * When PSK is selected, validate against `8 <= len <= 63 || (len == 64 && is_hex)`.
  * Revalidate when encryption method is changed (RADIUS secret can be become PSK).
  * Add `autocomplete="off"` to `reveal` checkboxes.
