### PR TITLE
Updated URL list

### DIFF
--- a/package/gargoyle-ip-query/src/gipquery.c
+++ b/package/gargoyle-ip-query/src/gipquery.c
@@ -38,7 +38,7 @@ char default_ip_lookup_url[][MAX_LOOKUP_URL_LENGTH] = {
 							"http://www.tracemyip.org",
 							"http://checkip.dyndns.org",
 							"http://checkip.org",
-							"https://aruljohn.com",
+							"https://aruljohn.com/ip/",
 							"http://www.lawrencegoetz.com/programs/ipinfo/",
 							"http://myipinfo.net",
 							"http://www.myipnumber.com",


### PR DESCRIPTION
I updated the URL list with a more IP-friendly URL for IP lookup regarding the aruljohn.com entry. The current URL for aruljohn.com requires the webpage to be parsed to get the IP address. Visiting the new URL aruljohn.com/ip/ returns just the IP address.