### PR TITLE
ipq806x: add extra wifi driver and firmware packages, add support for Linksys EA7500 v1

### DIFF
--- a/targets/ath79/profiles/ath10k-large/config
+++ b/targets/ath79/profiles/ath10k-large/config
@@ -3124,16 +3124,16 @@ CONFIG_PACKAGE_ath10k-board-qca988x=m
 # CONFIG_PACKAGE_ath10k-firmware-qca4019-ct-htt is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca6174 is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca9377 is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca9887 is not set
+CONFIG_PACKAGE_ath10k-firmware-qca9887=m
 CONFIG_PACKAGE_ath10k-firmware-qca9887-ct=m
-# CONFIG_PACKAGE_ath10k-firmware-qca9887-ct-full-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca9888 is not set
+CONFIG_PACKAGE_ath10k-firmware-qca9887-ct-full-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca9888=m
 CONFIG_PACKAGE_ath10k-firmware-qca9888-ct=m
-# CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-full-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca988x is not set
+CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-full-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca988x=m
 CONFIG_PACKAGE_ath10k-firmware-qca988x-ct=m
-# CONFIG_PACKAGE_ath10k-firmware-qca988x-ct-full-htt is not set
+CONFIG_PACKAGE_ath10k-firmware-qca988x-ct-full-htt=m
 # CONFIG_PACKAGE_ath10k-firmware-qca9984 is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca9984-ct is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca9984-ct-full-htt is not set
@@ -4002,11 +4002,11 @@ CONFIG_ATH_USER_REGD=y
 # CONFIG_PACKAGE_ATH_DEBUG is not set
 CONFIG_PACKAGE_ATH_DFS=y
 # CONFIG_PACKAGE_ATH_DYNACK is not set
-# CONFIG_PACKAGE_kmod-ath10k is not set
+CONFIG_PACKAGE_kmod-ath10k=m
 CONFIG_PACKAGE_kmod-ath10k-ct=m
 CONFIG_ATH10K-CT_LEDS=y
-# CONFIG_PACKAGE_kmod-ath10k-ct-smallbuffers is not set
-# CONFIG_PACKAGE_kmod-ath10k-smallbuffers is not set
+CONFIG_PACKAGE_kmod-ath10k-ct-smallbuffers=m
+CONFIG_PACKAGE_kmod-ath10k-smallbuffers=m
 # CONFIG_PACKAGE_kmod-ath5k is not set
 # CONFIG_PACKAGE_kmod-ath6kl-sdio is not set
 # CONFIG_PACKAGE_kmod-ath6kl-usb is not set

--- a/targets/ath79/profiles/ath10k/config
+++ b/targets/ath79/profiles/ath10k/config
@@ -3125,16 +3125,16 @@ CONFIG_PACKAGE_ath10k-board-qca988x=m
 # CONFIG_PACKAGE_ath10k-firmware-qca4019-ct-htt is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca6174 is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca9377 is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca9887 is not set
+CONFIG_PACKAGE_ath10k-firmware-qca9887=m
 CONFIG_PACKAGE_ath10k-firmware-qca9887-ct=m
-# CONFIG_PACKAGE_ath10k-firmware-qca9887-ct-full-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca9888 is not set
+CONFIG_PACKAGE_ath10k-firmware-qca9887-ct-full-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca9888=m
 CONFIG_PACKAGE_ath10k-firmware-qca9888-ct=m
-# CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-full-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca988x is not set
+CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-full-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca988x=m
 CONFIG_PACKAGE_ath10k-firmware-qca988x-ct=m
-# CONFIG_PACKAGE_ath10k-firmware-qca988x-ct-full-htt is not set
+CONFIG_PACKAGE_ath10k-firmware-qca988x-ct-full-htt=m
 # CONFIG_PACKAGE_ath10k-firmware-qca9984 is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca9984-ct is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca9984-ct-full-htt is not set
@@ -4003,11 +4003,11 @@ CONFIG_ATH_USER_REGD=y
 # CONFIG_PACKAGE_ATH_DEBUG is not set
 CONFIG_PACKAGE_ATH_DFS=y
 # CONFIG_PACKAGE_ATH_DYNACK is not set
-# CONFIG_PACKAGE_kmod-ath10k is not set
+CONFIG_PACKAGE_kmod-ath10k=m
 CONFIG_PACKAGE_kmod-ath10k-ct=m
 CONFIG_ATH10K-CT_LEDS=y
 CONFIG_PACKAGE_kmod-ath10k-ct-smallbuffers=m
-# CONFIG_PACKAGE_kmod-ath10k-smallbuffers is not set
+CONFIG_PACKAGE_kmod-ath10k-smallbuffers=m
 # CONFIG_PACKAGE_kmod-ath5k is not set
 # CONFIG_PACKAGE_kmod-ath6kl-sdio is not set
 # CONFIG_PACKAGE_kmod-ath6kl-usb is not set

