### PR TITLE
Fix SSID and RADIUS port validation.

### DIFF
--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -282,7 +282,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						</select>
 						<button class="btn btn-default" id="bridge_rescan_button" onclick="scanWifi('bridge_custom_ssid')"><%~ RScn %></button>
 						<div id="bridge_custom_ssid_container" class="second_row_right_column form-group">
-							<input type="text" class="form-control" id="bridge_custom_ssid" size="20" oninput="proofreadLengthRange(this,1,999)"/>
+							<input type="text" class="form-control" id="bridge_custom_ssid" size="20" maxlength="32" oninput="proofreadSsid(this)"/>
 						</div>
 
 					</span>
@@ -292,7 +292,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_ssid_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_ssid" id="bridge_ssid_label"><%~ Join %>:</label>
 					<span class="col-xs-7">
-						<input style="float:left;" type="text" id="bridge_ssid" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
+						<input style="float:left;" type="text" id="bridge_ssid" class="form-control" size="20" maxlength="32" oninput="proofreadSsid(this)"/>
 						<button style="float:left;" class="btn btn-default" id="bridge_scan_button" onclick="scanWifi('bridge_ssid')"><%~ Scan %></button>
 					</span>
 				</div>
@@ -300,7 +300,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="bridge_broadcast_ssid_container" class="row form-group">
 					<label class="col-xs-5" for="bridge_broadcast_ssid" id="bridge_broadcast_ssid_label"><%~ Bcst %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="bridge_broadcast_ssid" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
+						<input type="text" id="bridge_broadcast_ssid" class="form-control" size="20" maxlength="32" oninput="proofreadSsid(this)"/>
 					</span>
 				</div>
 
@@ -823,7 +823,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						</select>
 						<button class="btn btn-default" id="wifi_rescan_button" onclick="scanWifi('wifi_custom_ssid2')"><%~ RScn %></button>
 						<div id="wifi_custom_ssid2_container" class="second_row_right_column" >
-							<input type="text" id="wifi_custom_ssid2" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
+							<input type="text" id="wifi_custom_ssid2" class="form-control" size="20" maxlength="32" oninput="proofreadSsid(this)"/>
 						</div>
 
 					</span>
@@ -833,7 +833,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_ssid2_container" class="row form-group">
 					<label  class="col-xs-5" for="wifi_ssid2" id="wifi_ssid2_label">SSID:</label>
 					<span class="col-xs-7">
-						<input type="text" id="wifi_ssid2" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
+						<input type="text" id="wifi_ssid2" class="form-control" size="20" maxlength="32" oninput="proofreadSsid(this)"/>
 						<button class="btn btn-default" id="wifi_scan_button" onclick="scanWifi('wifi_ssid2')"><%~ Scan %></button>
 					</span>
 				</div>
@@ -920,14 +920,14 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_ssid1_container" class="row form-group">
 					<label class="col-xs-5" for="wifi_ssid1" id="wifi_ssid1_label"><%~ AcPtID %>:</label>
 					<span class="col-xs-7">
-						<input type="text" id="wifi_ssid1" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/><br/>
+						<input type="text" id="wifi_ssid1" class="form-control" size="20" maxlength="32" oninput="proofreadSsid(this)"/><br/>
 					</span>
 				</div>
 
 				<div id="wifi_ssid1a_container" class="row form-group">
 					<label class="col-xs-5" for="wifi_ssid1a" id="wifi_ssid1a_label">AP 5GHz SSID:</label>
 					<span class="col-xs-7">
-						<input type="text" id="wifi_ssid1a" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/>
+						<input type="text" id="wifi_ssid1a" class="form-control" size="20" maxlength="32" oninput="proofreadSsid(this)"/>
 					</span>
 				</div>
 
@@ -1022,7 +1022,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 				<div id="wifi_port1_container" class="row indent">
 					<label class="col-xs-5" for="wifi_port1" id="wifi_port1_label">RADIUS <%~ SrvPt %>:</label>
 					<span class="col-xs-7" >
-						<input type="text" id="wifi_port1" class="form-control" size="20" maxlength="5" oninput="proofreadNumeric(this)"/><br/>
+						<input type="text" id="wifi_port1" class="form-control" size="20" maxlength="5" oninput="proofreadPort(this)"/><br/>
 					</span>
 				</div>
 
@@ -1099,7 +1099,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<div id="wifi_guest_ssid1_container" class="row form-group">
 						<label class="col-xs-5" for="wifi_guest_ssid1" id="wifi_guest_ssid1_label"><%~ GNetID %>:</label>
 						<span class="col-xs-7">
