### PR TITLE
adblock: fix path in prerm script

### DIFF
--- a/package/plugin-gargoyle-adblock/Makefile
+++ b/package/plugin-gargoyle-adblock/Makefile
@@ -52,7 +52,7 @@ endef
 define Package/plugin-gargoyle-adblock/prerm
 #!/bin/sh
 
-sh /usr/lib/runadblock.sh -disable
+sh /usr/lib/adblock/runadblock.sh -disable
 endef
 
 define Package/plugin-gargoyle-adblock/postrm


### PR DESCRIPTION
Please backport it also in 1.12