--- a/targets/ipq806x/profiles/default/config
+++ b/targets/ipq806x/profiles/default/config
@@ -2654,17 +2654,17 @@ CONFIG_PACKAGE_ath10k-board-qca99x0=m
 # CONFIG_PACKAGE_ath10k-firmware-qca9888-ct is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-full-htt is not set
 # CONFIG_PACKAGE_ath10k-firmware-qca9888-ct-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca988x is not set
+CONFIG_PACKAGE_ath10k-firmware-qca988x=m
 CONFIG_PACKAGE_ath10k-firmware-qca988x-ct=m
-# CONFIG_PACKAGE_ath10k-firmware-qca988x-ct-full-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca9984 is not set
+CONFIG_PACKAGE_ath10k-firmware-qca988x-ct-full-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca9984=m
 CONFIG_PACKAGE_ath10k-firmware-qca9984-ct=m
-# CONFIG_PACKAGE_ath10k-firmware-qca9984-ct-full-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca9984-ct-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca99x0 is not set
+CONFIG_PACKAGE_ath10k-firmware-qca9984-ct-full-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca9984-ct-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca99x0=m
 CONFIG_PACKAGE_ath10k-firmware-qca99x0-ct=m
-# CONFIG_PACKAGE_ath10k-firmware-qca99x0-ct-full-htt is not set
-# CONFIG_PACKAGE_ath10k-firmware-qca99x0-ct-htt is not set
+CONFIG_PACKAGE_ath10k-firmware-qca99x0-ct-full-htt=m
+CONFIG_PACKAGE_ath10k-firmware-qca99x0-ct-htt=m
 # CONFIG_PACKAGE_ath6k-firmware is not set
 # CONFIG_PACKAGE_ath9k-htc-firmware is not set
 # CONFIG_PACKAGE_b43legacy-firmware is not set
@@ -3516,11 +3516,11 @@ CONFIG_PACKAGE_kmod-ath=y
 CONFIG_ATH_USER_REGD=y
 # CONFIG_PACKAGE_ATH_DEBUG is not set
 CONFIG_PACKAGE_ATH_DFS=y
-# CONFIG_PACKAGE_kmod-ath10k is not set
+CONFIG_PACKAGE_kmod-ath10k=m
 CONFIG_PACKAGE_kmod-ath10k-ct=m
 CONFIG_ATH10K-CT_LEDS=y
-# CONFIG_PACKAGE_kmod-ath10k-ct-smallbuffers is not set
-# CONFIG_PACKAGE_kmod-ath10k-smallbuffers is not set
+CONFIG_PACKAGE_kmod-ath10k-ct-smallbuffers=m
+CONFIG_PACKAGE_kmod-ath10k-smallbuffers=m
 # CONFIG_PACKAGE_kmod-ath5k is not set
 # CONFIG_PACKAGE_kmod-ath6kl-sdio is not set
 # CONFIG_PACKAGE_kmod-ath6kl-usb is not set

--- a/targets/ipq806x/profiles/default/config
+++ b/targets/ipq806x/profiles/default/config
@@ -75,7 +75,8 @@ CONFIG_TARGET_PER_DEVICE_ROOTFS=y
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_buffalo_wxr-2533dhp is not set
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_compex_wpq864 is not set
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_edgecore_ecw5410 is not set
-# CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_linksys_ea7500-v1 is not set
+CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_linksys_ea7500-v1=y
+CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_linksys_ea7500-v1="kmod-ath10k-ct ath10k-firmware-qca99x0-ct"
 CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_linksys_ea8500=y
 CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_linksys_ea8500="kmod-ath10k-ct ath10k-firmware-qca99x0-ct"
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_nec_wg2600hp is not set

--- a/targets/ipq806x/profiles/default/profile_images
+++ b/targets/ipq806x/profiles/default/profile_images
@@ -1,3 +1,4 @@
+linksys_ea7500-v1-squashfs-
 linksys_ea8500-squashfs-
 netgear_d7800-squashfs-
 netgear_r7500v2-squashfs-


### PR DESCRIPTION
Commit cca11a2:
While the ct (Candela Tech) driver and firmware packages are the
OpenWrt default, and should remain the Gargoyle default, some users
report better results with the original (aka non-ct) driver and
firmware packages.  As these are kmods, the OpenWrt packages can't
be used for Gargoyle so build them to give Gargoyle users the
option of installing them in place of the default ct packages.

Additionally there are now several variants of the ct firmware
packages and smallbuffers variants (which reduce memory
consumption) of the both ct and non-ct driver packages so build
them as well.

Commit 27eb818:
OpenWrt 21.02 added support for the Linksys EA7500 v1, which is
similar to the Linksys EA8500 except for having 256MB of RAM
(instead of 512MB) and 3 antennas (instead 4 antennas).