### PR TITLE
Improve autocomplete and proofread.

### DIFF
--- a/package/gargoyle/files/www/access.sh
+++ b/package/gargoyle/files/www/access.sh
@@ -75,12 +75,12 @@
 				<div>
 					<div id="local_http_port_container" class="row form-group">
 						<label class="col-xs-5" for="local_http_port" id="local_http_port_label"><%~ LocalPort %>:</label>
-						<span class="col-xs-7"><input type="text" class="form-control" id="local_http_port" size="7" maxlength="5" onkeyup="proofreadNumericRange(this,1,65535)"/></span>
+						<span class="col-xs-7"><input type="text" class="form-control" id="local_http_port" size="7" maxlength="5" oninput="proofreadNumericRange(this,1,65535)"/></span>
 					</div>
 
 					<div id="local_https_port_container" class="row form-group">
 						<label class="col-xs-5" for="local_https_port" id="local_https_port_label"><%~ Local_S_Port %>:</label>
-						<span class="col-xs-7"><input type="text" class="form-control" id="local_https_port" size="7" maxlength="5" onkeyup="proofreadNumericRange(this,1,65535)"/></span>
+						<span class="col-xs-7"><input type="text" class="form-control" id="local_https_port" size="7" maxlength="5" oninput="proofreadNumericRange(this,1,65535)"/></span>
 					</div>
 				</div>
 
@@ -99,12 +99,12 @@
 				<div id="remote_web_ports_container">
 					<div id="remote_http_port_container" class="row form-group">
 						<label class="col-xs-5" for="remote_http_port" id="remote_http_port_label"><%~ RemotePort %>:</label>
-						<span class="col-xs-7"><input type="text" class="form-control" id="remote_http_port" size="7" maxlength="5" onkeyup="proofreadNumericRange(this,1,65535)"/></span>
+						<span class="col-xs-7"><input type="text" class="form-control" id="remote_http_port" size="7" maxlength="5" oninput="proofreadNumericRange(this,1,65535)"/></span>
 					</div>
 
 					<div id="remote_https_port_container" class="row form-group">
 						<label class="col-xs-5" for="remote_https_port" id="remote_https_port_label"><%~ Remote_S_Port %>:</label>
-						<span class="col-xs-7"><input type="text" class="form-control" id="remote_https_port" size="7" maxlength="5" onkeyup="proofreadNumericRange(this,1,65535)"/></span>
+						<span class="col-xs-7"><input type="text" class="form-control" id="remote_https_port" size="7" maxlength="5" oninput="proofreadNumericRange(this,1,65535)"/></span>
 					</div>
 				</div>
 
@@ -142,7 +142,7 @@
 
 				<div class="row form-group">
 					<label class="col-xs-5" for="local_ssh_port" id="local_ssh_port_label"><%~ LocalSSHPort %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" id="local_ssh_port" size="7" maxlength="5" onkeyup="proofreadNumericRange(this,1,65535)"/></span>
+					<span class="col-xs-7"><input type="text" class="form-control" id="local_ssh_port" size="7" maxlength="5" oninput="proofreadNumericRange(this,1,65535)"/></span>
 				</div>
 
 				<div class="row form-group" id="remote_ssh_enabled_container">
@@ -154,7 +154,7 @@
 
 				<div class="row form-group" id="remote_ssh_port_container">
 					<label class="col-xs-5" for="remote_ssh_port" id="remote_ssh_port_label"><%~ RemoteSSHPort %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" id="remote_ssh_port"  size="7" maxlength="5" onkeyup="proofreadNumericRange(this,1,65535)"/></span>
+					<span class="col-xs-7"><input type="text" class="form-control" id="remote_ssh_port"  size="7" maxlength="5" oninput="proofreadNumericRange(this,1,65535)"/></span>
 				</div>
 
 				<div class="row form-group" id="remote_ssh_attempts_container">

--- a/package/gargoyle/files/www/access.sh
+++ b/package/gargoyle/files/www/access.sh
@@ -44,12 +44,12 @@
 			<div class="panel-body">
 			<div class="row form-group">
 				<label class="col-xs-5" for="password1" id="password1_label"><%~ NewPass %>:</label>
-				<span class="col-xs-7"><input type="password" class="form-control" id="password1" size="25"/></span>
+				<span class="col-xs-7"><input type="password" class="form-control" id="password1" size="25" autocomplete="new-password"/></span>
 			</div>
 
 			<div class="row form-group">
 				<label class="col-xs-5" for="password2" id="password2_label"><%~ ConfirmPass %>:</label>
-				<span class="col-xs-7"><input type="password" class="form-control" id="password2" size="25"/></span>
+				<span class="col-xs-7"><input type="password" class="form-control" id="password2" size="25" autocomplete="new-password"/></span>
 			</div>
 			</div>
 		</div>

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -136,7 +136,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_ip_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_ip" id="bridge_ip_label"><%~ BrIP %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" name="bridge_ip" id="bridge_ip" onkeyup="proofreadIp(this)" size="20" maxlength="15" />
+						<input type="text" class="form-control" name="bridge_ip" id="bridge_ip" oninput="proofreadIp(this)" size="20" maxlength="15" />
 						<em id="bridge_note"><%~ BrNoteClient %></em>
 					</span>
 				</div>
@@ -144,14 +144,14 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_gateway_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_gateway" id="bridge_gateway_label"><%~ GwIP %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" name="bridge_gateway" id="bridge_gateway" onkeyup="proofreadIp(this)" size="20" maxlength="15" />
+						<input type="text" class="form-control" name="bridge_gateway" id="bridge_gateway" oninput="proofreadIp(this)" size="20" maxlength="15" />
 					</span>
 				</div>
 
 				<div id="bridge_mask_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_mask" id="bridge_mask_label"><%~ SMsk %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" name="bridge_mask" id="bridge_mask" onkeyup="proofreadMask(this)" size="20" maxlength="15" />
+						<input type="text" class="form-control" name="bridge_mask" id="bridge_mask" oninput="proofreadMask(this)" size="20" maxlength="15" />
 						<em><%~ SMNote %></em>
 					</span>
 				</div>
@@ -175,7 +175,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						</select>
 						<span id="bridge_dns_custom_container">
 							<div class="second_row_right_column">
-								<input type="text" id="add_bridge_dns" onkeyup="proofreadIp(this)" class="form-control" size="20" maxlength="17" />
+								<input type="text" id="add_bridge_dns" oninput="proofreadIp(this)" class="form-control" size="20" maxlength="17" />
 								<button class="btn btn-default btn-add" id="add_bridge_dns_button" onclick="addDns('bridge')"><%~ Add %></button>
 							</div>
 							<div id="bridge_dns_table_container" class="second_row_right_column form-group"></div>
@@ -237,7 +237,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="custom"><%~ Cstm %></option>
 						</select>
 						&nbsp;
-						<input type="text" id="bridge_txpower" class="form-control" onkeyup="proofreadNumericRange(this,0,getMaxTxPower('G'))" size="10" />
+						<input type="text" id="bridge_txpower" class="form-control" oninput="proofreadNumericRange(this,0,getMaxTxPower('G'))" size="10" />
 						<em>
 							<span id="bridge_dbm">dBm</span>
 						</em>
@@ -268,7 +268,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="custom"><%~ Cstm %></option>
 						</select>
 						&nbsp;
-						<input type="text" id="bridge_txpower_5ghz" onkeyup="proofreadNumericRange(this,0,getMaxTxPower('A'));" size="10" />
+						<input type="text" id="bridge_txpower_5ghz" oninput="proofreadNumericRange(this,0,getMaxTxPower('A'));" size="10" />
 						<em><span id="bridge_dbm_5ghz">dBm</span></em>
 					</span>
 				</div>
@@ -281,7 +281,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						</select>
 						<button class="btn btn-default" id="bridge_rescan_button" onclick="scanWifi('bridge_custom_ssid')"><%~ RScn %></button>
 						<div id="bridge_custom_ssid_container" class="second_row_right_column form-group">
-							<input type="text" class="form-control" id="bridge_custom_ssid" size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+							<input type="text" class="form-control" id="bridge_custom_ssid" size="20" oninput="proofreadLengthRange(this,1,999)"/>
 						</div>
 
 					</span>
@@ -291,7 +291,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_ssid_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_ssid" id="bridge_ssid_label"><%~ Join %>:</label>
 					<span class="col-xs-7">
-						<input style="float:left;" type="text" id="bridge_ssid" class="form-control" size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+						<input style="float:left;" type="text" id="bridge_ssid" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
 						<button style="float:left;" class="btn btn-default" id="bridge_scan_button" onclick="scanWifi('bridge_ssid')"><%~ Scan %></button>
 					</span>
 				</div>
