### PR TITLE
plugin e-mail: some improvements

### DIFF
--- a/package/plugin-gargoyle-email-notifications/Makefile
+++ b/package/plugin-gargoyle-email-notifications/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=plugin-gargoyle-email-notifications
 PKG_VERSION:=2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)

--- a/package/plugin-gargoyle-email-notifications/files/usr/lib/gargoyle/email.sh
+++ b/package/plugin-gargoyle-email-notifications/files/usr/lib/gargoyle/email.sh
@@ -190,9 +190,9 @@ echo "</body></html>" >> /tmp/email-log.txt
 
 if printf '%s' "$tls" | egrep -q "0"
 then
-	cat /tmp/email-log.txt | sendmail $receiver 
+	cat /tmp/email-log.txt | msmtp $receiver
 else
-	cat /tmp/email-log.txt | sendmail --tls-trust-file $tlscert $receiver 
+	cat /tmp/email-log.txt | msmtp --tls-trust-file $tlscert $receiver
 fi
 
 rm /tmp/email-log.txt

--- a/package/plugin-gargoyle-email-notifications/files/www/email.sh
+++ b/package/plugin-gargoyle-email-notifications/files/www/email.sh
@@ -22,7 +22,7 @@ gargoyle_header_footer -h -s "system" -p "email_notifications" -j "email.js" -z 
 	fi
 	echo 'var msmtprc='"'$(cat /etc/msmtprc | tr '\n' ' ')'"';';
 	echo "var weekly_time=\"`date \"+%w-%H-%M\"`\";"
-	echo 'var TLSsupport='"'$(msmtp --version | grep OpenSSL)'"';';
+	echo 'var TLSsupport='"'$(msmtp --version | grep "TLS/SSL library: none")'"';';
 	webmon_enabled=$(ls /etc/rc.d/*webmon_gargoyle* 2>/dev/null)
 	if [ -n "$webmon_enabled" ] ; then
 		echo "var webmonEnabled=true;"

--- a/package/plugin-gargoyle-email-notifications/files/www/js/email.js
+++ b/package/plugin-gargoyle-email-notifications/files/www/js/email.js
@@ -860,13 +860,13 @@ function testMail() {
 		}else{
 			command = command + 'echo -e "account default\\nhost '+data['serverIP']+"\\nport "+data['serverPort']+"\\ndomain " + data['domain'] + "\\ntls on"+"\\nauth plain\\nuser " + data['username'] + "\\npassword " + data['password'] + "\\nauto_from off\\nfrom "+data['sender']+'" > /etc/msmtprc && ';
 		}
-		command = command + body + 'sendmail '+data['receiver']+' --syslog --tls-trust-file '+data['certpath']+' --timeout 30 && rm /etc/msmtprc && mv /tmp/msmtprc.tmp /etc/msmtprc';
+		command = command + body + 'msmtp '+data['receiver']+' --syslog --tls-trust-file '+data['certpath']+' --timeout 30 && rm /etc/msmtprc && mv /tmp/msmtprc.tmp /etc/msmtprc';
     } else {
 		if(!data['encryption']){
 			//Authentication and encryption disabled
-			command = body + 'sendmail --host='+data['serverIP']+' --port='+data['serverPort']+' --domain='+data['domain']+' --from '+data['sender']+' '+data['receiver']+' --timeout 30 --syslog';		
+			command = body + 'msmtp --host='+data['serverIP']+' --port='+data['serverPort']+' --domain='+data['domain']+' --from '+data['sender']+' '+data['receiver']+' --timeout 30 --syslog';
 		}else{
-			command = body + 'sendmail --host='+data['serverIP']+' --port='+data['serverPort']+' --domain='+data['domain']+' --tls=on --tls-trust-file='+data['certpath']+' --from '+data['sender']+' '+data['receiver']+' --timeout 30 --syslog';		
+			command = body + 'msmtp --host='+data['serverIP']+' --port='+data['serverPort']+' --domain='+data['domain']+' --tls=on --tls-trust-file='+data['certpath']+' --from '+data['sender']+' '+data['receiver']+' --timeout 30 --syslog';
 		}
     }
 	
@@ -901,7 +901,7 @@ function LoadData() {
 	
 	var config = readSendmailConfig();
 	
-	if(TLSsupport==''){
+	if(TLSsupport!=''){
 		document.getElementById("plain").checked = true;
 		document.getElementById("TLS").disabled = true;
 	}


### PR DESCRIPTION
- set the execution bit (group, other) to /usr/lib/gargoyle/email.sh
- reverse ssl library detection logic

msmtp can be installed from the openwrt repository and compiled with libgnutls. In this case, detection of the ssl library will fail (msmtp --version: "TLS / SSL Library: GnuTLS"). Reverse logic and detect msmtp without SSL support.

- by explicitly calling msmtp instead of sendmail

openwrt mstmp does not provide a link to sendmail

See old topic: https://www.gargoyle-router.com/phpbb/viewtopic.php?p=46337#p46337