### PR TITLE
Improve webcam preview.

### DIFF
--- a/package/plugin-gargoyle-i18n-Czech-CS/files/www/i18n/Czech-CS/webcam.js
+++ b/package/plugin-gargoyle-i18n-Czech-CS/files/www/i18n/Czech-CS/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="Port";
 WebC.WebCUName="Název uživatele";
 WebC.WebCPass="Heslo";
 WebC.PrevWebC="Náhled";
+WebC.WebCSnapshot="Snímek z Webkamera";
+WebC.WebCStream="Proud Webkamera";
+WebC.WebCAlert="<b>Náhled není možný.</b><br/>Zkuste otevřít proud ručně.";
 WebC.WebCOpt="volitelný";
 
 WebC.ErrorPortWebC="Port serveru webcamery koliduje s ";
-WebC.AvelAtWebC="Webkamera je dostupná na ";

--- a/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/webcam.js
+++ b/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="Port";
 WebC.WebCUName="User Name";
 WebC.WebCPass="Password";
 WebC.PrevWebC="Preview";
+WebC.WebCSnapshot="Webcam Snapshot";
+WebC.WebCStream="Webcam Stream";
+WebC.WebCAlert="<b>Preview not possible.</b><br/>Try to open stream manually.";
 WebC.WebCOpt="optional";
 
 WebC.ErrorPortWebC="Webcam server port conflicts with ";
-WebC.AvelAtWebC="Webcam is available at ";

--- a/package/plugin-gargoyle-i18n-French-FR/files/www/i18n/French-FR/webcam.js
+++ b/package/plugin-gargoyle-i18n-French-FR/files/www/i18n/French-FR/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="Port";
 WebC.WebCUName="Nom utilisateur";
 WebC.WebCPass="Mot de passe";
 WebC.PrevWebC="Prévisualisation";
+WebC.WebCSnapshot="Instantané de la Webcam";
+WebC.WebCStream="Flux Webcam";
+WebC.WebCAlert="<b>Aperçu impossible.</b><br/>Essayez d'ouvrir le flux manuellement.";
 WebC.WebCOpt="optionnel";
 
 WebC.ErrorPortWebC="Le port du serveur Webcam entre en conflit avec ";
-WebC.AvelAtWebC="La Webcam est joignable à ";

--- a/package/plugin-gargoyle-i18n-German-DE/files/www/i18n/German-DE/webcam.js
+++ b/package/plugin-gargoyle-i18n-German-DE/files/www/i18n/German-DE/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="Port";
 WebC.WebCUName="Benutzername";
 WebC.WebCPass="Passwort";
 WebC.PrevWebC="Vorschau";
+WebC.WebCSnapshot="Webcam-Schnappschuss";
+WebC.WebCStream="Webcam-Stream";
+WebC.WebCAlert="<b>Vorschau nicht möglich.</b><br/>Versuchen Sie, den Stream manuell zu öffnen.";
 WebC.WebCOpt="optional";
 
 WebC.ErrorPortWebC="Webcam Serverport steht im Konflikt mit ";
-WebC.AvelAtWebC="Webcam ist verfügbar über ";

--- a/package/plugin-gargoyle-i18n-Norwegian-NO/files/www/i18n/Norwegian-NO/webcam.js
+++ b/package/plugin-gargoyle-i18n-Norwegian-NO/files/www/i18n/Norwegian-NO/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="Port";
 WebC.WebCUName="Brukernavn";
 WebC.WebCPass="Passord";
 WebC.PrevWebC="Forhåndsvisning";
+WebC.WebCSnapshot="Øyeblikksbilde av Webcam";
+WebC.WebCStream="Webcam-strøm";
+WebC.WebCAlert="<b>Forhåndsvisning ikke mulig.</b><br/>Prøv å åpne strømmen manuelt.";
 WebC.WebCOpt="valgfritt";
 
 WebC.ErrorPortWebC="Webcam server port er i konflikt med ";
-WebC.AvelAtWebC="Webcam er tilgjengelig på ";

