### PR TITLE
Fixed displaying DNS addresses

### DIFF
--- a/package/gargoyle/files/www/overview.sh
+++ b/package/gargoyle/files/www/overview.sh
@@ -60,7 +60,7 @@
 
 	lan_ip=$(/sbin/uci get network.lan.ipaddr 2>/dev/null)
 	if [ -n "$lan_ip" ] ; then
-		echo "var wanDns=\""$(sed -e '/nameserver/!d; s#nameserver ##g' /tmp/resolv.conf.auto | sort | uniq | grep -v "$lan_ip" )"\";"
+		echo "var wanDns=\""$(sed -e '/nameserver/!d; s#nameserver ##g' /tmp/resolv.conf.auto | sort | uniq | grep -v "${lan_ip}$" )"\";"
 	else
 		echo "var wanDns=\""$(sed -e '/nameserver/!d; s#nameserver ##g' /tmp/resolv.conf.auto | sort | uniq )"\";"
 	fi


### PR DESCRIPTION
Removing exactly the IP address, not a string of characters starting with that address. If the DNS address is in the same address class as LAN, it is removed from the list but should stay.

For example
```
echo "192.168.1.100" | grep -v '192.168.1.1'
(return nothing)

echo "192.168.1.100" | grep -v '192.168.1.1$'
192.168.1.100
```
Also please add these changes to other branch.