@@ -299,7 +299,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_broadcast_ssid_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_broadcast_ssid" id="bridge_broadcast_ssid_label"><%~ Bcst %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="bridge_broadcast_ssid" class="form-control" size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+						<input type="text" id="bridge_broadcast_ssid" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
 					</span>
 				</div>
 
@@ -359,7 +359,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_pass_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_pass" id="bridge_pass_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7">
-						<input type="password" id="bridge_pass" class="form-control" size="20" onkeyup="proofreadPass(this, 'bridge_encryption')" autocomplete="new-password"/>
+						<input type="password" id="bridge_pass" class="form-control" size="20" oninput="proofreadPass(this, 'bridge_encryption')" autocomplete="new-password"/>
 						<input type="checkbox" id="show_bridge_pass" onclick="togglePass('bridge_pass')" autocomplete="off"/>
 						<label for="show_bridge_pass" id="show_bridge_pass_label"><%~ rvel %></label>
 					</span>
@@ -368,7 +368,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_wep_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_wep" id="bridge_wep_label" ><%~ HexK %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="bridge_wep" class="form-control" size="30" maxLength="26" onkeyup="proofreadWep(this)"/>
+						<input type="text" id="bridge_wep" class="form-control" size="30" maxLength="26" oninput="proofreadWep(this)"/>
 					</span>
 				</div>
 
@@ -380,7 +380,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_wds_container" class="row form-group">
 					<label class="col-xs-5"  for="bridge_wds_label" id="bridge_wds_label"><%~ OWDS %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="add_bridge_wds_mac" class="form-control" onkeyup="proofreadMac(this)" size="20" maxlength="17"/>
+						<input type="text" id="add_bridge_wds_mac" class="form-control" oninput="proofreadMac(this)" size="20" maxlength="17"/>
 						<button class="btn btn-default btn-add" id="add_bridge_wds_mac_button" onclick="addMacToWds('bridge')"><%~ Add %></button>
 						<div id="bridge_wds_mac_table_container" class="second_row_right_column form-group"></div>
 					</span>
@@ -446,12 +446,12 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 
 				<div id="wan_pppoe_user_container" class="row form-group">
 					<label class="col-xs-5" for="wan_pppoe_user" id="wan_pppoe_user_label"><%~ UNam %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" id="wan_pppoe_user" size="20" onkeyup="proofreadLengthRange(this,1,999)"/></span>
+					<span class="col-xs-7"><input type="text" class="form-control" id="wan_pppoe_user" size="20" oninput="proofreadLengthRange(this,1,999)"/></span>
 				</div>
 
 				<div id="wan_pppoe_pass_container" class="row form-group">
 					<label class="col-xs-5" for="wan_pppoe_pass" id="wan_pppoe_pass_label"><%~ Pswd %>:</label>
-					<span class="col-xs-7"><input type="password" class="form-control" id="wan_pppoe_pass" size="20" onkeyup="proofreadLengthRange(this,1,999)" autocomplete="new-password"/></span>
+					<span class="col-xs-7"><input type="password" class="form-control" id="wan_pppoe_pass" size="20" oninput="proofreadLengthRange(this,1,999)" autocomplete="new-password"/></span>
 				</div>
 
 				<div id="wan_pppoe_reconnect_mode_container" class="row form-group">
@@ -467,7 +467,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wan_pppoe_max_idle_container" class="row form-group" >
 					<label class="col-xs-5" for="wan_pppoe_max_idle" id="wan_pppoe_max_idle_label"><%~ MIdl %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" id="wan_pppoe_max_idle" onkeyup="proofreadNumeric(this)" size="20" maxlength="4" />
+						<input type="text" class="form-control" id="wan_pppoe_max_idle" oninput="proofreadNumeric(this)" size="20" maxlength="4" />
 						<em>(<%~ minutes %>)</em>
 					</span>
 				</div>
@@ -475,31 +475,31 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wan_pppoe_reconnect_pings_container" class="row form-group">
 					<label class="col-xs-5" for="wan_pppoe_reconnect_pings" id="wan_pppoe_reconnect_pings_label"><%~ FPngs %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="wan_pppoe_reconnect_pings" onkeyup="proofreadNumeric(this)" class="form-control" size="20" maxlength="4" />
+						<input type="text" id="wan_pppoe_reconnect_pings" oninput="proofreadNumeric(this)" class="form-control" size="20" maxlength="4" />
 					</span>
 				</div>
 
 				<div id="wan_pppoe_interval_container" class="row form-group">
 					<label class="col-xs-5" for="wan_pppoe_interval" id="wan_pppoe_interval_label"><%~ PngI %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="wan_pppoe_interval" onkeyup="proofreadNumeric(this)" class="form-control" size="20" maxlength="4" />
+						<input type="text" id="wan_pppoe_interval" oninput="proofreadNumeric(this)" class="form-control" size="20" maxlength="4" />
 						<em>(<%~ seconds %>)</em>
 					</span>
 				</div>
 
 				<div id="wan_static_ip_container" class="row form-group">
 					<label class="col-xs-5" for="wan_static_ip" id="wan_static_ip_label"><%~ StIP %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" name="wan_static_ip" id="wan_static_ip" onkeyup="proofreadIp(this)" size="20" maxlength="15" /></span>
+					<span class="col-xs-7"><input type="text" class="form-control" name="wan_static_ip" id="wan_static_ip" oninput="proofreadIp(this)" size="20" maxlength="15" /></span>
 				</div>
 
 				<div id="wan_static_mask_container" class="row form-group">
 					<label class="col-xs-5" for="wan_static_mask" id="wan_static_mask_label"><%~ SMsk %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" name="wan_static_mask" id="wan_static_mask" onkeyup="proofreadMask(this)" size="20" maxlength="15" /></span>
+					<span class="col-xs-7"><input type="text" class="form-control" name="wan_static_mask" id="wan_static_mask" oninput="proofreadMask(this)" size="20" maxlength="15" /></span>
 				</div>
 
 				<div id="wan_static_gateway_container" class="row form-group">
 					<label class="col-xs-5" for="wan_static_gateway" id="wan_static_gateway_label"><%~ Gtwy %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" name="wan_static_gateway" id="wan_static_gateway" onkeyup="proofreadIp(this)" size="20" maxlength="15" /></span>
+					<span class="col-xs-7"><input type="text" class="form-control" name="wan_static_gateway" id="wan_static_gateway" oninput="proofreadIp(this)" size="20" maxlength="15" /></span>
 				</div>
 
 				<div id="wan_3g_service_container" class="row form-group">
@@ -520,7 +520,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<label class="col-xs-5" for="wan_3g_device" id="wan_3g_device_label"><%~ Dvic %>:</label>
 					<span class="col-xs-7">
 						<select style="display:none;float:left;max-width:180px" id="wan_3g_list_device" onchange="set3GDevice(this.value)"></select>
-						<input style="float:left;" type="text" class="form-control" id="wan_3g_device" size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+						<input style="float:left;" type="text" class="form-control" id="wan_3g_device" size="20" oninput="proofreadLengthRange(this,1,999)"/>
 						<button style="float:left;" class="btn btn-default" id="wan_3g_scan_button" onclick="scan3GDevice('wan_3g_list_device')"><%~ Scan %></button>
 					</span>
 				</div>
@@ -528,7 +528,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wan_3g_pincode_container" class="row form-group">
 					<label class="col-xs-5" for="wan_3g_pincode" id="wan_3g_pincode_label"><%~ Pncd %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" id="wan_3g_pincode"  size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+						<input type="text" class="form-control" id="wan_3g_pincode"  size="20" oninput="proofreadLengthRange(this,1,999)"/>
 						<em>(<%~ optl %>)</em>
 					</span>
 				</div>
@@ -544,13 +544,13 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 
 				<div id="wan_3g_apn_container" class="row form-group">
 					<label class="col-xs-5" for="wan_3g_apn" id="wan_3g_apn_label">APN:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" id="wan_3g_apn" size="20" onkeyup="proofreadLengthRange(this,1,999)"/></span>
+					<span class="col-xs-7"><input type="text" class="form-control" id="wan_3g_apn" size="20" oninput="proofreadLengthRange(this,1,999)"/></span>
 				</div>
 
 				<div id="wan_3g_user_container" class="row form-group">
 					<label class="col-xs-5" for="wan_3g_user" id="wan_3g_user_label"><%~ UNam %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" id="wan_3g_user" size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+						<input type="text" class="form-control" id="wan_3g_user" size="20" oninput="proofreadLengthRange(this,1,999)"/>
 						<em>(<%~ optl %>)</em>
 					</span>
 				</div>
