### PR TITLE
Update Edgerouter X profile image regexp to match OpenWrt 19.07 naming

### DIFF
--- a/targets/ramips/profiles/mt7621/profile_images
+++ b/targets/ramips/profiles/mt7621/profile_images
@@ -1,3 +1,3 @@
 netgear_wndr3700-v5-
-ubiquiti_edgerouterx-
+ubnt-erx-
 xiaomi_mir3g-


### PR DESCRIPTION
See image names for 19.07.8 at
https://downloads.openwrt.org/releases/19.07.8/targets/ramips/mt7621/