### PR TITLE
Update page's uci once dropbear section is global.

### DIFF
--- a/package/gargoyle/files/www/js/access.js
+++ b/package/gargoyle/files/www/js/access.js
@@ -8,8 +8,6 @@
 
 var accessStr=new Object(); //part of i18n
 
-var stopRedirect = false;
-
 function saveChanges()
 {
 	var errorList = proofreadAll();
@@ -21,7 +19,7 @@ function saveChanges()
 	{
 		setControlsEnabled(false, true);
 
-		var uciCompare = uciOriginal.clone();
+		var uci = uciOriginal.clone();
 
 		var oldLocalHttpPort  = getHttpPort(uciOriginal);
 		var oldLocalHttpsPort = getHttpsPort(uciOriginal);
@@ -30,7 +28,6 @@ function saveChanges()
 		var dropbearSections = uciOriginal.getAllSections("dropbear");
 		var oldLocalSshPort = uciOriginal.get("dropbear", dropbearSections[0], "Port");
 
-		var firewallSectionCommands = [];
 		var remoteAcceptSections = uciOriginal.getAllSectionsOfType("firewall", "remote_accept");
 		while(remoteAcceptSections.length > 0)
 		{
@@ -38,11 +35,9 @@ function saveChanges()
 			var localPort = uciOriginal.get("firewall", lastSection, "local_port");
 			if(localPort == oldLocalSshPort || localPort == oldLocalHttpsPort || localPort == oldLocalHttpPort)
 			{
-				uciCompare.removeSection("firewall", lastSection);
-				firewallSectionCommands.push("uci del firewall." + lastSection);
+				uci.removeSection("firewall", lastSection);
 			}
 		}
-		var uci = uciCompare.clone();
 
 
 
@@ -56,7 +51,6 @@ function saveChanges()
 			uci.set("firewall", id, "remote_port", remote);
 			uci.set("firewall", id, "proto", "tcp");
 			uci.set("firewall", id, "zone", "wan");
-			firewallSectionCommands.push("uci set firewall." + id + "=remote_accept");
 		};
 		var localHttpPort = document.getElementById("local_http_port").value;
 		var remoteHttpPort = document.getElementById("remote_http_port").value;
@@ -94,32 +88,22 @@ function saveChanges()
 
 		//recreate dropbear config section if anonymous-- anonymous uci section can cause problems saving
 		var remoteAttempts =  document.getElementById("remote_ssh_attempts").disabled ? "" : getSelectedValue("remote_ssh_attempts");
-		var uciPreCommands = [];
-
 		var oldSshPwdEnabled = uciOriginal.get("dropbear", dropbearSections[0], "PasswordAuth");
 		var sshPwdEnabled = document.getElementById("pwd_auth_enabled").checked ? "on" : "off";
-		if(dropbearSections[0] != "global")
+		for(s = 0; s < dropbearSections.length; s++)
 		{
-			for(s=0; s < dropbearSections.length; s++)
+			if(dropbearSections[s] != "global")
 			{
-				uciPreCommands.push("uci del dropbear.@dropbear[0]" );
+				uci.removeSection("dropbear", dropbearSections[s]);
 			}
-			uciPreCommands.push("uci set dropbear.global=dropbear");
-			uciPreCommands.push("uci set dropbear.global.PasswordAuth='" + sshPwdEnabled + "'");
-			uciPreCommands.push("uci set dropbear.global.Port=" + localSshPort);
-			if(remoteAttempts != "") { uciPreCommands.push("uci set dropbear.global.max_remote_attempts='" + remoteAttempts + "'" ); }
-			uciPreCommands.push("uci commit");
 		}
-		else
-		{
-			//update dropbear uci configuration
-			uci.set("dropbear", "global", "Port", localSshPort);
-			if(remoteAttempts != "") { uci.set("dropbear", "global", "max_remote_attempts",  remoteAttempts ); }
-			uci.set("dropbear", "global", "PasswordAuth", sshPwdEnabled);
+		//update dropbear uci configuration
+		uci.set("dropbear", "global", "", "dropbear");
+		uci.set("dropbear", "global", "Port", localSshPort);
+		if(remoteAttempts != "") { uci.set("dropbear", "global", "max_remote_attempts",  remoteAttempts ); }
+		uci.set("dropbear", "global", "PasswordAuth", sshPwdEnabled);
 
-
-		}
- 		//only restart dropbear if we need to
+		//only restart dropbear if we need to
 		var restartDropbear = oldLocalSshPort != localSshPort || oldSshPwdEnabled != sshPwdEnabled;
 
 		var authorizedKeys = new Array();
@@ -246,11 +230,9 @@ function saveChanges()
 
 		var commands = passwordCommands + "\n";
 		commands += httpsCommands.join("\n") + "\n";
-		commands += firewallSectionCommands.join("\n") + "\n";
-		commands += uciPreCommands.join("\n") + "\n";
-		commands += uci.getScriptCommands(uciCompare) + "\n";
+		commands += uci.getScriptCommands(uciOriginal) + "\n";
 		commands += sshKeysCommands.join("\n") + "\n";
-		commands += restartFirewall ? "sh /usr/lib/gargoyle/restart_firewall.sh ;\n" : "";
+		commands += restartFirewall ? "sh /usr/lib/gargoyle/restart_firewall.sh\n" : "";
 		commands += restartDropbear ? "/etc/init.d/dropbear restart\n" : "";
 		commands += restartUhttpd ? "killall uhttpd\n/etc/init.d/uhttpd restart\n" : "";
 		//document.getElementById("output").value = commands;


### PR DESCRIPTION
After first boot, the dropbear section is anonymous. Saving changes of the access page the first time works but will reset page data incorrectly to the previous dropbear config. Reloading the page afterwards will correctly show the new dropbear config. Renaming (delete/add) the dropbear section to `'global'` was done by script commands which do not update the `uci` variable and thus `resetData()` will use the old dropbear section instead of the new one.

Now we use `uci.removeSection()` which immediately updates `uci` while the delete/add commands will be generated by `uci.getScriptCommands(uciOriginal)`. Doing this for both dropbear and firewall sections allows us to remove `uciCompare` entirely.