@@ -558,7 +558,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wan_3g_pass_container" class="row form-group">
 					<label class="col-xs-5" for="wan_3g_pass" id="wan_3g_pass_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" id="wan_3g_pass" size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+						<input type="text" class="form-control" id="wan_3g_pass" size="20" oninput="proofreadLengthRange(this,1,999)"/>
 						<em>(<%~ optl %>)</em>
 					</span>
 				</div>
@@ -579,7 +579,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						<input type="checkbox" id="wan_use_mac" onclick="enableAssociatedField(this, 'wan_mac', defaultWanMac)"/>
 						<label class="short-left-pad" for="wan_use_mac" id="wan_mac_label"><%~ CustMAC %>:</label>
 					</span>
-					<span class="col-xs-7"><input type="text" name="wan_mac" id="wan_mac" class="form-control" onkeyup="proofreadMac(this)" size="20" maxlength="17"/></span>
+					<span class="col-xs-7"><input type="text" name="wan_mac" id="wan_mac" class="form-control" oninput="proofreadMac(this)" size="20" maxlength="17"/></span>
 				</div>
 
 				<div id="wan_mtu_container" class="row form-group">
@@ -587,7 +587,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						<input type="checkbox" id="wan_use_mtu" onclick="enableAssociatedField(this, 'wan_mtu', 1500)"/>
 						<label class="short-left-pad" for="wan_use_mtu" id="wan_mtu_label"><%~ CustMTU %>:</label>
 					</span>
-					<span class="col-xs-7"><input type="text" name="wan_mtu" id="wan_mtu" class="form-control" onkeyup="proofreadNumeric(this)" size="20" maxlength="4"/></span>
+					<span class="col-xs-7"><input type="text" name="wan_mtu" id="wan_mtu" class="form-control" oninput="proofreadNumeric(this)" size="20" maxlength="4"/></span>
 				</div>
 
 				<div id="wan_ping_container" class="row form-group">
@@ -610,17 +610,17 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 
 				<div id="lan_ip_container" class="row form-group">
 					<label  class="col-xs-5" for="lan_ip" id="lan_ip_label"><%~ RtrIP %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" name="lan_ip" id="lan_ip" onkeyup="proofreadIp(this)" size="20" maxlength="15" /></span>
+					<span class="col-xs-7"><input type="text" class="form-control" name="lan_ip" id="lan_ip" oninput="proofreadIp(this)" size="20" maxlength="15" /></span>
 				</div>
 
 				<div id="lan_mask_container" class="row form-group">
 					<label  class="col-xs-5" for="lan_mask" id="lan_mask_label"><%~ SMsk %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" name="lan_mask" id="lan_mask" onkeyup="proofreadMask(this)" size="20" maxlength="15" /></span>
+					<span class="col-xs-7"><input type="text" class="form-control" name="lan_mask" id="lan_mask" oninput="proofreadMask(this)" size="20" maxlength="15" /></span>
 				</div>
 
 				<div id="lan_gateway_container" class="row form-group">
 					<label  class="col-xs-5" for="lan_gateway" id="lan_gateway_label"><%~ Gtwy %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" name="lan_gateway" id="lan_gateway" onkeyup="proofreadIp(this)" size="20" maxlength="15" /></span>
+					<span class="col-xs-7"><input type="text" class="form-control" name="lan_gateway" id="lan_gateway" oninput="proofreadIp(this)" size="20" maxlength="15" /></span>
 				</div>
 
 				<div id="lan_dns_source_container" class="row form-group">
@@ -635,7 +635,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="custom"><%~ CstDSrv %></option>
 						</select>
 						<div id="lan_dns_custom_container" class="second_row_right_column">
-							<input  type="text" id="add_lan_dns" class="form-control" onkeyup="proofreadIp(this)" size="20" maxlength="17" />
+							<input  type="text" id="add_lan_dns" class="form-control" oninput="proofreadIp(this)" size="20" maxlength="17" />
 							<button class="btn btn-default btn-add" id="add_lan_dns_button" onclick="addDns('lan')"><%~ Add %></button>
 							<div id="lan_dns_table_container" class="form-group second_row_right_column"></div>
 						</div>
@@ -718,7 +718,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="custom"><%~ Cstm %></option>
 						</select>
 						&nbsp;
-						<input type="text" id="wifi_txpower" class="form-control" onkeyup="proofreadNumericRange(this,0,getMaxTxPower('G'))" size="10"/>
+						<input type="text" id="wifi_txpower" class="form-control" oninput="proofreadNumericRange(this,0,getMaxTxPower('G'))" size="10"/>
 						<em><span id="wifi_dbm">dBm</span></em>
 					</span>
 				</div>
@@ -758,7 +758,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="custom"><%~ Cstm %></option>
 						</select>
 						&nbsp;
-						<input type="text" id="wifi_txpower_5ghz" class="form-control" onkeyup="proofreadNumericRange(this,0,getMaxTxPower('A'));" size="10" />
+						<input type="text" id="wifi_txpower_5ghz" class="form-control" oninput="proofreadNumericRange(this,0,getMaxTxPower('A'));" size="10" />
 						<em><span id="wifi_dbm_5ghz">dBm</span></em>
 					</span>
 				</div>
@@ -782,7 +782,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						</select>
 						<div class="second_row_right_column"><em><%~ FltrInfo %></em></div>
 						<div class="second_row_right_column">
-							<input type="text" id="add_mac" class="form-control" onkeyup="proofreadMac(this)" size="20" maxlength="17"/>
+							<input type="text" id="add_mac" class="form-control" oninput="proofreadMac(this)" size="20" maxlength="17"/>
 							<button class="btn btn-default btn-add" id="add_mac_button" onclick="addMacToFilter()"><%~ Add %></button>
 						</div>
 						<div id="mac_table_container" class="form-group second_row_right_column"></div>
@@ -810,7 +810,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						</select>
 						<button class="btn btn-default" id="wifi_rescan_button" onclick="scanWifi('wifi_custom_ssid2')"><%~ RScn %></button>
 						<div id="wifi_custom_ssid2_container" class="second_row_right_column" >
-							<input type="text" id="wifi_custom_ssid2" class="form-control" size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+							<input type="text" id="wifi_custom_ssid2" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
 						</div>
 
 					</span>
@@ -820,7 +820,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_ssid2_container" class="row form-group">
 					<label  class="col-xs-5" for="wifi_ssid2" id="wifi_ssid2_label">SSID:</label>
 					<span class="col-xs-7">
-						<input type="text" id="wifi_ssid2" class="form-control" size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+						<input type="text" id="wifi_ssid2" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
 						<button class="btn btn-default" id="wifi_scan_button" onclick="scanWifi('wifi_ssid2')"><%~ Scan %></button>
 					</span>
 				</div>
@@ -889,7 +889,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_pass2_container" class="row indent">
 					<label class="col-xs-5" for="wifi_pass2" id="wifi_pass2_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7">
-						<input type="password" id="wifi_pass2" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_encryption2')" autocomplete="new-password"/>&nbsp;&nbsp;
+						<input type="password" id="wifi_pass2" class="form-control" size="20" oninput="proofreadPass(this, 'wifi_encryption2')" autocomplete="new-password"/>&nbsp;&nbsp;
 						<input type="checkbox" id="show_pass2" onclick="togglePass('wifi_pass2')" autocomplete="off"/>
 						<label for="show_pass2" id="show_pass2_label"><%~ rvel %></label><br/>
 					</span>
@@ -898,7 +898,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_wep2_container" class="row indent">
 					<label class="col-xs-5" for="wifi_wep2" id="wifi_wep2_label"><%~ HexK %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="wifi_wep2" class="form-control" size="30" maxLength="26" onkeyup="proofreadWep(this)"/>
+						<input type="text" id="wifi_wep2" class="form-control" size="30" maxLength="26" oninput="proofreadWep(this)"/>
 					</span>
 				</div>
 
@@ -907,14 +907,14 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_ssid1_container" class="row form-group">
 					<label class="col-xs-5" for="wifi_ssid1" id="wifi_ssid1_label"><%~ AcPtID %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="wifi_ssid1" class="form-control" size="20" onkeyup="proofreadLengthRange(this,1,999)"/><br/>
+						<input type="text" id="wifi_ssid1" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/><br/>
 					</span>
 				</div>
 
 				<div id="wifi_ssid1a_container" class="row form-group">
 					<label class="col-xs-5" for="wifi_ssid1a" id="wifi_ssid1a_label">AP 5GHz SSID:</label>
 					<span class="col-xs-7">
-						<input type="text" id="wifi_ssid1a" class="form-control" size="20" onkeyup="proofreadLengthRange(this,1,999)"/>
+						<input type="text" id="wifi_ssid1a" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
 					</span>
 				</div>
 
