### PR TITLE
plugin adblock: removing error display

### DIFF
--- a/package/plugin-gargoyle-adblock/Makefile
+++ b/package/plugin-gargoyle-adblock/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=plugin_gargoyle_adblock
 PKG_VERSION:=20191111
-PKG_RELEASE:=1.2.1
+PKG_RELEASE:=1.2.2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 

--- a/package/plugin-gargoyle-adblock/files/usr/lib/adblock/runadblock.sh
+++ b/package/plugin-gargoyle-adblock/files/usr/lib/adblock/runadblock.sh
@@ -18,7 +18,7 @@ ENDPOINT_IP4=`uci get adblock.config.endpoint4`
 CRON="0 4 * * 0 sh /plugin_root/usr/lib/adblock/runadblock.sh"
 
 #Check if Tor is enabled
-TOR=`uci get tor.global.enabled`
+TOR=`uci -q get tor.global.enabled`
 #### END CONFIG ####
 
 #### FUNCTIONS ####
@@ -58,7 +58,7 @@ add_config()
 	echo "$CRON" >> /etc/crontabs/root
 
 	#Add firewall rules unless TOR is enabled
-	if [ "$TOR" == 1 ]
+	if [ "${TOR:-0}" == 1 ]
 	then
 		logger -t ADBLOCK Tor is enabled, discarding firewall rules
 	else


### PR DESCRIPTION
Fixes for this if plugin tor is not installed:
```
root@Gargoyle:/usr/lib/adblock# sh ./runadblock.sh 
uci: Entry not found

```