-							<input type="text" id="wifi_guest_ssid1" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/><br/>
+							<input type="text" id="wifi_guest_ssid1" class="form-control" size="20" maxlength="32" oninput="proofreadSsid(this)"/><br/>
 							<input type="text" id="wifi_guest_mac_g" class="form-control" style="display: none"/>
 						</span>
 					</div>
@@ -1107,7 +1107,7 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<div id="wifi_guest_ssid1a_container" class="row form-group">
 						<label class="col-xs-5" for="wifi_guest_ssid1a" id="wifi_guest_ssid1a_label"><%~ GNet5ID %></label>
 						<span class="col-xs-7">
-							<input type="text" id="wifi_guest_ssid1a" class="form-control" size="20" oninput="proofreadLengthRange(this,1,999)"/><br/>
+							<input type="text" id="wifi_guest_ssid1a" class="form-control" size="20" maxlength="32" oninput="proofreadSsid(this)"/><br/>
 							<input type="text" id="wifi_guest_mac_a" class="form-control" style="display: none"/>
 						</span>
 					</div>

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -1087,10 +1087,12 @@ function proofreadAll()
 {
 	var vlr1 = function(text){return validateLengthRange(text,1,999);};
 	var vip = validateIP;
+	var vnp = validatePort;
 	var vnm = validateNetMask;
 	var vm = validateMac;
 	var vn = validateNumeric;
 	var vw = validateWep;
+	var vid = validateSsid;
 	var vp = function(text){ return validatePass(text, 'wifi_encryption1'); }
 	var vpg = function(text){ return validatePass(text, 'wifi_guest_encryption1'); }
 	var vp2 = function(text){ return validatePass(text, 'wifi_encryption2'); }
@@ -1115,7 +1117,7 @@ function proofreadAll()
 	{
 		var inputIds = ['wan_pppoe_user', 'wan_pppoe_pass', 'wan_pppoe_max_idle', 'wan_pppoe_reconnect_pings', 'wan_pppoe_interval', 'wan_static_ip', 'wan_static_mask', 'wan_static_gateway', 'wan_mac', 'wan_mtu', 'lan_ip', 'lan_mask', 'lan_gateway', 'wifi_txpower', 'wifi_txpower_5ghz', 'wifi_ssid1', 'wifi_pass1', 'wifi_wep1', 'wifi_ft_key', 'wifi_guest_pass1', 'wifi_guest_wep1', 'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_pass2', 'wifi_wep2', 'wan_3g_device', 'wan_3g_apn'];
 
-		var functions= [vlr1, vlr1, vn, vn, vn, vip, vnm, vip, vm, vn, vip, vnm, vip, vtp, vtpa, vlr1, vp, vw, vfk, vpg, vw, vip, vn, vlr1, vp2, vw, vlr1, vlr1];
+		var functions= [vlr1, vlr1, vn, vn, vn, vip, vnm, vip, vm, vn, vip, vnm, vip, vtp, vtpa, vid, vp, vw, vfk, vpg, vw, vip, vnp, vid, vp2, vw, vlr1, vlr1];
 
 		var optInputIds = ['wifi_ssid1a', 'wifi_guest_ssid1', 'wifi_guest_ssid1a']
 		for(index in optInputIds)
@@ -1124,7 +1126,7 @@ function proofreadAll()
 			if(document.getElementById(input + "_container").style.display == "block")
 			{
 				inputIds.push(input);
-				functions.push(vlr1);
+				functions.push(vid);
 			}
 		}
 
@@ -1152,7 +1154,7 @@ function proofreadAll()
 	else
 	{
 		var inputIds = ['bridge_ip', 'bridge_mask', 'bridge_gateway', 'bridge_txpower', 'bridge_ssid', 'bridge_pass', 'bridge_wep', 'bridge_broadcast_ssid'];
-		var functions = [vip, vnm, vip, vtp, vlr1,vpb,vw,vlr1];
+		var functions = [vip, vnm, vip, vtp, vid, vpb, vw, vid];
 		var returnCodes=[];
 		var visibilityIds=[];
 		var labelIds=[];

--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -1941,6 +1941,14 @@ function validateHex(text)
 }
 
 
+function validateSsid(ssid)
+{
+	return validateLengthRange(ssid, 1, 32)
+}
+function proofreadSsid(input)
+{
+	proofreadText(input, validateSsid, 0);
+}
 
 function validateHours(hoursStr)
 {


### PR DESCRIPTION
The [maximum length of an SSID](https://serverfault.com/questions/45439/what-is-the-maximum-length-of-a-wifi-access-points-ssid) is 32 bytes (the 1-character but 2-byte string `🤓` has a length of 2 for proofread). Currently, hostapd fails restarting when an SSID of 33 bytes is given:

```
daemon.err hostapd: Line 39: invalid SSID '12345678901234567890123456789012a'
```

The RADIUS port was not validated against a valid port range.