@@ -971,7 +971,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_pass1_container" class="row indent">
 					<label class="col-xs-5" for="wifi_pass1" id="wifi_pass1_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7" >
-						<input type="password" id="wifi_pass1" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_encryption1')" autocomplete="new-password"/>&nbsp;&nbsp;
+						<input type="password" id="wifi_pass1" class="form-control" size="20" oninput="proofreadPass(this, 'wifi_encryption1')" autocomplete="new-password"/>&nbsp;&nbsp;
 						<input type="checkbox" id="show_pass1" onclick="togglePass('wifi_pass1')" autocomplete="off"/>
 						<label for="show_pass1" id="show_pass1_label"><%~ rvel %></label><br/>
 					</span>
@@ -980,7 +980,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_wep1_container" class="row indent">
 					<label class="col-xs-5" for="wifi_wep1" id="wifi_wep1_label"><%~ HexK %>:</label>
 					<span class="col-xs-7" >
-						<input type="text" id="wifi_wep1" class="form-control" size="30" maxLength="26" onkeyup="proofreadWep(this)"/>
+						<input type="text" id="wifi_wep1" class="form-control" size="30" maxLength="26" oninput="proofreadWep(this)"/>
 						<div class="second_row_right_column">	
 							<button class="btn btn-default" id="wep1gen40" onclick="setToWepKey('wifi_wep1',10)"><%~ Rndm %> 40/64 Bit WEP Key</button>
 							<button class="btn btn-default" id="wep1gen104" onclick="setToWepKey('wifi_wep1',26)"><%~ Rndm %> 104/128 Bit WEP Key</button>
@@ -991,14 +991,14 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_server1_container" class="row indent">
 					<label class="col-xs-5" for="wifi_server1" id="wifi_server1_label">RADIUS <%~ Srvr %> IP:</label>
 					<span class="col-xs-7" >
-						<input type="text" id="wifi_server1" class="form-control" size="20" onkeyup="proofreadIp(this)"/>
+						<input type="text" id="wifi_server1" class="form-control" size="20" oninput="proofreadIp(this)"/>
 					</span>
 				</div>
 
 				<div id="wifi_port1_container" class="row indent">
 					<label class="col-xs-5" for="wifi_port1" id="wifi_port1_label">RADIUS <%~ SrvPt %>:</label>
 					<span class="col-xs-7" >
-						<input type="text" id="wifi_port1" class="form-control" size="20" maxlength="5" onkeyup="proofreadNumeric(this)"/><br/>
+						<input type="text" id="wifi_port1" class="form-control" size="20" maxlength="5" oninput="proofreadNumeric(this)"/><br/>
 					</span>
 				</div>
 
@@ -1015,7 +1015,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_ft_key_container" class="row indent">
 					<label class="col-xs-5" for="wifi_ft_key" id="wifi_ft_key_label"><%~ FtKey %>:</label>
 					<span class="col-xs-7" >
-						<input type="password" id="wifi_ft_key" class="form-control" size="20" maxLength="64" onkeyup="proofreadFtKey(this)" placeholder="64 <%~ HexCh %>" autocomplete="new-password"/>&nbsp;&nbsp;
+						<input type="password" id="wifi_ft_key" class="form-control" size="20" maxLength="64" oninput="proofreadFtKey(this)" placeholder="64 <%~ HexCh %>" autocomplete="new-password"/>&nbsp;&nbsp;
 						<input type="checkbox" id="show_ft_key" onclick="togglePass('wifi_ft_key')" autocomplete="off"/>
 						<label for="show_ft_key" id="show_ft_key_label"><%~ rvel %></label><br/>
 						<div class="second_row_right_column">
@@ -1052,7 +1052,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_wds_container" class="row indent">
 					<label  class="col-xs-5" for="wifi_wds_label" id="wifi_wds_label"><%~ OWDS %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="add_wifi_wds_mac" class="form-control" onkeyup="proofreadMac(this)" size="20" maxlength="17"/>
+						<input type="text" id="add_wifi_wds_mac" class="form-control" oninput="proofreadMac(this)" size="20" maxlength="17"/>
 						<button class="btn btn-default btn-add" id="add_wifi_wds_mac_button" onclick="addMacToWds('wifi')"><%~ Add %></button>
 						<div id="wifi_wds_mac_table_container" class="second_row_right_column form-group"></div>
 					</span>
@@ -1075,7 +1075,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<div id="wifi_guest_ssid1_container" class="row form-group">
 						<label class="col-xs-5" for="wifi_guest_ssid1" id="wifi_guest_ssid1_label"><%~ GNetID %>:</label>
 						<span class="col-xs-7">
-							<input type="text" id="wifi_guest_ssid1" class="form-control" size="20" onkeyup="proofreadLengthRange(this,1,999)"/><br/>
+							<input type="text" id="wifi_guest_ssid1" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/><br/>
 							<input type="text" id="wifi_guest_mac_g" class="form-control" style="display: none"/>
 						</span>
 					</div>
@@ -1083,7 +1083,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<div id="wifi_guest_ssid1a_container" class="row form-group">
 						<label class="col-xs-5" for="wifi_guest_ssid1a" id="wifi_guest_ssid1a_label"><%~ GNet5ID %></label>
 						<span class="col-xs-7">
-							<input type="text" id="wifi_guest_ssid1a" class="form-control" size="20" onkeyup="proofreadLengthRange(this,1,999)"/><br/>
+							<input type="text" id="wifi_guest_ssid1a" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/><br/>
 							<input type="text" id="wifi_guest_mac_a" class="form-control" style="display: none"/>
 						</span>
 					</div>
@@ -1103,7 +1103,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<div id="wifi_guest_pass1_container" class="row indent">
 						<label class="col-xs-5" for="wifi_guest_pass1" id="wifi_guest_pass1_label"><%~ Pswd %>:</label>
 						<span class="col-xs-7">
-							<input type="password" id="wifi_guest_pass1" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_guest_encryption1')" autocomplete="new-password"/>&nbsp;&nbsp;
+							<input type="password" id="wifi_guest_pass1" class="form-control" size="20" oninput="proofreadPass(this, 'wifi_guest_encryption1')" autocomplete="new-password"/>&nbsp;&nbsp;
 							<input type="checkbox" id="show_guest_pass1" onclick="togglePass('wifi_guest_pass1')" autocomplete="off"/>
 							<label for="show_guest_pass1" id="show_guest_pass1_label"><%~ rvel %></label><br/>
 						</span>
@@ -1112,7 +1112,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<div id="wifi_guest_wep1_container" class="row indent">
 						<label class="col-xs-5" for="wifi_guest_wep1" id="wifi_guest_wep1_label"><%~ HexK %>:</label>
 						<span class="col-xs-7">
-							<input type="text" id="wifi_guest_wep1" class="form-control" size="30" maxLength="26" onkeyup="proofreadWep(this)"/>
+							<input type="text" id="wifi_guest_wep1" class="form-control" size="30" maxLength="26" oninput="proofreadWep(this)"/>
 							<div class="second_row_right_column form-group">
 								<button class="btn btn-default" id="guestwep1gen40" onclick="setToWepKey('wifi_guest_wep1',10)"><%~ Rndm %> 40/64 Bit WEP Key</button>
 								<button class="btn btn-default" id="guestwep1gen104" onclick="setToWepKey('wifi_guest_wep1',26)"><%~ Rndm %> 104/128 Bit WEP Key</button>

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -359,7 +359,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_pass_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_pass" id="bridge_pass_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7">
-						<input type="password" id="bridge_pass" class="form-control" size="20" onkeyup="proofreadPass(this, 'bridge_encryption')"/>
+						<input type="password" id="bridge_pass" class="form-control" size="20" onkeyup="proofreadPass(this, 'bridge_encryption')" autocomplete="new-password"/>
 						<input type="checkbox" id="show_bridge_pass" onclick="togglePass('bridge_pass')" autocomplete="off"/>
 						<label for="show_bridge_pass" id="show_bridge_pass_label"><%~ rvel %></label>
 					</span>
@@ -451,7 +451,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 
 				<div id="wan_pppoe_pass_container" class="row form-group">
 					<label class="col-xs-5" for="wan_pppoe_pass" id="wan_pppoe_pass_label"><%~ Pswd %>:</label>
-					<span class="col-xs-7"><input type="password" class="form-control" id="wan_pppoe_pass" size="20" onkeyup="proofreadLengthRange(this,1,999)"/></span>
+					<span class="col-xs-7"><input type="password" class="form-control" id="wan_pppoe_pass" size="20" onkeyup="proofreadLengthRange(this,1,999)" autocomplete="new-password"/></span>
 				</div>
 
 				<div id="wan_pppoe_reconnect_mode_container" class="row form-group">
