### PR TITLE
ath79: Add support for TP-Link Archer C60 v3

### DIFF
--- a/targets/ath79/profiles/ath10k/config
+++ b/targets/ath79/profiles/ath10k/config
@@ -250,7 +250,8 @@ CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c60-v1=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c60-v1="kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9888-ct"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c60-v2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c60-v2="kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9888-ct"
-# CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c60-v3 is not set
+CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c60-v3=y
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c60-v3="kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9888-ct"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c7-v1=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c7-v1=""
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c7-v2 is not set

--- a/targets/ath79/profiles/ath10k/profile_images
+++ b/targets/ath79/profiles/ath10k/profile_images
@@ -3,5 +3,6 @@ tplink_archer-c2-v3-squashfs-
 tplink_archer-c58-v1-squashfs-
 tplink_archer-c60-v1-squashfs-
 tplink_archer-c60-v2-squashfs-
+tplink_archer-c60-v3-squashfs-
 tplink_archer-c6-v2-squashfs-
 tplink_archer-c7-v1-squashfs-


### PR DESCRIPTION
I have tried to add support for the tplink archer c60 v3 router. It is very similar to the v1 and v2 versions. I am not sure if i have done anything wrong, but i built an image and it seemed to work fine.