### PR TITLE
Updated IP address endpoints from aruljohn.com

### DIFF
--- a/package/ddns-gargoyle/src/check_local_ip_urls.c
+++ b/package/ddns-gargoyle/src/check_local_ip_urls.c
@@ -82,7 +82,7 @@ char default_ip_lookup_url_data[][MAX_LOOKUP_URL_LENGTH] = {
 							"http://www.tracemyip.org",
 							"http://checkip.dyndns.org",
 							"http://checkip.org",
-							"https://aruljohn.com/ip/",
+							"https://api.aruljohn.com/ip",
 							"http://www.lawrencegoetz.com/programs/ipinfo/",
 							"http://myipinfo.net",
 							"http://www.myipnumber.com",

--- a/package/ddns-gargoyle/src/ddns_updater.c
+++ b/package/ddns-gargoyle/src/ddns_updater.c
@@ -5,7 +5,7 @@
  * 			http://www.gargoyle-router.com
  * 		  
  *
- *  Copyright © 2008-2011 by Eric Bishop <eric@gargoyle-router.com>
+ *  Copyright ï¿½ 2008-2011 by Eric Bishop <eric@gargoyle-router.com>
  * 
  *  This file is free software: you may copy, redistribute and/or modify it
  *  under the terms of the GNU General Public License as published by the
@@ -88,7 +88,7 @@ char default_ip_lookup_url_data[][MAX_LOOKUP_URL_LENGTH] = {
 							"http://www.tracemyip.org",
 							"http://checkip.dyndns.org",
 							"http://checkip.org",
-							"https://aruljohn.com/ip/",
+							"https://api.aruljohn.com/ip",
 							"http://www.lawrencegoetz.com/programs/ipinfo/",
 							"http://myipinfo.net",
 							"http://www.myipnumber.com",
@@ -113,6 +113,7 @@ char default_ip6_lookup_url_data[][MAX_LOOKUP_URL_LENGTH] = {
 							"https://ifconfig.co/ip",
 							"https://ipapi.co/ip",
 							"https://api.ip.sb/ip",
+							"https://api.aruljohn.com/ip",
 							"\0"
 							};
 

--- a/package/gargoyle-ip-query/src/gipquery.c
+++ b/package/gargoyle-ip-query/src/gipquery.c
@@ -38,7 +38,7 @@ char default_ip_lookup_url[][MAX_LOOKUP_URL_LENGTH] = {
 							"http://www.tracemyip.org",
 							"http://checkip.dyndns.org",
 							"http://checkip.org",
-							"https://aruljohn.com/ip/",
+							"https://api.aruljohn.com/ip",
 							"http://www.lawrencegoetz.com/programs/ipinfo/",
 							"http://myipinfo.net",
 							"http://www.myipnumber.com",


### PR DESCRIPTION
I updated the IP address endpoints. The new IP address URL works for both IPv4 and IPv6 addresses, and is served through a high efficiency Go service running on api.aruljohn.com.

Old IP address URL:
https://aruljohn.com/ip/

New IP address:
https://api.aruljohn.com/ip