@@ -889,7 +889,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_pass2_container" class="row indent">
 					<label class="col-xs-5" for="wifi_pass2" id="wifi_pass2_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7">
-						<input type="password" id="wifi_pass2" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_encryption2')"/>&nbsp;&nbsp;
+						<input type="password" id="wifi_pass2" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_encryption2')" autocomplete="new-password"/>&nbsp;&nbsp;
 						<input type="checkbox" id="show_pass2" onclick="togglePass('wifi_pass2')" autocomplete="off"/>
 						<label for="show_pass2" id="show_pass2_label"><%~ rvel %></label><br/>
 					</span>
@@ -971,7 +971,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_pass1_container" class="row indent">
 					<label class="col-xs-5" for="wifi_pass1" id="wifi_pass1_label"><%~ Pswd %>:</label>
 					<span class="col-xs-7" >
-						<input type="password" id="wifi_pass1" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_encryption1')"/>&nbsp;&nbsp;
+						<input type="password" id="wifi_pass1" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_encryption1')" autocomplete="new-password"/>&nbsp;&nbsp;
 						<input type="checkbox" id="show_pass1" onclick="togglePass('wifi_pass1')" autocomplete="off"/>
 						<label for="show_pass1" id="show_pass1_label"><%~ rvel %></label><br/>
 					</span>
@@ -1015,7 +1015,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_ft_key_container" class="row indent">
 					<label class="col-xs-5" for="wifi_ft_key" id="wifi_ft_key_label"><%~ FtKey %>:</label>
 					<span class="col-xs-7" >
-						<input type="password" id="wifi_ft_key" class="form-control" size="20" maxLength="64" onkeyup="proofreadFtKey(this)" placeholder="64 <%~ HexCh %>"/>&nbsp;&nbsp;
+						<input type="password" id="wifi_ft_key" class="form-control" size="20" maxLength="64" onkeyup="proofreadFtKey(this)" placeholder="64 <%~ HexCh %>" autocomplete="new-password"/>&nbsp;&nbsp;
 						<input type="checkbox" id="show_ft_key" onclick="togglePass('wifi_ft_key')" autocomplete="off"/>
 						<label for="show_ft_key" id="show_ft_key_label"><%~ rvel %></label><br/>
 						<div class="second_row_right_column">
@@ -1103,7 +1103,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<div id="wifi_guest_pass1_container" class="row indent">
 						<label class="col-xs-5" for="wifi_guest_pass1" id="wifi_guest_pass1_label"><%~ Pswd %>:</label>
 						<span class="col-xs-7">
-							<input type="password" id="wifi_guest_pass1" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_guest_encryption1')"/>&nbsp;&nbsp;
+							<input type="password" id="wifi_guest_pass1" class="form-control" size="20" onkeyup="proofreadPass(this, 'wifi_guest_encryption1')" autocomplete="new-password"/>&nbsp;&nbsp;
 							<input type="checkbox" id="show_guest_pass1" onclick="togglePass('wifi_guest_pass1')" autocomplete="off"/>
 							<label for="show_guest_pass1" id="show_guest_pass1_label"><%~ rvel %></label><br/>
 						</span>

--- a/package/gargoyle/files/www/connlimits.sh
+++ b/package/gargoyle/files/www/connlimits.sh
@@ -39,21 +39,21 @@
 				<div class="row form-group">
 					<label class="col-xs-5" for="max_connections" id="max_connections_label"><%~ MaxC %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" onkeyup="proofreadNumericRange(this,1,16384)" id="max_connections" size="10" maxlength="5" />
+						<input type="text" class="form-control" oninput="proofreadNumericRange(this,1,16384)" id="max_connections" size="10" maxlength="5" />
 						<em>(<%~ max %> 16384)</em>
 					</span>
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" for="tcp_timeout" id="tcp_timeout_label"><%~ TTout %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" onkeyup="proofreadNumericRange(this,1,3600)" id="tcp_timeout" size="10" maxlength="4" />
+						<input type="text" class="form-control" oninput="proofreadNumericRange(this,1,3600)" id="tcp_timeout" size="10" maxlength="4" />
 						<em><%~ seconds %> (<%~ max %> 3600)</em>
 					</span>
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" for="udp_timeout" id="udp_timeout_label"><%~ UTout %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" onkeyup="proofreadNumericRange(this,1,3600)" id="udp_timeout" size="10" maxlength="4" />
+						<input type="text" class="form-control" oninput="proofreadNumericRange(this,1,3600)" id="udp_timeout" size="10" maxlength="4" />
 						<em><%~ seconds %> (<%~ max %> 3600)</em>
 					</span>
 				</div>

--- a/package/gargoyle/files/www/dhcp.sh
+++ b/package/gargoyle/files/www/dhcp.sh
@@ -77,7 +77,7 @@ for (etherIndex in etherData)
 					<label class="col-xs-5" for="dhcp_start" id="dhcp_start_label"><%~ Strt %>:</label>
 					<span class="col-xs-7">
 						<% echo -n "$subnet" %>
-						<input type="text" class="form-control" id="dhcp_start" onkeyup="proofreadNumeric(this)" size="5" maxlength="3" />
+						<input type="text" class="form-control" id="dhcp_start" oninput="proofreadNumeric(this)" size="5" maxlength="3" />
 					</span>
 				</div>
 
@@ -85,14 +85,14 @@ for (etherIndex in etherData)
 					<label class="col-xs-5" for="dhcp_end" id="dhcp_end_label"><%~ End %>:</label>
 					<span class="col-xs-7">
 						<% echo -n "$subnet" %>
-						<input type="text" class="form-control" id="dhcp_end" onkeyup="proofreadNumeric(this)" size="5" maxlength="3" />
+						<input type="text" class="form-control" id="dhcp_end" oninput="proofreadNumeric(this)" size="5" maxlength="3" />
 					</span>
 				</div>
 
 				<div id="dhcp_lease_container" class="row form-group">
 					<label class="col-xs-5" for="dhcp_lease" id="dhcp_lease_label"><%~ LsTm %>:</label>
 					<span class="col-xs-7">
-						<input type="text" class="form-control" onkeyup="proofreadNumeric(this)" id="dhcp_lease" size="5" maxlength="4" />
+						<input type="text" class="form-control" oninput="proofreadNumeric(this)" id="dhcp_lease" size="5" maxlength="4" />
 						<em>(<%~ hours %>)</em>
 					</span>
 				</div>

--- a/package/gargoyle/files/www/firstboot.sh
+++ b/package/gargoyle/files/www/firstboot.sh
@@ -34,12 +34,12 @@
 
 				<div class="row form-group">
 					<label class="col-xs-4 col-md-3 col-lg-2" for="password1" id="password1_label"><%~ NPass %>:</label>
-					<span class="col-xs-7 col-md-8 col-lg-8"><input type="password" id="password1" class="form-control" size="25" /></span>
+					<span class="col-xs-7 col-md-8 col-lg-8"><input type="password" id="password1" class="form-control" size="25" autocomplete="new-password"/></span>
 				</div>
 
 				<div class="row form-group">
 					<label class="col-xs-4 col-md-3 col-lg-2" for="password2" id="password2_label"><%~ CPass %>:</label>
-					<span class="col-xs-7 col-md3 col-lg-2"><input type="password" id="password2" class="form-control" size="25" /></span>
+					<span class="col-xs-7 col-md3 col-lg-2"><input type="password" id="password2" class="form-control" size="25" autocomplete="new-password"/></span>
 				</div>
 
 				<p><strong><%~ Stz %>:</strong></p>

--- a/package/gargoyle/files/www/identification.sh
+++ b/package/gargoyle/files/www/identification.sh
@@ -26,12 +26,12 @@
 			<div class="panel-body">
 				<div class="row form-group">
 					<label class="col-xs-5" for="hostname" id="hostname_label"><%~ HsNm %></label>
-					<span class="col-xs-7"><input type="text" id="hostname" class="form-control" onkeyup="proofreadLengthRange(this,1,999)"  size="35" maxlength="25"/></span>
+					<span class="col-xs-7"><input type="text" id="hostname" class="form-control" oninput="proofreadLengthRange(this,1,999)"  size="35" maxlength="25"/></span>
 				</div>
 				
 				<div id="domain_container" class="row form-group">
 					<label class="col-xs-5" for="domain" id="domain_label"><%~ Domn %></label>
