### PR TITLE
Fix readonly style for dark-one theme.

### DIFF
--- a/package/gargoyle/files/www/themes/Gargoyle/common.css
+++ b/package/gargoyle/files/www/themes/Gargoyle/common.css
@@ -194,7 +194,7 @@ input.text_disabled, select.select_disabled
 }
 input.form-control[readonly]
 {
-	background-color: transparent;
+	background-color: #fff;
 	border-style: dashed
 }
 #bottom_button_container

--- a/package/plugin-gargoyle-theme-dark-one/files/www/themes/Dark-One/theme.css
+++ b/package/plugin-gargoyle-theme-dark-one/files/www/themes/Dark-One/theme.css
@@ -548,6 +548,10 @@ input
 	padding:2px;
 	display:inline;
 }
+input.form-control[readonly]
+{
+	border-color: #333
+}
 select
 {
 	font-size:11px;


### PR DESCRIPTION
Previously the background-color of the readonly inputs was transparent, which doesn't work for dark themes (dark font on dark background). Also a dark dashed border is easier seen than a white one when the outer background is dark.