### PR TITLE
build: Properly set num_build_thread_str in auto mode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -288,6 +288,7 @@ elif [ "$num_build_threads" = "auto" ] ; then
 	num_cores=$(grep -c "^processor" /proc/cpuinfo 2>/dev/null)
 	if [ -z "$num_cores" ] ; then num_cores=1 ; fi
 	num_build_threads=$(($num_cores + 2)) # more threads than cores, since each thread will sometimes block for i/o
+	num_build_thread_str="-j$num_build_threads"
 elif [ "$num_build_threads" -lt 1 ] ; then
 	num_build_threads="1"
 	num_build_thread_str="-j1"

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -278,6 +278,7 @@ elif [ "$num_build_threads" = "auto" ] ; then
 	num_cores=$(grep -c "^processor" /proc/cpuinfo 2>/dev/null)
 	if [ -z "$num_cores" ] ; then num_cores=1 ; fi
 	num_build_threads=$(($num_cores + 2)) # more threads than cores, since each thread will sometimes block for i/o
+	num_build_thread_str="-j$num_build_threads"
 elif [ "$num_build_threads" -lt 1 ] ; then
 	num_build_threads="1"
 	num_build_thread_str="-j1"


### PR DESCRIPTION
As this var was not set, we only built in single-core mode when "auto"
was selected.

Signed-off-by: Jan Kiszka <jan.kiszka@web.de>