-					<span class="col-xs-7"><input type="text" id="domain" class="form-control" onkeyup="proofreadLengthRange(this,1,999)" size="35" maxlength="100"/></span>
+					<span class="col-xs-7"><input type="text" id="domain" class="form-control" oninput="proofreadLengthRange(this,1,999)" size="35" maxlength="100"/></span>
 				</div>
 			</div>
 		</div>

--- a/package/gargoyle/files/www/js/table.js
+++ b/package/gargoyle/files/www/js/table.js
@@ -315,7 +315,7 @@ function createTableFilter()
 			filterTxt.value = TFilter_Store[x];
 		}
 
-		filterTxt.onkeyup = function(){applyTableFilter(this.parentNode.parentNode.parentNode.parentNode.id);};
+		filterTxt.oninput = function(){applyTableFilter(this.parentNode.parentNode.parentNode.parentNode.id);};
 
 		filterCol.appendChild(filterTxt);
 		filterRow.appendChild(filterCol);

--- a/package/gargoyle/files/www/login.sh
+++ b/package/gargoyle/files/www/login.sh
@@ -79,7 +79,7 @@ var passInvalid = false;
 				<div class="row form-group">
 					<label class="sr-only" for="password" id="password_label"><%~ EAdmP %></label>
 					<span class="col-xs-12">
-						<input id="password" class="form-control" type="password" onkeyup="proofreadLengthRange(this,1,999)" onkeydown="checkKey(event)" size="25" placeholder="<%~ EAdmP %>" autocomplete="current-password"/>
+						<input id="password" class="form-control" type="password" oninput="proofreadLengthRange(this,1,999)" onkeydown="checkKey(event)" size="25" placeholder="<%~ EAdmP %>" autocomplete="current-password"/>
 						<button class="btn btn-default" onclick="doLogin()" ><%~ LSect %></button>
 					</span>
 				</div>

--- a/package/gargoyle/files/www/login.sh
+++ b/package/gargoyle/files/www/login.sh
@@ -79,7 +79,7 @@ var passInvalid = false;
 				<div class="row form-group">
 					<label class="sr-only" for="password" id="password_label"><%~ EAdmP %></label>
 					<span class="col-xs-12">
-						<input id="password" class="form-control" type="password" onkeyup="proofreadLengthRange(this,1,999)" onkeydown="checkKey(event)" size="25" placeholder="<%~ EAdmP %>"/>
+						<input id="password" class="form-control" type="password" onkeyup="proofreadLengthRange(this,1,999)" onkeydown="checkKey(event)" size="25" placeholder="<%~ EAdmP %>" autocomplete="current-password"/>
 						<button class="btn btn-default" onclick="doLogin()" ><%~ LSect %></button>
 					</span>
 				</div>

--- a/package/gargoyle/files/www/plugins.sh
+++ b/package/gargoyle/files/www/plugins.sh
@@ -87,7 +87,7 @@
 
 						<div class="row form-group">
 							<label class="col-xs-5" for="add_source_name"><%~ ANam %>:</label>
-							<span class="col-xs-7"><input type="text" id="add_source_name" class="form-control" onkeyup="proofreadSourceName(this)"/></span>
+							<span class="col-xs-7"><input type="text" id="add_source_name" class="form-control" oninput="proofreadSourceName(this)"/></span>
 						</div>
 
 						<div class="row form-group">

--- a/package/gargoyle/files/www/port_forwarding.sh
+++ b/package/gargoyle/files/www/port_forwarding.sh
@@ -104,7 +104,7 @@
 				<div id="upnp_up_container" class="row form-group">
 					<label class="col-xs-5" for="upnp_up" id="upnp_up_label"><%~ USpd %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="upnp_up" class="form-control" onkeyup="proofreadNumeric(this)" size="5" maxlength="5" />
+						<input type="text" id="upnp_up" class="form-control" oninput="proofreadNumeric(this)" size="5" maxlength="5" />
 						<em><%~ KBs %></em>
 					</span>
 				</div>
@@ -112,7 +112,7 @@
 				<div id="upnp_down_container" class="row form-group">
 					<label class="col-xs-5" for="upnp_down" id="upnp_down_label"><%~ DSpd %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="upnp_down" class="form-control" onkeyup="proofreadNumeric(this)" size="5" maxlength="5" />
+						<input type="text" id="upnp_down" class="form-control" oninput="proofreadNumeric(this)" size="5" maxlength="5" />
 						<em><%~ KBs %></em>
 					</span>
 				</div>
@@ -141,7 +141,7 @@
 
 				<div id="dmz_ip_container" class="row form-group">
 					<label class="col-xs-5" for="dmz_ip" id="dmz_ip_label"><%~ DMZIP %>:</label>
-					<span class="col-xs-7"><input type="text" class="form-control" name="dmz_ip" id="dmz_ip" onkeyup="proofreadIp(this)" size="20" maxlength="15" /></span>
+					<span class="col-xs-7"><input type="text" class="form-control" name="dmz_ip" id="dmz_ip" oninput="proofreadIp(this)" size="20" maxlength="15" /></span>
 				</div>
 			</div>
 		</div>

--- a/package/gargoyle/files/www/templates/multi_forward_template
+++ b/package/gargoyle/files/www/templates/multi_forward_template
@@ -14,13 +14,13 @@
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='addr_sp_label' for='addr_sp'><%~ SPrt %></label>
-					<span class="col-xs-7"><input type='text' id='addr_sp' onkeyup='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></span>
+					<span class="col-xs-7"><input type='text' id='addr_sp' oninput='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></span>
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='addr_ep_label' for='addr_ep'><%~ EPrt %></label>
-					<span class="col-xs-7"><input type='text' id='addr_ep' onkeyup='proofreadNumeric(this,1,65535)' maxLength='5' class='form-control' /></span>
+					<span class="col-xs-7"><input type='text' id='addr_ep' oninput='proofreadNumeric(this,1,65535)' maxLength='5' class='form-control' /></span>
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='addr_ip_label' for='addr_ip'><%~ TIP %></label>
-					<span class="col-xs-7"><input type='text' id='addr_ip' onkeyup='proofreadIp(this)' maxLength='15' class='form-control' /></span>
+					<span class="col-xs-7"><input type='text' id='addr_ip' oninput='proofreadIp(this)' maxLength='15' class='form-control' /></span>
 				</div>

--- a/package/gargoyle/files/www/templates/password_confirm_template
+++ b/package/gargoyle/files/www/templates/password_confirm_template
@@ -11,7 +11,7 @@
 
 				<div class="row form-group">
 					<span class="col-xs-12">
-						<input type="password" id="password" class="form-control"/>
+						<input type="password" id="password" class="form-control" autocomplete="new-password"/>
 					</span>
 				</div>
 			</div>

--- a/package/gargoyle/files/www/templates/password_confirm_template
+++ b/package/gargoyle/files/www/templates/password_confirm_template
@@ -11,7 +11,7 @@
 
 				<div class="row form-group">
 					<span class="col-xs-12">
-						<input type="password" id="password" class="form-control" autocomplete="new-password"/>
+						<input type="password" id="password" class="form-control" autocomplete="current-password"/>
 					</span>
 				</div>
 			</div>

--- a/package/gargoyle/files/www/templates/quotas_template
+++ b/package/gargoyle/files/www/templates/quotas_template
@@ -14,7 +14,7 @@
 		<div class="col-xs-offset-5 col-xs-7" id="quota_ip_table_container" style="margin-top:0px;margin-bottom:0px;"></div>
 		<div style="padding:0px;margin-top:0px;margin-bottom:0px">
 			<span class="col-xs-offset-5 col-xs-7">
-				<input type='text' id='add_ip' onkeyup='proofreadMultipleIps(this)' style="width:250px;" class='form-control' />
+				<input type='text' id='add_ip' oninput='proofreadMultipleIps(this)' style="width:250px;" class='form-control' />
 				<button type="button" class="btn btn-default btn-add" id="add_ip_button" onclick='addAddressesToTable(document,"add_ip","quota_ip_table_container","quota_ip_table",false,3,true,250)'><%~ Add %></button>
 			</span>
 		</div>
@@ -32,7 +32,7 @@
 			<option value="limited"><%~ Limited %></option>
 		</select>
 		<span id="max_up_container">
-			<input type='text' id='max_up' onkeyup='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
+			<input type='text' id='max_up' oninput='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
 			<select id="max_up_unit" class='form-control'>
 				<option value="MB"><%~ MBy %></option>
 				<option value="GB"><%~ GBy %></option>
@@ -50,7 +50,7 @@
 			<option value="limited"><%~ Limited %></option>
 		</select>
 		<span id="max_down_container">