--- a/package/plugin-gargoyle-i18n-Polish-PL/files/www/i18n/Polish-PL/webcam.js
+++ b/package/plugin-gargoyle-i18n-Polish-PL/files/www/i18n/Polish-PL/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="Port";
 WebC.WebCUName="Nazwa użytkownika";
 WebC.WebCPass="Hasło";
 WebC.PrevWebC="Podgląd obrazu";
+WebC.WebCSnapshot="Migawka Kamery";
+WebC.WebCStream="Strumień Kamery";
+WebC.WebCAlert="<b>Podgląd nie jest możliwy.</b><br/>Spróbuj otworzyć strumień ręcznie.";
 WebC.WebCOpt="opcjonalne";
 
 WebC.ErrorPortWebC="Nie można włączyć obsługi kamery - konflikt portu z wartością wpisaną w polu ";
-WebC.AvelAtWebC="Obraz z kamery dostępny jest pod adresem ";

--- a/package/plugin-gargoyle-i18n-Portuguese-BR/files/www/i18n/Portuguese-BR/webcam.js
+++ b/package/plugin-gargoyle-i18n-Portuguese-BR/files/www/i18n/Portuguese-BR/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="Porta";
 WebC.WebCUName="Nome de Usuário";
 WebC.WebCPass="Senha";
 WebC.PrevWebC="Pre-Visualização";
+WebC.WebCSnapshot="Instantâneo da Câmera";
+WebC.WebCStream="Fluxo de Câmera";
+WebC.WebCAlert="<b>Visualização não possível.</b><br/>Tente abrir o fluxo manualmente.";
 WebC.WebCOpt="opcional";
 
 WebC.ErrorPortWebC="Porta do servidor da Câmera em conflito com ";
-WebC.AvelAtWebC="A Câmera USB está disponível em ";

--- a/package/plugin-gargoyle-i18n-Russian-RU/files/www/i18n/Russian-RU/webcam.js
+++ b/package/plugin-gargoyle-i18n-Russian-RU/files/www/i18n/Russian-RU/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="Порт";
 WebC.WebCUName="Имя пользователя";
 WebC.WebCPass="Пароль";
 WebC.PrevWebC="Предпросмотр";
+WebC.WebCSnapshot="снимок с веб-камеры";
+WebC.WebCStream="Поток веб-камеры";
+WebC.WebCAlert="<b>Предварительный просмотр невозможен.</b><br/>Попробуйте открыть поток вручную.";
 WebC.WebCOpt="опционально";
 
 WebC.ErrorPortWebC="Порт сервера вебкамеры конфликтует с ";
-WebC.AvelAtWebC="Вебкамера доступна на ";

--- a/package/plugin-gargoyle-i18n-SimplifiedChinese-ZH-CN/files/www/i18n/SimplifiedChinese-ZH-CN/webcam.js
+++ b/package/plugin-gargoyle-i18n-SimplifiedChinese-ZH-CN/files/www/i18n/SimplifiedChinese-ZH-CN/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="端口";
 WebC.WebCUName="用户名";
 WebC.WebCPass="密码";
 WebC.PrevWebC="预览";
+WebC.WebCSnapshot="网络摄像头快照";
+WebC.WebCStream="网络摄像头流";
+WebC.WebCAlert="<b>无法预览。</b><br/>尝试手动打开视频流。";
 WebC.WebCOpt="选项";
 
 WebC.ErrorPortWebC="网络摄像头端口号冲突";
-WebC.AvelAtWebC="网络摄像头可用";

--- a/package/plugin-gargoyle-i18n-Slovak-SK/files/www/i18n/Slovak-SK/webcam.js
+++ b/package/plugin-gargoyle-i18n-Slovak-SK/files/www/i18n/Slovak-SK/webcam.js
@@ -14,7 +14,9 @@ WebC.WebCPort="Port";
 WebC.WebCUName="Názov užívateľa";
 WebC.WebCPass="Heslo";
 WebC.PrevWebC="Náhľad";
