### PR TITLE
`make menuconfig` related config fixes

### DIFF
--- a/files-generic/config/Config-gargoyle.in
+++ b/files-generic/config/Config-gargoyle.in
@@ -93,6 +93,8 @@ menuconfig USE_GARGOYLE_PROFILE_PKGS
 			select PACKAGE_plugin-gargoyle-webshell
 			select PACKAGE_plugin-gargoyle-wifi-schedule
 			select PACKAGE_resolveip
+			select PACKAGE_ksmbd-server if !GARGOYLE_SMB_KSMBD
+			select PACKAGE_samba36-server if !GARGOYLE_SMB_SAMBA
 			help
 				Other plugin packages
 

--- a/package/gargoyle-firewall-util/Makefile
+++ b/package/gargoyle-firewall-util/Makefile
@@ -15,7 +15,7 @@ define Package/gargoyle-firewall-util
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=A couple of shell script routines for firewall initialization
-	DEPENDS:=+ebtables +libericstools +uci +libiptbwctl +iptables-mod-filter +iptables-mod-ipopt +iptables-mod-conntrack-extra +iptables-mod-nat-extra +iptables-mod-extra +iptables-mod-iprange +iptables-mod-bandwidth +iptables-mod-timerange +iptables-mod-weburl +kmod-gre +kmod-pptp +kmod-tun +kmod-nf-nathelper +kmod-nf-nathelper-extra +ipset +kmod-ipt-ipset
+	DEPENDS:=+ebtables +libericstools +uci +libiptbwctl +iptables-mod-filter +iptables-mod-ipopt +iptables-mod-conntrack-extra +iptables-mod-nat-extra +iptables-mod-extra +iptables-mod-iprange +iptables-mod-bandwidth +iptables-mod-timerange +iptables-mod-weburl +kmod-tun +kmod-nf-nathelper +kmod-nf-nathelper-extra +ipset +kmod-ipt-ipset
 	MAINTAINER:=Eric Bishop <eric@gargoyle-router.com>
 endef
 

--- a/package/gargoyle-profiles/Makefile
+++ b/package/gargoyle-profiles/Makefile
@@ -10,6 +10,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/gargoyle-profiles/Default
 	CATEGORY:=Administration
+	SUBMENU:=Gargoyle Profile Meta-packages
 	SECTION:=admin
 	TITLE:=Gargoyle device profile -
 	MAINTAINER:=Eric Bishop <eric@gargoyle-router.com>

--- a/package/gargoyle/Makefile
+++ b/package/gargoyle/Makefile
@@ -30,12 +30,16 @@ define Package/gargoyle
 	SECTION:=admin
 	CATEGORY:=Administration
 	TITLE:=Gargoyle Web Interface
-	DEPENDS:=+uci +libuci +libjson-c +haserl-i18n +uhttpd +libustream-openssl +bwmon-gargoyle +webmon-gargoyle +gargoyle-firewall-util +libericstools +gpkg +gargoyle-ip-query  $(ATH_DEPS) $(BRCM_DEPS) $(LED_DEPS)
+	DEPENDS:=+uci +libuci +libjson-c +haserl-i18n +uhttpd +libustream-openssl +bwmon-gargoyle +webmon-gargoyle +libericstools +gpkg +gargoyle-ip-query  $(ATH_DEPS) $(BRCM_DEPS) $(LED_DEPS)
 	MAINTAINER:=Eric Bishop <eric@gargoyle-router.com>
 endef
 
 define Package/gargoyle/description
 	A user-friendly web interface for OpenWrt
+endef
+
+define Package/gargoyle/config
+	select PACKAGE_gargoyle-firewall-util
 endef
 
 define Build/Prepare

--- a/package/plugin-gargoyle-usb-storage-full/Config.in
+++ b/package/plugin-gargoyle-usb-storage-full/Config.in
@@ -1,0 +1,17 @@
+if PACKAGE_plugin-gargoyle-usb-storage-full
+
+comment "SMB Server"
+
+choice
+	prompt "Select Default SMB Server"
+	default GARGOYLE_SMB_KSMBD
+
+	config GARGOYLE_SMB_KSMBD
+		bool "KSMBD"
+
+	config GARGOYLE_SMB_SAMBA
+		bool "Samba"
+
+endchoice
+
+endif

--- a/package/plugin-gargoyle-usb-storage-full/Makefile
+++ b/package/plugin-gargoyle-usb-storage-full/Makefile
@@ -25,13 +25,18 @@ define Package/plugin-gargoyle-usb-storage-full
 	CATEGORY:=Administration
 	SUBMENU:=Gargoyle Web Interface
 	TITLE:=USB Storage Support for Gargoyle (Full)
-	DEPENDS:=+plugin-gargoyle-usb-storage-noshare +share-users +nfs-kernel-server +nfs-kernel-server-utils +nfs-utils +vsftpd +gargoyle-sambapkg
+	DEPENDS:=+plugin-gargoyle-usb-storage-noshare +share-users +nfs-kernel-server +nfs-kernel-server-utils +nfs-utils +vsftpd +GARGOYLE_SMB_KSMBD:ksmbd-server +GARGOYLE_SMB_SAMBA:samba36-server
 	MAINTAINER:=Eric Bishop
 	PKGARCH:=all
+	MENU:=1
 endef
 
 define Package/plugin-gargoyle-usb-storage-full/description
 	USB Storage Support for Gargoyle
+endef
+
+define Package/plugin-gargoyle-usb-storage-full/config
+	source "$(SOURCE)/Config.in"
 endef
 
 define Build/Prepare


### PR DESCRIPTION
The first 4 commits (bf6b32b, c973d6d, f38e7b3, 4bc7f7e) all relate to an issue where `make defconfig` correctly sets all the expected package selections but then `make menuconfig` won't display the profile meta-package selections or preserve them in the output .config.  These changes represent the least invasive changes I was able to identify that rectified the `make menuconfig` behaviour and with them in place I was able to generate an ath79 config from a diffconfig with the profile meta-packages specified in device packages lists (as discussed in recent comments to #959) and then select an additional device and specify one of the profile meta-packages as a device package and have `make menuconfig` retain everything in the base .config and include the extra config items for the additional device in the final .config.

Commit e666b5b is a very minor, non-critical, cleanup to the gargoyle-firewall-util package to scrounge back a smidgin more flash storage on devices without plugin-gargoyle-pptp installed.