-			<input type='text' id='max_down' onkeyup='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
+			<input type='text' id='max_down' oninput='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
 			<select id="max_down_unit" class='form-control'>
 				<option value="MB"><%~ MBy %></option>
 				<option value="GB"><%~ GBy %></option>
@@ -69,7 +69,7 @@
 			<option value="limited"><%~ Limited %></option>
 		</select>
 		<span id="max_combined_container">
-			<input type='text' id='max_combined' onkeyup='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
+			<input type='text' id='max_combined' oninput='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
 			<select id="max_combined_unit" class='form-control'>
 				<option value="MB"><%~ MBy %></option>
 				<option value="GB"><%~ GBy %></option>
@@ -138,12 +138,12 @@
 	</span>
 
 	<span class="col-xs-offset-5 col-xs-7" id="active_hours_container">
-		<input class='form-control' type='text' id='active_hours' onkeyup='proofreadHours(this)' style="width:250px;margin-bottom:5px;margin-top:5px;"/>
+		<input class='form-control' type='text' id='active_hours' oninput='proofreadHours(this)' style="width:250px;margin-bottom:5px;margin-top:5px;"/>
 		<span id="hours_example" style="margin-top:0px;padding-top:0px;"><em><%~ SSample %> 02:00-04:00,11:35-13:25</em></span>
 	</span>
 
 	<span class="col-xs-offset-5 col-xs-7" id="active_weekly_container">
-		<input class='form-control' type='text' id='active_weekly' onkeyup='proofreadWeeklyRange(this)' style="width:250px;margin-bottom:5px;margin-top:5px;"/>
+		<input class='form-control' type='text' id='active_weekly' oninput='proofreadWeeklyRange(this)' style="width:250px;margin-bottom:5px;margin-top:5px;"/>
 		<span id="weekly_example" style="margin-top:0px;padding-top:0px;"><em><%~ Sample %></em></span>
 	</span>
 </div>
@@ -161,7 +161,7 @@
 <div id="quota_only_qos_container" class="row form-group">
 	<span class="col-xs-offset-5 col-xs-7" style="margin-top:1px;margin-bottom:1px;">
 		<label><%~ UpLimit %>: </label>
-		<input type='text' id='quota_qos_up' onkeyup='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
+		<input type='text' id='quota_qos_up' oninput='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
 		<select id="quota_qos_up_unit" class='form-control'>
 			<option value="KBytes/s"><%~ KBs %></option>
 			<option value="MBytes/s"><%~ MBs %></option>
@@ -169,7 +169,7 @@
 	</span>
 	<span class="col-xs-offset-5 col-xs-7" style="margin-top:1px;margin-bottom:1px;">
 		<label><%~ DownLimit %>: </label>
-		<input type='text' id='quota_qos_down' onkeyup='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
+		<input type='text' id='quota_qos_down' oninput='proofreadDecimal(this)' size='7' maxlength='15' class='form-control' />
 		<select id="quota_qos_down_unit" class='form-control'>
 			<option value="KBytes/s"><%~ KBs %></option>
 			<option value="MBytes/s"><%~ MBs %></option>

--- a/package/gargoyle/files/www/templates/restriction_template
+++ b/package/gargoyle/files/www/templates/restriction_template
@@ -17,7 +17,7 @@
 <div id="rule_applies_to_container" class="row form-group">
 	<div class="col-xs-offset-5 col-xs-7" id="rule_applies_to_table_container"></div>
 	<div class="col-xs-offset-5 col-xs-7">
-		<input type='text' id='rule_applies_to_addr' size='30' onkeyup='proofreadMultipleIpsOrMacs(this)' class='form-control' />
+		<input type='text' id='rule_applies_to_addr' size='30' oninput='proofreadMultipleIpsOrMacs(this)' class='form-control' />
 		<button type="button" class="btn btn-default btn-add" id="rule_add_applies_to_addr" onclick='addAddressesToTable("rule_applies_to_addr","rule_applies_to_table_container","rule_applies_to_table",true)'><%~ Add %></button>
 	</div>
 	<div class="col-xs-offset-5 col-xs-7">
@@ -52,7 +52,7 @@
 
 <div id="rule_hours_active_container" class="indent">
 	<label class="col-xs-5" for='rule_hours_active' id='rule_hours_active_label'><%~ HActv %>:</label>
-	<span class="col-xs-offset-5 col-xs-7"><input type='text' id='rule_hours_active' size='30' onkeyup='proofreadHours(this)' class='form-control' /></span>
+	<span class="col-xs-offset-5 col-xs-7"><input type='text' id='rule_hours_active' size='30' oninput='proofreadHours(this)' class='form-control' /></span>
 	<div class="col-xs-offset-5 col-xs-7">
 		<em><%~ SSample %> 00:30-13:15, 14:00-15:00</em>
 	</div>
@@ -60,7 +60,7 @@
 
 <div id="rule_days_and_hours_active_container" class="indent">
 	<label class="col-xs-5" for='rule_days_and_hours_active' id='rule_days_and_hours_active_label'><%~ DHActv %>:</label>
-	<span class="col-xs-offset-5 col-xs-7"><input type='text' id='rule_days_and_hours_active' size='30' onkeyup='proofreadWeeklyRange(this)' class='form-control' /></span>
+	<span class="col-xs-offset-5 col-xs-7"><input type='text' id='rule_days_and_hours_active' size='30' oninput='proofreadWeeklyRange(this)' class='form-control' /></span>
 	<div class="col-xs-offset-5 col-xs-7">
 		<em><%~ Sample %></em>
 	</div>
@@ -85,7 +85,7 @@
 	<div id="rule_remote_ip_container" class="row form-group">
 		<div class="col-xs-offset-5 col-xs-7" id="rule_remote_ip_table_container"></div>
 		<div class="col-xs-offset-5 col-xs-7">
-			<input type='text' id='rule_remote_ip' size='30' onkeyup='proofreadMultipleIps(this)' class='form-control' />
+			<input type='text' id='rule_remote_ip' size='30' oninput='proofreadMultipleIps(this)' class='form-control' />
 			<button type="button" class="btn btn-default btn-add" id="rule_add_remote_ip" onclick='addAddressesToTable("rule_remote_ip","rule_remote_ip_table_container","rule_remote_ip_table",false)'><%~ Add %></button>
 		</div>
 	</div>
@@ -100,7 +100,7 @@
 			</select>
 		</span>
 		<span class='col-xs-offset-5 col-xs-7'>
-			<input type='text' id='rule_remote_port' onkeyup='proofreadMultiplePorts(this)' size='20' class='form-control' />
+			<input type='text' id='rule_remote_port' oninput='proofreadMultiplePorts(this)' size='20' class='form-control' />
 		</span>
 	</div>
 	<div class="row form-group">
@@ -113,7 +113,7 @@
 			</select>
 		</span>
 		<span class="col-xs-offset-5 col-xs-7">
-			<input class='form-control' type='text' id='rule_local_port' onkeyup='proofreadMultiplePorts(this)' size='20'/>
+			<input class='form-control' type='text' id='rule_local_port' oninput='proofreadMultiplePorts(this)' size='20'/>
 		</span>
 	</div>
 

--- a/package/gargoyle/files/www/templates/single_forward_template
+++ b/package/gargoyle/files/www/templates/single_forward_template
@@ -14,13 +14,13 @@
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='add_fp_label' for='add_fp'><%~ FPrt %></label>
-					<span class="col-xs-7"><input type='text' id='add_fp' onkeyup='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></span>
+					<span class="col-xs-7"><input type='text' id='add_fp' oninput='proofreadNumericRange(this,1,65535)' maxLength='5' class='form-control' /></span>
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='add_ip_label' for='add_ip'><%~ TIP %></label>
-					<span class="col-xs-7"><input type='text' id='add_ip' onkeyup='proofreadIp(this)' maxLength='15' class='form-control' /></span>
+					<span class="col-xs-7"><input type='text' id='add_ip' oninput='proofreadIp(this)' maxLength='15' class='form-control' /></span>
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='add_dp_label' for='add_dp'><%~ TPrt %></label>
-					<span class="col-xs-7"><input type='text' id='add_dp' onkeyup='proofreadNumeric(this,1,65535)' maxLength='5' class='form-control' /></span>
+					<span class="col-xs-7"><input type='text' id='add_dp' oninput='proofreadNumeric(this,1,65535)' maxLength='5' class='form-control' /></span>
 				</div>

