### PR TITLE
Fix escaping UCI value.

### DIFF
--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -588,20 +588,20 @@ function UCIContainer()
 							for(vi=0; vi< newValue.length ; vi++)
 							{
 								var nv = "" + newValue[vi] + "";
-								commandArray.push( "uci add_list " + key + "=\'" + nv.replace(/'/, "'\\''") + "\'" );
+								commandArray.push( "uci add_list " + key + "=\'" + nv.replace(/'/g, "'\\''") + "\'" );
 							}
 						}
 					}
 					else
 					{
 						newValue = "" + newValue + ""
-						commandArray.push( "uci set " + key + "=\'" + newValue.replace(/'/, "'\\''") + "\'" );
+						commandArray.push( "uci set " + key + "=\'" + newValue.replace(/'/g, "'\\''") + "\'" );
 					}
 				}
 				else if(oldValue != newValue && (newValue != null && newValue !=''))
 				{
 					newValue = "" + newValue + ""
-					commandArray.push( "uci set " + key + "=\'" + newValue.replace(/'/, "'\\''") + "\'" );
+					commandArray.push( "uci set " + key + "=\'" + newValue.replace(/'/g, "'\\''") + "\'" );
 				}
 			}
 			catch(e)


### PR DESCRIPTION
Currently the value `123'45'678` cannot be saved (Wi-Fi password, SSID, ...). Only the first `'` occurrence is escaped, a `g` is missing in the regex.