+WebC.WebCSnapshot="Snímka z Webkamera";
+WebC.WebCStream="Prúd Webkamera";
+WebC.WebCAlert="<b>Ukážka nie je možná.</b><br/>Pokúste sa prúd otvoriť ručne.";
 WebC.WebCOpt="voliteľný";
 
 WebC.ErrorPortWebC="Port servera webcamery koliduje s ";
-WebC.AvelAtWebC="Webkamera je dostupná na ";

--- a/package/plugin-gargoyle-webcam/files/www/webcam.sh
+++ b/package/plugin-gargoyle-webcam/files/www/webcam.sh
@@ -22,6 +22,13 @@ var webcams = [];
 
 	lan_ip=$(uci -p /tmp/state get network.lan.ipaddr 2>/dev/null)
 	echo "currentLanIp=\"$lan_ip\";"
+
+	echo "const REMOTE_ADDR = \"$REMOTE_ADDR\";";
+	echo "const SERVER_ADDR = \"$SERVER_ADDR\";";
+
+	echo "const HTTPS = \"$HTTPS\";";
+	echo "const HTTP_HOST = \"$HTTP_HOST\";";
+	echo "const SERVER_PORT = \"$SERVER_PORT\";";
 %>
 //-->
 </script>
@@ -42,7 +49,7 @@ var webcams = [];
 </div>
 
 <div id="webcam" class="row">
-	<div class="col-lg-6">
+	<div id="webcam_fieldset" class="col-lg-6">
 		<div class="panel panel-default">
 			<div class="panel-heading">
 				<h3 class="panel-title"><%~ webcam.WebC %></h3>
@@ -108,19 +115,42 @@ var webcams = [];
 			</div>
 		</div>
 	</div>
-</div>
-
-<div id="webcam_preview" class="row">
-	<div class="col-lg-6">
+	<div id="webcam_preview" class="col-lg-6">
 		<div class="panel panel-default">
 			<div class="panel-heading">
 				<h3 class="panel-title"><%~ PrevWebC %></h3>
 			</div>
 
-			<div class="panel-body">
-				<em><span id="webcam_info"></span></em>
-				<div>
-					<iframe id="videoframe" scrolling="no" border="0" width="320" height="240" frameBorder="0" src="about:blank" align="center"></iframe>
+			<div class="panel-body text-center">
+				<div class="row form-group">
+					<span class="col-xs-12">
+						<a id="webcam_snapshot" href="" target="_blank"><%~ WebCSnapshot %></a>
+					</span>
+				</div>
+				<div class="row form-group">
+					<span class="col-xs-12">
+						<input id="webcam_snapshot_url" class="form-control text-center" style="width: 100%" type="text" readonly="readonly" onclick="copy(this)"/>
+					</span>
+				</div>
+				<div class="row form-group">
+					<span class="col-xs-12">
+						<a id="webcam_stream" href="" target="_blank"><%~ WebCStream %></a>
+					</span>
+				</div>
+				<div class="row form-group">
+					<span class="col-xs-12">
+						<input id="webcam_stream_url" class="form-control text-center" style="width: 100%" type="text" readonly="readonly" onclick="copy(this)"/>
+					</span>
+				</div>
+				<div class="row form-group">
+					<span class="col-xs-12">
+						<a id="webcam_frame" href="" target="_blank">
+							<img alt="<%~ PrevWebC %>" src="" style="max-width: 100%"/>
+						</a>
+						<div id="webcam_alert" class="alert alert-info" role="alert">
+							<%~ WebCAlert %>
+						</div>
+					</span>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
  * Works now also with HTTPS, remote access, and reverse proxy.
  * Use `img` instead of `iframe`:
     * Allows to set `max-width` instead of `width`/`height` preserving aspect ratio.
     * Avoids infinite loading progress bar.
     * Avoids deprecated `iframe` attributes.
  * Place fieldset and preview panel into same row.
  * Make URL readonly input and copy to clipboard on click.
  * Add snapshot URL.
  * Alert when preview not possible and hint at opening manually since Chromium
    blocks *subresource* URLs with embedded credentials as first step to stop
    supporting these deprecated URLs.