--- a/package/gargoyle/files/www/templates/static_ip_template
+++ b/package/gargoyle/files/www/templates/static_ip_template
@@ -4,9 +4,9 @@
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='add_mac_label' for='add_mac'>MAC</label>
-					<span class="col-xs-7"><input type='text' id='add_mac' onkeyup='proofreadMac(this)' maxLength='17' class='form-control' /></span>
+					<span class="col-xs-7"><input type='text' id='add_mac' oninput='proofreadMac(this)' maxLength='17' class='form-control' /></span>
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='add_ip_label' for='add_ip'>IP</label>
-					<span class="col-xs-7"><input type='text' id='add_ip' onkeyup='proofreadIp(this)' maxLength='15' class='form-control' /></span>
+					<span class="col-xs-7"><input type='text' id='add_ip' oninput='proofreadIp(this)' maxLength='15' class='form-control' /></span>
 				</div>

--- a/package/gargoyle/files/www/templates/static_route_template
+++ b/package/gargoyle/files/www/templates/static_route_template
@@ -1,6 +1,6 @@
 				<div class="row form-group">
 					<label class="col-xs-5" id='add_dest_label' for='add_dest'><%~ routing.DstnM %></label>
-					<span class="col-xs-7"><input type='text' id='add_dest' class='form-control' onkeyup='proofreadRouteIp(this)' maxLength='35' /></span>
+					<span class="col-xs-7"><input type='text' id='add_dest' class='form-control' oninput='proofreadRouteIp(this)' maxLength='35' /></span>
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='add_iface_label' for='add_iface'><%~ Ntwk %></label>
@@ -13,5 +13,5 @@
 				</div>
 				<div class="row form-group">
 					<label class="col-xs-5" id='add_gateway_label' for='add_gateway'><%~ Gtwy %></label>
-					<span class="col-xs-7"><input type='text' id='add_gateway' onkeyup='proofreadGatewayIp(this)' maxLength='15' class='form-control' /></span>
+					<span class="col-xs-7"><input type='text' id='add_gateway' oninput='proofreadGatewayIp(this)' maxLength='15' class='form-control' /></span>
 				</div>

--- a/package/gargoyle/files/www/templates/whitelist_template
+++ b/package/gargoyle/files/www/templates/whitelist_template
@@ -17,7 +17,7 @@
 <div id="exception_applies_to_container" class="row form-group">
 	<div class="col-xs-offset-5 col-xs-7" id="exception_applies_to_table_container"></div>
 	<div class="col-xs-offset-5 col-xs-7">
-		<input type='text' id='exception_applies_to_addr' size='30' onkeyup='proofreadMultipleIpsOrMacs(this)' class='form-control' />
+		<input type='text' id='exception_applies_to_addr' size='30' oninput='proofreadMultipleIpsOrMacs(this)' class='form-control' />
 		<button type="button" class="btn btn-default btn-add" id="exception_add_applies_to_addr" onclick='addAddressesToTable("exception_applies_to_addr","exception_applies_to_table_container","exception_applies_to_table",true)'><%~ Add %></button>
 	</div>
 	<div class="col-xs-offset-5 col-xs-7">
@@ -52,7 +52,7 @@
 
 <div id="exception_hours_active_container" class="indent">
 	<label class='col-xs-5' for='exception_hours_active' id='exception_hours_active_label'><%~ HActv %>:</label>
-	<span class="col-xs-offset-5 col-xs-7"><input type='text' id='exception_hours_active' size='30' onkeyup='proofreadHours(this)' class='form-control' /></span>
+	<span class="col-xs-offset-5 col-xs-7"><input type='text' id='exception_hours_active' size='30' oninput='proofreadHours(this)' class='form-control' /></span>
 	<div class="col-xs-offset-5 col-xs-7">
 		<em><%~ SSample %> 00:30-13:15, 14:00-15:00</em>
 	</div>
@@ -60,7 +60,7 @@
 
 <div id="exception_days_and_hours_active_container" class="indent">
 	<label class='col-xs-5' for='exception_days_and_hours_active' id='exception_days_and_hours_active_label'><%~ DHActv %>:</label>
-	<span class="col-xs-offset-5 col-xs-7"><input type='text' id='exception_days_and_hours_active' size='30' onkeyup='proofreadWeeklyRange(this)' class='form-control' /></span>
+	<span class="col-xs-offset-5 col-xs-7"><input type='text' id='exception_days_and_hours_active' size='30' oninput='proofreadWeeklyRange(this)' class='form-control' /></span>
 	<div class="col-xs-offset-5 col-xs-7">
 		<em><%~ Sample %></em>
 	</div>
@@ -85,7 +85,7 @@
 	<div id="exception_remote_ip_container" class="row form-group">
 		<div class="col-xs-offset-5 col-xs-7" id="exception_remote_ip_table_container"></div>
 		<div class="col-xs-offset-5 col-xs-7">
-			<input type='text' id='exception_remote_ip' size='30' onkeyup='proofreadMultipleIps(this)' class='form-control' />
+			<input type='text' id='exception_remote_ip' size='30' oninput='proofreadMultipleIps(this)' class='form-control' />
 			<button type="button" class="btn btn-default btn-add" id="exception_add_remote_ip" onclick='addAddressesToTable("exception_remote_ip","exception_remote_ip_table_container","exception_remote_ip_table",false)'><%~ Add %></button>
 		</div>
 	</div>
@@ -100,7 +100,7 @@
 			</select>
 		</span>
 		<span class='col-xs-offset-5 col-xs-7'>
-			<input type='text' id='exception_remote_port' onkeyup='proofreadMultiplePorts(this)' size='20' class='form-control' />
+			<input type='text' id='exception_remote_port' oninput='proofreadMultiplePorts(this)' size='20' class='form-control' />
 		</span>
 	</div>
 	<div class="row form-group">
@@ -113,7 +113,7 @@
 			</select>
 		</span>
 		<span class="col-xs-offset-5 col-xs-7">
-			<input class='form-control' type='text' id='exception_local_port' onkeyup='proofreadMultiplePorts(this)' size='20'/>
+			<input class='form-control' type='text' id='exception_local_port' oninput='proofreadMultiplePorts(this)' size='20'/>
 		</span>
 	</div>
 

--- a/package/gargoyle/files/www/webmon.sh
+++ b/package/gargoyle/files/www/webmon.sh
@@ -42,12 +42,12 @@
 				<div>
 					<div class="row form-group">
 						<label class="col-xs-5" for="num_domains" id="num_domains_label"><%~ NumSt %>:</label>
-						<span class="col-xs-7"><input type="text" class="form-control" id="num_domains" onkeyup="proofreadNumericRange(this,1,9999)" size="6" maxlength="4" /></span>
+						<span class="col-xs-7"><input type="text" class="form-control" id="num_domains" oninput="proofreadNumericRange(this,1,9999)" size="6" maxlength="4" /></span>
 					</div>
 
 					<div class="row form-group">
 						<label class="col-xs-5" for="num_searches" id="num_searches_label"><%~ NumSr %>:</label>
-						<span class="col-xs-7"><input type="text" class="form-control" id="num_searches" onkeyup="proofreadNumericRange(this,1,9999)" size="6" maxlength="4" /></span>
+						<span class="col-xs-7"><input type="text" class="form-control" id="num_searches" oninput="proofreadNumericRange(this,1,9999)" size="6" maxlength="4" /></span>
 					</div>
 
 					<div class="row form-group">
@@ -63,7 +63,7 @@
 					<div id="add_ip_container">
 						<div class="row form-group">
 							<span class="col-xs-12">
-								<input type="text" id="add_ip" onkeyup="proofreadMultipleIps(this)" size="30" />
+								<input type="text" id="add_ip" oninput="proofreadMultipleIps(this)" size="30" />
 								<button class="btn btn-default btn-add" id="add_ip_button" onclick="addAddressesToTable(document, 'add_ip', 'ip_table_container', 'ip_table', false, 3, 1, 250)"><%~ Add %></button>
 							</span>
 							<em class="col-xs-12"><%~ SpcIP %></em>


### PR DESCRIPTION
While browsers ignore `autocomplete="off"` for both login and non-login password fields, there is a [new way](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields) to prevent non-login password fields from being autofilled with the currently saved password by marking them as those via `autocomplete="current-password"` for login  and `autocomplete="new-password"` for non-login fields. Browsers will suggest a randomly generated password for non-login fields instead of autofilling the saved one.

Currently, input validation is triggered `onkeyup` instead of `oninput`. This was necessary in the past due to inconsistencies across browsers but as part of HTML5 the behavior of `oninput` was standardized and is now [widely supported](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/oninput#Browser_compatibility). `oninput` additionally fires on cut/paste/autofill and is more responsive, try this [demo](https://mathiasbynens.be/demo/input).

Changes:

  * Append `autocomplete="current-password"` to login password fields (`login.sh`, `password_confirm_template `). **Updated**.
  * Append `autocomplete="new-password"` to non-login password fields.
  * Replace `onkeyup` with `oninput`.