### PR TITLE
USB profile rejig and various other cleanups

### DIFF
--- a/package/gargoyle-profiles/Makefile
+++ b/package/gargoyle-profiles/Makefile
@@ -45,7 +45,7 @@ endef
 define Package/gargoyle-usb
 	$(call Package/gargoyle-profiles/Default)
 	TITLE+= basic functionality, USB local storage, USB networking
-	DEPENDS+= +plugin-gargoyle-usb-storage-noshare
+	DEPENDS+= +plugin-gargoyle-usb-storage-extroot
 endef
 
 define Package/gargoyle-usb/description

--- a/package/plugin-gargoyle-usb-storage-noshare/Makefile
+++ b/package/plugin-gargoyle-usb-storage-noshare/Makefile
@@ -20,27 +20,48 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/plugin-gargoyle-usb-storage-noshare
+define Package/plugin-gargoyle-usb-storage-extroot
 	SECTION:=admin
 	CATEGORY:=Administration
 	SUBMENU:=Gargoyle Web Interface
-	TITLE:=USB Storage Support for Gargoyle (No share)
+	TITLE:=USB Storage Support for Gargoyle (ext4, msdos only)
 	DEPENDS:=+gargoyle +fdisk +blkid 
 	DEPENDS+=+libusb-1.0 +chat +kmod-usb-acm +kmod-usb-serial +comgt +comgt-ncm +usb-modeswitch
 	DEPENDS+=+kmod-usb-wdm +kmod-usb-net-qmi-wwan +uqmi +kmod-usb-net-cdc-ncm +kmod-usb-net-huawei-cdc-ncm +kmod-usb-net-cdc-ether +kmod-usb-net-rndis
 	DEPENDS+=+umbim +kmod-usb-net-cdc-mbim
 	DEPENDS+=+kmod-usb2 +kmod-usb-storage-uas +kmod-usb-net +kmod-usb-serial-option +kmod-usb-serial-qualcomm +kmod-usb-serial-wwan +kmod-usb-serial-sierrawireless
-	DEPENDS+=+kmod-usb-net-sierrawireless +e2fsprogs +kmod-usb-storage +kmod-usb-storage-extras +swap-utils +block-mount
-	DEPENDS+=+badblocks +kmod-fs-ext4 +kmod-fs-msdos +kmod-fs-vfat +kmod-fs-hfsplus
-	DEPENDS+=+kmod-nls-base +kmod-nls-cp1250 +kmod-nls-cp1251 +kmod-nls-cp437 +kmod-nls-cp775 +kmod-nls-cp850 
-	DEPENDS+=+kmod-nls-cp852 +kmod-nls-cp866 +kmod-nls-iso8859-1 +kmod-nls-iso8859-13 +kmod-nls-iso8859-15 
-	DEPENDS+=+kmod-nls-iso8859-2 +kmod-nls-koi8r +kmod-nls-utf8 +disktype +kmod-fuse +ntfs-3g
+	DEPENDS+=+kmod-usb-net-sierrawireless +e2fsprogs +kmod-usb-storage +kmod-usb-storage-extras +block-mount
+	DEPENDS+=+badblocks +kmod-fs-ext4 +kmod-fs-msdos +kmod-fs-vfat
+	DEPENDS+=+kmod-nls-base +kmod-nls-cp437 +kmod-nls-iso8859-1
+	DEPENDS+=+kmod-nls-utf8 +disktype
+	MAINTAINER:=Eric Bishop
+	PKGARCH:=all
+endef
+
+define Package/plugin-gargoyle-usb-storage-extroot/description
+	USB Networking and Storage Support for Gargoyle
+	(ext4 and msdos filesystems only, swap and extroot support,
+	 no CIFS/FTP/SMB sharing)
+endef
+
+define Package/plugin-gargoyle-usb-storage-noshare
+	SECTION:=admin
+	CATEGORY:=Administration
+	SUBMENU:=Gargoyle Web Interface
+	TITLE:=USB Storage Support for Gargoyle (complete)
+	DEPENDS:=+plugin-gargoyle-usb-storage-extroot
+	DEPENDS+=+kmod-fs-hfsplus
+	DEPENDS+=+kmod-nls-cp1250 +kmod-nls-cp1251 +kmod-nls-cp775 +kmod-nls-cp850 
+	DEPENDS+=+kmod-nls-cp852 +kmod-nls-cp866 +kmod-nls-iso8859-13 +kmod-nls-iso8859-15 
+	DEPENDS+=+kmod-nls-iso8859-2 +kmod-nls-koi8r +kmod-fuse +ntfs-3g
 	MAINTAINER:=Eric Bishop
 	PKGARCH:=all
 endef
 
 define Package/plugin-gargoyle-usb-storage-noshare/description
-	USB Storage Support for Gargoyle (without CIFS/FTP/SMB sharing)
+	USB Networking and Storage Support for Gargoyle
+	(all supported filesystems, swap and extroot support,
+	 no CIFS/FTP/SMB sharing)
 endef
 
 define Build/Prepare
@@ -52,9 +73,14 @@ endef
 define Build/Compile
 endef
 
-define Package/plugin-gargoyle-usb-storage-noshare/install
+define Package/plugin-gargoyle-usb-storage-extroot/install
 	$(INSTALL_DIR) $(1)
 	$(CP) ./files/* $(1)/
 endef
 
+define Package/plugin-gargoyle-usb-storage-noshare/install
+	/bin/true
+endef
+
+$(eval $(call BuildPackage,plugin-gargoyle-usb-storage-extroot))
 $(eval $(call BuildPackage,plugin-gargoyle-usb-storage-noshare))

--- a/targets/ath79/profiles/default/config
+++ b/targets/ath79/profiles/default/config
@@ -588,7 +588,7 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_openmesh_om5p-ac-v2="gargoyle
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e1700ac-v2-16m=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e1700ac-v2-16m="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e1700ac-v2-8m=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e1700ac-v2-8m="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e1700ac-v2-8m="gargoyle-basic"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e558-v2-16m is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e558-v2-8m is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e600g-v2-16m is not set
@@ -718,7 +718,7 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr842n-v1="gargoyle
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr842n-v2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr842n-v2="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr902ac-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr902ac-v1="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr902ac-v1="gargoyle-basic"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr941hp-v1 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_wbs210-v1 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_wbs210-v2 is not set

--- a/targets/ath79/profiles/default/config
+++ b/targets/ath79/profiles/default/config
@@ -407,13 +407,13 @@ CONFIG_TARGET_PER_DEVICE_ROOTFS=y
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_buffalo_bhr-4grv is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_buffalo_bhr-4grv2 is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_buffalo_wzr-600dhp=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_buffalo_wzr-600dhp="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_buffalo_wzr-600dhp="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_buffalo_wzr-hp-ag300h=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_buffalo_wzr-hp-ag300h="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_buffalo_wzr-hp-g300nh-rb=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_buffalo_wzr-hp-g300nh-rb="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_buffalo_wzr-hp-g300nh-rb="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_buffalo_wzr-hp-g300nh-s=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_buffalo_wzr-hp-g300nh-s="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_buffalo_wzr-hp-g300nh-s="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_buffalo_wzr-hp-g302h-a1a0 is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_buffalo_wzr-hp-g450h=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_buffalo_wzr-hp-g450h="gargoyle-large"
@@ -444,7 +444,7 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_comfast_cf-e375ac="gargoyle-l
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dap-3662-a1 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dch-g020-a1 is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dir-505=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-505="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-505="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dir-825-b1=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-825-b1="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dir-825-c1=y
@@ -452,13 +452,13 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-825-c1="gargoyle-la
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dir-835-a1=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-835-a1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dir-842-c1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-842-c1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-842-c1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dir-842-c2=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-842-c2="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-842-c2="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dir-842-c3=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-842-c3="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-842-c3="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_dlink_dir-859-a1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-859-a1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_dlink_dir-859-a1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_devolo_dlan-pro-1200plus-ac=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_devolo_dlan-pro-1200plus-ac="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_devolo_magic-2-wifi is not set
@@ -525,7 +525,7 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_jjplus_ja76pf2="gargoyle-larg
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_netgear_ex7300-v2 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_netgear_wndap360 is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_netgear_wndr3700=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_netgear_wndr3700="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_netgear_wndr3700="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_netgear_wndr3700-v2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_netgear_wndr3700-v2="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_netgear_wndr3800=y
@@ -539,7 +539,7 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_netgear_wndrmac-v2="gargoyle-
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_netgear_wnr2200-16m=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_netgear_wnr2200-16m="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_netgear_wnr2200-8m=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_netgear_wnr2200-8m="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_netgear_wnr2200-8m="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_ocedo_koala is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_ocedo_raccoon is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_ocedo_ursus is not set
@@ -567,11 +567,11 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_openmesh_om2p-v4="gargoyle-ba
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_openmesh_om2p-hs-v4 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_openmesh_om2p-lc is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_openmesh_om5p=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_openmesh_om5p="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_openmesh_om5p="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_openmesh_om5p-ac-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_openmesh_om5p-ac-v1="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_openmesh_om5p-ac-v1="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_openmesh_om5p-ac-v2=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_openmesh_om5p-ac-v2="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_openmesh_om5p-ac-v2="gargoyle-basic"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_openmesh_om5p-an is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_phicomm_k2t is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_pisen_wmm003n is not set
@@ -586,15 +586,15 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_openmesh_om5p-ac-v2="gargoyle
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qca_ap143-16m is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qca_ap143-8m is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e1700ac-v2-16m=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e1700ac-v2-16m="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e1700ac-v2-16m="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e1700ac-v2-8m=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e1700ac-v2-8m="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e1700ac-v2-8m="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e558-v2-16m is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e558-v2-8m is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e600g-v2-16m is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e600g-v2-8m is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e600gac-v2-16m=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e600gac-v2-16m="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e600gac-v2-16m="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e600gac-v2-8m=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_qxwlan_e600gac-v2-8m="gargoyle-basic"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_qxwlan_e750a-v4-16m is not set
@@ -642,7 +642,7 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c60-v2="gargoyl
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c60-v3=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c60-v3="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c7-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c7-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c7-v1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c7-v2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c7-v2="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_archer-c7-v4=y
@@ -680,9 +680,9 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_archer-c7-v5="gargoyle
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wa1201-v2 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wdr3500-v1 is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wdr3600-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wdr3600-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wdr3600-v1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wdr4300-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wdr4300-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wdr4300-v1="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wdr4300-v1-il is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wdr4310-v1 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wdr4900-v2 is not set
@@ -691,22 +691,22 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wdr4300-v1="gargoyl
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr1043n-v5=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr1043n-v5="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr1043nd-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr1043nd-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr1043nd-v1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr1043nd-v2=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr1043nd-v2="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr1043nd-v2="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr1043nd-v3=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr1043nd-v3="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr1043nd-v3="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr1043nd-v4=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr1043nd-v4="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr1045nd-v2 is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr2543-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr2543-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr2543-v1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr710n-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr710n-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr710n-v1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr710n-v2.1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr710n-v2.1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr710n-v2.1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr810n-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr810n-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr810n-v1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr810n-v2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr810n-v2="gargoyle-basic"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr841hp-v2 is not set
@@ -714,20 +714,20 @@ CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr810n-v2="gargoyle
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr842n-v3=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr842n-v3="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr842n-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr842n-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr842n-v1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr842n-v2=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr842n-v2="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr842n-v2="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr902ac-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr902ac-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_tplink_tl-wr902ac-v1="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_tl-wr941hp-v1 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_wbs210-v1 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_wbs210-v2 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_wbs510-v1 is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_tplink_wbs510-v2 is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_trendnet_tew-673gru=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_trendnet_tew-673gru="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_trendnet_tew-673gru="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_trendnet_tew-823dru=y
-CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_trendnet_tew-823dru="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_trendnet_tew-823dru="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_ubnt_aircube-ac is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_ubnt_aircube-isp is not set
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_ubnt_bullet-ac=y
@@ -2816,8 +2816,11 @@ CONFIG_BUSYBOX_CONFIG_PIVOT_ROOT=y
 # CONFIG_BUSYBOX_CONFIG_LINUX64 is not set
 # CONFIG_BUSYBOX_CONFIG_SETPRIV is not set
 # CONFIG_BUSYBOX_CONFIG_SETSID is not set
-# CONFIG_BUSYBOX_CONFIG_SWAPON is not set
-# CONFIG_BUSYBOX_CONFIG_SWAPOFF is not set
+CONFIG_BUSYBOX_CONFIG_SWAPON=y
+CONFIG_BUSYBOX_CONFIG_FEATURE_SWAPON_DISCARD=y
+CONFIG_BUSYBOX_CONFIG_FEATURE_SWAPON_PRI=y
+CONFIG_BUSYBOX_CONFIG_SWAPOFF=y
+# CONFIG_BUSYBOX_CONFIG_FEATURE_SWAPONOFF_LABEL is not set
 CONFIG_BUSYBOX_CONFIG_SWITCH_ROOT=y
 # CONFIG_BUSYBOX_CONFIG_TASKSET is not set
 # CONFIG_BUSYBOX_CONFIG_UEVENT is not set
@@ -3183,8 +3186,8 @@ CONFIG_PACKAGE_jsonfilter=y
 CONFIG_PACKAGE_libc=y
 CONFIG_PACKAGE_libgcc=y
 # CONFIG_PACKAGE_libgomp is not set
-CONFIG_PACKAGE_libpthread=y
-CONFIG_PACKAGE_librt=y
+CONFIG_PACKAGE_libpthread=m
+CONFIG_PACKAGE_librt=m
 # CONFIG_PACKAGE_libstdcpp is not set
 CONFIG_PACKAGE_logd=y
 CONFIG_PACKAGE_mtd=y
@@ -3208,7 +3211,7 @@ CONFIG_PACKAGE_resolveip=m
 # CONFIG_PACKAGE_rpcd is not set
 # CONFIG_PACKAGE_selinux-policy is not set
 # CONFIG_PACKAGE_snapshot-tool is not set
-CONFIG_PACKAGE_swconfig=y
+CONFIG_PACKAGE_swconfig=m
 CONFIG_PACKAGE_ubox=y
 CONFIG_PACKAGE_ubus=y
 CONFIG_PACKAGE_ubusd=y
@@ -3272,7 +3275,7 @@ CONFIG_PACKAGE_plugin-gargoyle-minidlna=m
 CONFIG_PACKAGE_plugin-gargoyle-openvpn=m
 CONFIG_PACKAGE_plugin-gargoyle-ping-watchdog=m
 CONFIG_PACKAGE_plugin-gargoyle-pptp=m
-CONFIG_PACKAGE_plugin-gargoyle-qos=y
+CONFIG_PACKAGE_plugin-gargoyle-qos=m
 CONFIG_PACKAGE_plugin-gargoyle-qr-code=m
 CONFIG_PACKAGE_plugin-gargoyle-spectrum-analyser=m
 CONFIG_PACKAGE_plugin-gargoyle-spectrum-analyser-minimal=m
@@ -3296,6 +3299,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=m
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=m
 CONFIG_PACKAGE_plugin-gargoyle-webcam=m
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -3524,15 +3528,15 @@ CONFIG_PACKAGE_kmod-scsi-core=m
 #
 # Cryptographic API modules
 #
-CONFIG_PACKAGE_kmod-crypto-aead=y
+CONFIG_PACKAGE_kmod-crypto-aead=m
 CONFIG_PACKAGE_kmod-crypto-arc4=m
 # CONFIG_PACKAGE_kmod-crypto-authenc is not set
 CONFIG_PACKAGE_kmod-crypto-cbc=m
-CONFIG_PACKAGE_kmod-crypto-ccm=y
+CONFIG_PACKAGE_kmod-crypto-ccm=m
 # CONFIG_PACKAGE_kmod-crypto-chacha20poly1305 is not set
-CONFIG_PACKAGE_kmod-crypto-cmac=y
-CONFIG_PACKAGE_kmod-crypto-crc32c=y
-CONFIG_PACKAGE_kmod-crypto-ctr=y
+CONFIG_PACKAGE_kmod-crypto-cmac=m
+CONFIG_PACKAGE_kmod-crypto-crc32c=m
+CONFIG_PACKAGE_kmod-crypto-ctr=m
 CONFIG_PACKAGE_kmod-crypto-cts=m
 # CONFIG_PACKAGE_kmod-crypto-deflate is not set
 CONFIG_PACKAGE_kmod-crypto-des=m
@@ -3541,11 +3545,11 @@ CONFIG_PACKAGE_kmod-crypto-ecb=m
 # CONFIG_PACKAGE_kmod-crypto-echainiv is not set
 # CONFIG_PACKAGE_kmod-crypto-essiv is not set
 # CONFIG_PACKAGE_kmod-crypto-fcrypt is not set
-CONFIG_PACKAGE_kmod-crypto-gcm=y
-CONFIG_PACKAGE_kmod-crypto-gf128=y
-CONFIG_PACKAGE_kmod-crypto-ghash=y
-CONFIG_PACKAGE_kmod-crypto-hash=y
-CONFIG_PACKAGE_kmod-crypto-hmac=y
+CONFIG_PACKAGE_kmod-crypto-gcm=m
+CONFIG_PACKAGE_kmod-crypto-gf128=m
+CONFIG_PACKAGE_kmod-crypto-ghash=m
+CONFIG_PACKAGE_kmod-crypto-hash=m
+CONFIG_PACKAGE_kmod-crypto-hmac=m
 # CONFIG_PACKAGE_kmod-crypto-hw-hifn-795x is not set
 # CONFIG_PACKAGE_kmod-crypto-hw-padlock is not set
 CONFIG_PACKAGE_kmod-crypto-kpp=m
@@ -3553,18 +3557,18 @@ CONFIG_PACKAGE_kmod-crypto-lib-chacha20=m
 CONFIG_PACKAGE_kmod-crypto-lib-chacha20poly1305=m
 CONFIG_PACKAGE_kmod-crypto-lib-curve25519=m
 CONFIG_PACKAGE_kmod-crypto-lib-poly1305=m
-CONFIG_PACKAGE_kmod-crypto-manager=y
+CONFIG_PACKAGE_kmod-crypto-manager=m
 CONFIG_PACKAGE_kmod-crypto-md4=m
 CONFIG_PACKAGE_kmod-crypto-md5=m
 # CONFIG_PACKAGE_kmod-crypto-michael-mic is not set
 # CONFIG_PACKAGE_kmod-crypto-misc is not set
-CONFIG_PACKAGE_kmod-crypto-null=y
+CONFIG_PACKAGE_kmod-crypto-null=m
 # CONFIG_PACKAGE_kmod-crypto-pcbc is not set
 # CONFIG_PACKAGE_kmod-crypto-rmd160 is not set
-CONFIG_PACKAGE_kmod-crypto-rng=y
-CONFIG_PACKAGE_kmod-crypto-seqiv=y
+CONFIG_PACKAGE_kmod-crypto-rng=m
+CONFIG_PACKAGE_kmod-crypto-seqiv=m
 CONFIG_PACKAGE_kmod-crypto-sha1=m
-CONFIG_PACKAGE_kmod-crypto-sha256=y
+CONFIG_PACKAGE_kmod-crypto-sha256=m
 CONFIG_PACKAGE_kmod-crypto-sha512=m
 # CONFIG_PACKAGE_kmod-crypto-test is not set
 # CONFIG_PACKAGE_kmod-crypto-user is not set
@@ -3758,8 +3762,8 @@ CONFIG_PACKAGE_kmod-asn1-decoder=y
 # CONFIG_PACKAGE_kmod-lib-cordic is not set
 CONFIG_PACKAGE_kmod-lib-crc-ccitt=y
 # CONFIG_PACKAGE_kmod-lib-crc-itu-t is not set
-CONFIG_PACKAGE_kmod-lib-crc16=y
-CONFIG_PACKAGE_kmod-lib-crc32c=y
+CONFIG_PACKAGE_kmod-lib-crc16=m
+CONFIG_PACKAGE_kmod-lib-crc32c=m
 # CONFIG_PACKAGE_kmod-lib-crc7 is not set
 # CONFIG_PACKAGE_kmod-lib-crc8 is not set
 # CONFIG_PACKAGE_kmod-lib-lz4 is not set
@@ -3831,13 +3835,13 @@ CONFIG_PACKAGE_kmod-ipt-ipset=y
 # CONFIG_PACKAGE_kmod-ipt-led is not set
 CONFIG_PACKAGE_kmod-ipt-nat=y
 CONFIG_PACKAGE_kmod-ipt-nat-extra=y
-CONFIG_PACKAGE_kmod-ipt-nat6=y
+CONFIG_PACKAGE_kmod-ipt-nat6=m
 # CONFIG_PACKAGE_kmod-ipt-nflog is not set
 # CONFIG_PACKAGE_kmod-ipt-nfqueue is not set
 CONFIG_PACKAGE_kmod-ipt-offload=y
 # CONFIG_PACKAGE_kmod-ipt-physdev is not set
 CONFIG_PACKAGE_kmod-ipt-raw=y
-CONFIG_PACKAGE_kmod-ipt-raw6=y
+CONFIG_PACKAGE_kmod-ipt-raw6=m
 # CONFIG_PACKAGE_kmod-ipt-rpfilter is not set
 # CONFIG_PACKAGE_kmod-ipt-socket is not set
 # CONFIG_PACKAGE_kmod-ipt-tee is not set
@@ -3856,7 +3860,7 @@ CONFIG_PACKAGE_kmod-nf-ipt6=y
 CONFIG_PACKAGE_kmod-nf-log=y
 CONFIG_PACKAGE_kmod-nf-log6=y
 CONFIG_PACKAGE_kmod-nf-nat=y
-CONFIG_PACKAGE_kmod-nf-nat6=y
+CONFIG_PACKAGE_kmod-nf-nat6=m
 CONFIG_PACKAGE_kmod-nf-nathelper=y
 CONFIG_PACKAGE_kmod-nf-nathelper-extra=y
 CONFIG_PACKAGE_kmod-nf-reject=y
@@ -3907,16 +3911,16 @@ CONFIG_PACKAGE_kmod-nfnetlink=y
 # CONFIG_PACKAGE_kmod-hfcpci is not set
 # CONFIG_PACKAGE_kmod-i40e is not set
 # CONFIG_PACKAGE_kmod-iavf is not set
-CONFIG_PACKAGE_kmod-ifb=y
+CONFIG_PACKAGE_kmod-ifb=m
 # CONFIG_PACKAGE_kmod-igb is not set
 # CONFIG_PACKAGE_kmod-igc is not set
 # CONFIG_PACKAGE_kmod-ipvlan is not set
 # CONFIG_PACKAGE_kmod-ixgbe is not set
 # CONFIG_PACKAGE_kmod-ixgbevf is not set
-CONFIG_PACKAGE_kmod-libphy=m
+# CONFIG_PACKAGE_kmod-libphy is not set
 # CONFIG_PACKAGE_kmod-macvlan is not set
 # CONFIG_PACKAGE_kmod-mdio-gpio is not set
-CONFIG_PACKAGE_kmod-mii=y
+CONFIG_PACKAGE_kmod-mii=m
 # CONFIG_PACKAGE_kmod-mlx4-core is not set
 # CONFIG_PACKAGE_kmod-mlx5-core is not set
 # CONFIG_PACKAGE_kmod-natsemi is not set
@@ -4000,15 +4004,15 @@ CONFIG_PACKAGE_kmod-pppoe=y
 # CONFIG_PACKAGE_kmod-pppol2tp is not set
 CONFIG_PACKAGE_kmod-pppox=y
 CONFIG_PACKAGE_kmod-pptp=m
-CONFIG_PACKAGE_kmod-sched=y
+CONFIG_PACKAGE_kmod-sched=m
 # CONFIG_PACKAGE_kmod-sched-act-ipt is not set
 # CONFIG_PACKAGE_kmod-sched-act-police is not set
 # CONFIG_PACKAGE_kmod-sched-act-sample is not set
 # CONFIG_PACKAGE_kmod-sched-act-vlan is not set
 # CONFIG_PACKAGE_kmod-sched-bpf is not set
 # CONFIG_PACKAGE_kmod-sched-cake is not set
-CONFIG_PACKAGE_kmod-sched-connmark=y
-CONFIG_PACKAGE_kmod-sched-core=y
+CONFIG_PACKAGE_kmod-sched-connmark=m
+CONFIG_PACKAGE_kmod-sched-core=m
 # CONFIG_PACKAGE_kmod-sched-ctinfo is not set
 # CONFIG_PACKAGE_kmod-sched-drr is not set
 # CONFIG_PACKAGE_kmod-sched-flower is not set
@@ -4554,7 +4558,7 @@ CONFIG_PACKAGE_libusbmuxd=m
 # CONFIG_PACKAGE_libaudit is not set
 CONFIG_PACKAGE_libbbtargz=y
 # CONFIG_PACKAGE_libbfd is not set
-CONFIG_PACKAGE_libblkid=y
+CONFIG_PACKAGE_libblkid=m
 CONFIG_PACKAGE_libblobmsg-json=y
 # CONFIG_PACKAGE_libbpf is not set
 # CONFIG_PACKAGE_libbsd is not set
@@ -4692,7 +4696,7 @@ CONFIG_PACKAGE_libusb-1.0=m
 # CONFIG_PACKAGE_libustream-mbedtls is not set
 CONFIG_PACKAGE_libustream-openssl=y
 CONFIG_PACKAGE_libustream-wolfssl=m
-CONFIG_PACKAGE_libuuid=y
+CONFIG_PACKAGE_libuuid=m
 # CONFIG_PACKAGE_libv4l is not set
 CONFIG_PACKAGE_libvorbis=m
 CONFIG_PACKAGE_libwrap=m
@@ -4701,7 +4705,7 @@ CONFIG_PACKAGE_libxml2=m
 # CONFIG_PACKAGE_musl-fts is not set
 # CONFIG_PACKAGE_p11-kit is not set
 CONFIG_PACKAGE_terminfo=m
-CONFIG_PACKAGE_zlib=y
+CONFIG_PACKAGE_zlib=m
 
 #
 # Configuration
@@ -4863,16 +4867,16 @@ CONFIG_PACKAGE_p910nd=m
 # CONFIG_PACKAGE_genl is not set
 # CONFIG_PACKAGE_ip-bridge is not set
 # CONFIG_PACKAGE_ip-full is not set
-CONFIG_PACKAGE_ip-tiny=y
+CONFIG_PACKAGE_ip-tiny=m
 # CONFIG_PACKAGE_lldpd is not set
 # CONFIG_PACKAGE_nstat is not set
 # CONFIG_PACKAGE_rdma is not set
-CONFIG_PACKAGE_relayd=y
+CONFIG_PACKAGE_relayd=m
 # CONFIG_PACKAGE_ss is not set
 # CONFIG_PACKAGE_tc-bpf is not set
 # CONFIG_PACKAGE_tc-full is not set
 # CONFIG_PACKAGE_tc-mod-iptables is not set
-CONFIG_PACKAGE_tc-tiny=y
+CONFIG_PACKAGE_tc-tiny=m
 # end of Routing and Redirection
 
 #
@@ -5043,7 +5047,7 @@ CONFIG_PACKAGE_gargoyle-tor=m
 # CONFIG_PACKAGE_ipip is not set
 CONFIG_PACKAGE_ipset=y
 # CONFIG_PACKAGE_ipset-dns is not set
-CONFIG_PACKAGE_iw=y
+CONFIG_PACKAGE_iw=m
 # CONFIG_PACKAGE_iw-full is not set
 CONFIG_PACKAGE_libipset=y
 CONFIG_PACKAGE_libiptbwctl=y
@@ -5073,7 +5077,7 @@ CONFIG_PACKAGE_ppp-mod-pptp=m
 # CONFIG_PACKAGE_pppdump is not set
 # CONFIG_PACKAGE_pppoe-discovery is not set
 # CONFIG_PACKAGE_pppstats is not set
-CONFIG_PACKAGE_qos-gargoyle=y
+CONFIG_PACKAGE_qos-gargoyle=m
 # CONFIG_PACKAGE_rpcapd is not set
 CONFIG_PACKAGE_rpcbind=m
 CONFIG_RPCBIND_LIBWRAP=y
@@ -5089,11 +5093,11 @@ CONFIG_PACKAGE_SAMBA_MAX_DEBUG_LEVEL=-1
 # CONFIG_PACKAGE_tcpdump-mini is not set
 CONFIG_PACKAGE_uclient-fetch=m
 # CONFIG_PACKAGE_umdns is not set
-CONFIG_PACKAGE_usteer=y
+CONFIG_PACKAGE_usteer=m
 # CONFIG_PACKAGE_ustp is not set
 # CONFIG_PACKAGE_vxlan is not set
 # CONFIG_PACKAGE_wpan-tools is not set
-CONFIG_PACKAGE_wwan=y
+CONFIG_PACKAGE_wwan=m
 # end of Network
 
 #
@@ -5191,7 +5195,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem

--- a/targets/ath79/profiles/nand/config
+++ b/targets/ath79/profiles/nand/config
@@ -2626,6 +2626,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=m
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=m
 CONFIG_PACKAGE_plugin-gargoyle-webcam=m
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -4521,7 +4522,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem

--- a/targets/custom/profiles/default/config
+++ b/targets/custom/profiles/default/config
@@ -3170,6 +3170,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=y
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=y
 CONFIG_PACKAGE_plugin-gargoyle-webcam=y
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -5058,7 +5059,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem

--- a/targets/ipq40xx/profiles/default/config
+++ b/targets/ipq40xx/profiles/default/config
@@ -2742,6 +2742,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=m
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=m
 CONFIG_PACKAGE_plugin-gargoyle-webcam=m
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -4657,7 +4658,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem

--- a/targets/ipq806x/profiles/default/config
+++ b/targets/ipq806x/profiles/default/config
@@ -2645,6 +2645,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=m
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=m
 CONFIG_PACKAGE_plugin-gargoyle-webcam=m
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -4558,7 +4559,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem

--- a/targets/ipq806x/profiles/default/config
+++ b/targets/ipq806x/profiles/default/config
@@ -88,30 +88,31 @@ CONFIG_TARGET_PER_DEVICE_ROOTFS=y
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_compex_wpq864 is not set
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_edgecore_ecw5410 is not set
 CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_linksys_ea7500-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_linksys_ea7500-v1="kmod-ath10k-ct ath10k-firmware-qca99x0-ct"
+CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_linksys_ea7500-v1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_linksys_ea8500=y
-CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_linksys_ea8500="kmod-ath10k-ct ath10k-firmware-qca99x0-ct"
+CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_linksys_ea8500="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_nec_wg2600hp is not set
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_nec_wg2600hp3 is not set
 CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_netgear_d7800=y
-CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_netgear_d7800="kmod-ath10k-ct ath10k-firmware-qca99x0-ct"
+CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_netgear_d7800="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_netgear_r7500 is not set
 CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_netgear_r7500v2=y
-CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_netgear_r7500v2="kmod-ath10k-ct ath10k-firmware-qca99x0-ct"
+CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_netgear_r7500v2="gargoyle-large"
 CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_netgear_r7800=y
-CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_netgear_r7800="kmod-ath10k-ct ath10k-firmware-qca9984-ct"
-# CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_netgear_xr500 is not set
+CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_netgear_r7800="gargoyle-large"
+CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_netgear_xr500=y
+CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_netgear_xr500="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_qcom_ipq8064-ap148-legacy is not set
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_qcom_ipq8064-ap148 is not set
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_qcom_ipq8064-ap161 is not set
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_qcom_ipq8064-db149 is not set
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_tplink_ad7200 is not set
 CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_tplink_c2600=y
-CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_tplink_c2600="kmod-ath10k-ct ath10k-firmware-qca99x0-ct"
+CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_tplink_c2600="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_tplink_vr2600v is not set
 # CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_ubnt_unifi-ac-hd is not set
 CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_zyxel_nbg6817=y
-CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_zyxel_nbg6817="kmod-ath10k-ct ath10k-firmware-qca9984-ct"
+CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_zyxel_nbg6817="gargoyle-large"
 # end of Target Devices
 
 CONFIG_HAS_SUBTARGETS=y
@@ -2578,9 +2579,9 @@ CONFIG_PACKAGE_usign=y
 #
 # Gargoyle Profile Meta-packages
 #
-# CONFIG_PACKAGE_gargoyle-basic is not set
-# CONFIG_PACKAGE_gargoyle-large is not set
-# CONFIG_PACKAGE_gargoyle-usb is not set
+CONFIG_PACKAGE_gargoyle-basic=m
+CONFIG_PACKAGE_gargoyle-large=m
+CONFIG_PACKAGE_gargoyle-usb=m
 # end of Gargoyle Profile Meta-packages
 
 #

--- a/targets/ipq806x/profiles/default/config
+++ b/targets/ipq806x/profiles/default/config
@@ -523,7 +523,7 @@ CONFIG_PER_FEED_REPO=y
 # Base system
 #
 CONFIG_PACKAGE_base-files=y
-CONFIG_PACKAGE_block-mount=y
+CONFIG_PACKAGE_block-mount=m
 # CONFIG_PACKAGE_blockd is not set
 CONFIG_PACKAGE_busybox=y
 CONFIG_BUSYBOX_CUSTOM=y
@@ -2591,8 +2591,8 @@ CONFIG_PACKAGE_gargoyle=y
 CONFIG_PACKAGE_gargoyle-i18n=y
 CONFIG_PACKAGE_plugin-gargoyle-adblock=m
 CONFIG_PACKAGE_plugin-gargoyle-cron=m
-CONFIG_PACKAGE_plugin-gargoyle-ddns=y
-CONFIG_PACKAGE_plugin-gargoyle-diagnostics=y
+CONFIG_PACKAGE_plugin-gargoyle-ddns=m
+CONFIG_PACKAGE_plugin-gargoyle-diagnostics=m
 
 #
 # Diagnostics Plugin Configuration
@@ -2615,10 +2615,10 @@ CONFIG_PACKAGE_plugin-gargoyle-i18n-SimplifiedChinese-ZH-CN=m
 CONFIG_PACKAGE_plugin-gargoyle-i18n-Slovak-SK=m
 CONFIG_PACKAGE_plugin-gargoyle-i18n-Spanish-ES=m
 CONFIG_PACKAGE_plugin-gargoyle-initd=m
-CONFIG_PACKAGE_plugin-gargoyle-ipheth-tether=y
+CONFIG_PACKAGE_plugin-gargoyle-ipheth-tether=m
 CONFIG_PACKAGE_plugin-gargoyle-logread=m
-CONFIG_PACKAGE_plugin-gargoyle-minidlna=y
-CONFIG_PACKAGE_plugin-gargoyle-openvpn=y
+CONFIG_PACKAGE_plugin-gargoyle-minidlna=m
+CONFIG_PACKAGE_plugin-gargoyle-openvpn=m
 CONFIG_PACKAGE_plugin-gargoyle-ping-watchdog=m
 CONFIG_PACKAGE_plugin-gargoyle-pptp=m
 CONFIG_PACKAGE_plugin-gargoyle-qos=y
@@ -2635,22 +2635,22 @@ CONFIG_PACKAGE_plugin-gargoyle-theme-green=m
 CONFIG_PACKAGE_plugin-gargoyle-theme-horchata=m
 CONFIG_PACKAGE_plugin-gargoyle-theme-light=m
 CONFIG_PACKAGE_plugin-gargoyle-theme-xeye=m
-CONFIG_PACKAGE_plugin-gargoyle-tor=y
-CONFIG_PACKAGE_plugin-gargoyle-upnp=y
-CONFIG_PACKAGE_plugin-gargoyle-usb-printer=y
-CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=y
+CONFIG_PACKAGE_plugin-gargoyle-tor=m
+CONFIG_PACKAGE_plugin-gargoyle-upnp=m
+CONFIG_PACKAGE_plugin-gargoyle-usb-printer=m
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=m
 
 #
 # SMB Server
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
-CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=y
-CONFIG_PACKAGE_plugin-gargoyle-webcam=y
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=m
+CONFIG_PACKAGE_plugin-gargoyle-webcam=m
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
 CONFIG_PACKAGE_plugin-gargoyle-wifi-schedule=m
-CONFIG_PACKAGE_plugin-gargoyle-wireguard=y
-CONFIG_PACKAGE_plugin-gargoyle-wol=y
+CONFIG_PACKAGE_plugin-gargoyle-wireguard=m
+CONFIG_PACKAGE_plugin-gargoyle-wol=m
 # end of Gargoyle Web Interface
 # end of Administration
 
@@ -2881,8 +2881,8 @@ CONFIG_PACKAGE_kmod-ata-core=y
 # CONFIG_PACKAGE_kmod-ata-sil24 is not set
 # CONFIG_PACKAGE_kmod-ata-via-sata is not set
 # CONFIG_PACKAGE_kmod-block2mtd is not set
-CONFIG_PACKAGE_kmod-dax=y
-CONFIG_PACKAGE_kmod-dm=y
+CONFIG_PACKAGE_kmod-dax=m
+CONFIG_PACKAGE_kmod-dm=m
 # CONFIG_PACKAGE_kmod-dm-raid is not set
 # CONFIG_PACKAGE_kmod-iosched-bfq is not set
 # CONFIG_PACKAGE_kmod-iscsi-initiator is not set
@@ -2891,7 +2891,7 @@ CONFIG_PACKAGE_kmod-dm=y
 # CONFIG_PACKAGE_kmod-nbd is not set
 # CONFIG_PACKAGE_kmod-nvme is not set
 # CONFIG_PACKAGE_kmod-scsi-cdrom is not set
-CONFIG_PACKAGE_kmod-scsi-core=y
+CONFIG_PACKAGE_kmod-scsi-core=m
 # CONFIG_PACKAGE_kmod-scsi-generic is not set
 # CONFIG_PACKAGE_kmod-scsi-tape is not set
 # end of Block Devices
@@ -2912,6 +2912,7 @@ CONFIG_PACKAGE_kmod-crypto-cbc=y
 CONFIG_PACKAGE_kmod-crypto-ccm=y
 # CONFIG_PACKAGE_kmod-crypto-chacha20poly1305 is not set
 CONFIG_PACKAGE_kmod-crypto-cmac=y
+CONFIG_PACKAGE_kmod-crypto-crc32=y
 CONFIG_PACKAGE_kmod-crypto-crc32c=y
 CONFIG_PACKAGE_kmod-crypto-ctr=y
 CONFIG_PACKAGE_kmod-crypto-cts=y
@@ -2964,32 +2965,32 @@ CONFIG_PACKAGE_kmod-crypto-sha512=y
 # CONFIG_PACKAGE_kmod-fs-configfs is not set
 # CONFIG_PACKAGE_kmod-fs-cramfs is not set
 # CONFIG_PACKAGE_kmod-fs-exfat is not set
-CONFIG_PACKAGE_kmod-fs-exportfs=y
-CONFIG_PACKAGE_kmod-fs-ext4=y
-# CONFIG_PACKAGE_kmod-fs-f2fs is not set
+CONFIG_PACKAGE_kmod-fs-exportfs=m
+CONFIG_PACKAGE_kmod-fs-ext4=m
+CONFIG_PACKAGE_kmod-fs-f2fs=m
 # CONFIG_PACKAGE_kmod-fs-fscache is not set
 # CONFIG_PACKAGE_kmod-fs-hfs is not set
-CONFIG_PACKAGE_kmod-fs-hfsplus=y
+CONFIG_PACKAGE_kmod-fs-hfsplus=m
 # CONFIG_PACKAGE_kmod-fs-isofs is not set
 # CONFIG_PACKAGE_kmod-fs-jfs is not set
-CONFIG_PACKAGE_kmod-fs-ksmbd=y
+CONFIG_PACKAGE_kmod-fs-ksmbd=m
 CONFIG_KSMBD_SMB_INSECURE_SERVER=y
 # CONFIG_PACKAGE_kmod-fs-minix is not set
-CONFIG_PACKAGE_kmod-fs-msdos=y
-CONFIG_PACKAGE_kmod-fs-nfs=y
-CONFIG_PACKAGE_kmod-fs-nfs-common=y
-CONFIG_PACKAGE_kmod-fs-nfs-common-rpcsec=y
+CONFIG_PACKAGE_kmod-fs-msdos=m
+CONFIG_PACKAGE_kmod-fs-nfs=m
+CONFIG_PACKAGE_kmod-fs-nfs-common=m
+CONFIG_PACKAGE_kmod-fs-nfs-common-rpcsec=m
 # CONFIG_PACKAGE_kmod-fs-nfs-v3 is not set
-CONFIG_PACKAGE_kmod-fs-nfs-v4=y
-CONFIG_PACKAGE_kmod-fs-nfsd=y
+CONFIG_PACKAGE_kmod-fs-nfs-v4=m
+CONFIG_PACKAGE_kmod-fs-nfsd=m
 # CONFIG_PACKAGE_kmod-fs-ntfs is not set
 # CONFIG_PACKAGE_kmod-fs-reiserfs is not set
 # CONFIG_PACKAGE_kmod-fs-squashfs is not set
 # CONFIG_PACKAGE_kmod-fs-udf is not set
-CONFIG_PACKAGE_kmod-fs-vfat=y
+CONFIG_PACKAGE_kmod-fs-vfat=m
 # CONFIG_PACKAGE_kmod-fs-xfs is not set
-CONFIG_PACKAGE_kmod-fuse=y
-CONFIG_PACKAGE_kmod-pstore=y
+CONFIG_PACKAGE_kmod-fuse=m
+CONFIG_PACKAGE_kmod-pstore=m
 # end of Filesystems
 
 #
@@ -3157,27 +3158,27 @@ CONFIG_PACKAGE_kmod-oid-registry=y
 #
 # Native Language Support
 #
-CONFIG_PACKAGE_kmod-nls-base=y
-CONFIG_PACKAGE_kmod-nls-cp1250=y
-CONFIG_PACKAGE_kmod-nls-cp1251=y
-CONFIG_PACKAGE_kmod-nls-cp437=y
-CONFIG_PACKAGE_kmod-nls-cp775=y
-CONFIG_PACKAGE_kmod-nls-cp850=y
-CONFIG_PACKAGE_kmod-nls-cp852=y
+CONFIG_PACKAGE_kmod-nls-base=m
+CONFIG_PACKAGE_kmod-nls-cp1250=m
+CONFIG_PACKAGE_kmod-nls-cp1251=m
+CONFIG_PACKAGE_kmod-nls-cp437=m
+CONFIG_PACKAGE_kmod-nls-cp775=m
+CONFIG_PACKAGE_kmod-nls-cp850=m
+CONFIG_PACKAGE_kmod-nls-cp852=m
 # CONFIG_PACKAGE_kmod-nls-cp862 is not set
 # CONFIG_PACKAGE_kmod-nls-cp864 is not set
-CONFIG_PACKAGE_kmod-nls-cp866=y
+CONFIG_PACKAGE_kmod-nls-cp866=m
 # CONFIG_PACKAGE_kmod-nls-cp932 is not set
 # CONFIG_PACKAGE_kmod-nls-cp936 is not set
 # CONFIG_PACKAGE_kmod-nls-cp950 is not set
-CONFIG_PACKAGE_kmod-nls-iso8859-1=y
-CONFIG_PACKAGE_kmod-nls-iso8859-13=y
-CONFIG_PACKAGE_kmod-nls-iso8859-15=y
-CONFIG_PACKAGE_kmod-nls-iso8859-2=y
+CONFIG_PACKAGE_kmod-nls-iso8859-1=m
+CONFIG_PACKAGE_kmod-nls-iso8859-13=m
+CONFIG_PACKAGE_kmod-nls-iso8859-15=m
+CONFIG_PACKAGE_kmod-nls-iso8859-2=m
 # CONFIG_PACKAGE_kmod-nls-iso8859-6 is not set
 # CONFIG_PACKAGE_kmod-nls-iso8859-8 is not set
-CONFIG_PACKAGE_kmod-nls-koi8r=y
-CONFIG_PACKAGE_kmod-nls-utf8=y
+CONFIG_PACKAGE_kmod-nls-koi8r=m
+CONFIG_PACKAGE_kmod-nls-utf8=m
 # end of Native Language Support
 
 #
@@ -3351,7 +3352,7 @@ CONFIG_PACKAGE_kmod-dnsresolver=y
 # CONFIG_PACKAGE_kmod-fou is not set
 # CONFIG_PACKAGE_kmod-fou6 is not set
 # CONFIG_PACKAGE_kmod-geneve is not set
-CONFIG_PACKAGE_kmod-gre=y
+CONFIG_PACKAGE_kmod-gre=m
 # CONFIG_PACKAGE_kmod-gre6 is not set
 # CONFIG_PACKAGE_kmod-inet-diag is not set
 # CONFIG_PACKAGE_kmod-ip6-tunnel is not set
@@ -3379,7 +3380,7 @@ CONFIG_PACKAGE_kmod-mppe=m
 CONFIG_PACKAGE_kmod-pppoe=y
 # CONFIG_PACKAGE_kmod-pppol2tp is not set
 CONFIG_PACKAGE_kmod-pppox=y
-CONFIG_PACKAGE_kmod-pptp=y
+CONFIG_PACKAGE_kmod-pptp=m
 CONFIG_PACKAGE_kmod-sched=y
 # CONFIG_PACKAGE_kmod-sched-act-ipt is not set
 # CONFIG_PACKAGE_kmod-sched-act-police is not set
@@ -3411,7 +3412,7 @@ CONFIG_PACKAGE_kmod-udptunnel4=y
 CONFIG_PACKAGE_kmod-udptunnel6=y
 # CONFIG_PACKAGE_kmod-veth is not set
 # CONFIG_PACKAGE_kmod-vxlan is not set
-CONFIG_PACKAGE_kmod-wireguard=y
+CONFIG_PACKAGE_kmod-wireguard=m
 # end of Network Support
 
 #
@@ -3501,48 +3502,48 @@ CONFIG_PACKAGE_kmod-reed-solomon=y
 #
 # CONFIG_PACKAGE_kmod-chaoskey is not set
 CONFIG_PACKAGE_kmod-phy-qcom-ipq806x-usb=y
-CONFIG_PACKAGE_kmod-usb-acm=y
+CONFIG_PACKAGE_kmod-usb-acm=m
 # CONFIG_PACKAGE_kmod-usb-atm is not set
 # CONFIG_PACKAGE_kmod-usb-cm109 is not set
-CONFIG_PACKAGE_kmod-usb-core=y
+CONFIG_PACKAGE_kmod-usb-core=m
 # CONFIG_PACKAGE_kmod-usb-dwc2 is not set
-CONFIG_PACKAGE_kmod-usb-dwc3=y
-CONFIG_PACKAGE_kmod-usb-dwc3-qcom=y
-CONFIG_PACKAGE_kmod-usb-ehci=y
+CONFIG_PACKAGE_kmod-usb-dwc3=m
+CONFIG_PACKAGE_kmod-usb-dwc3-qcom=m
+CONFIG_PACKAGE_kmod-usb-ehci=m
 # CONFIG_PACKAGE_kmod-usb-hid is not set
 # CONFIG_PACKAGE_kmod-usb-hid-cp2112 is not set
-CONFIG_PACKAGE_kmod-usb-ledtrig-usbport=y
-CONFIG_PACKAGE_kmod-usb-net=y
+CONFIG_PACKAGE_kmod-usb-ledtrig-usbport=m
+CONFIG_PACKAGE_kmod-usb-net=m
 # CONFIG_PACKAGE_kmod-usb-net-aqc111 is not set
 # CONFIG_PACKAGE_kmod-usb-net-asix is not set
 # CONFIG_PACKAGE_kmod-usb-net-asix-ax88179 is not set
 # CONFIG_PACKAGE_kmod-usb-net-cdc-eem is not set
-CONFIG_PACKAGE_kmod-usb-net-cdc-ether=y
-CONFIG_PACKAGE_kmod-usb-net-cdc-mbim=y
-CONFIG_PACKAGE_kmod-usb-net-cdc-ncm=y
+CONFIG_PACKAGE_kmod-usb-net-cdc-ether=m
+CONFIG_PACKAGE_kmod-usb-net-cdc-mbim=m
+CONFIG_PACKAGE_kmod-usb-net-cdc-ncm=m
 # CONFIG_PACKAGE_kmod-usb-net-cdc-subset is not set
 # CONFIG_PACKAGE_kmod-usb-net-dm9601-ether is not set
 # CONFIG_PACKAGE_kmod-usb-net-hso is not set
-CONFIG_PACKAGE_kmod-usb-net-huawei-cdc-ncm=y
-CONFIG_PACKAGE_kmod-usb-net-ipheth=y
+CONFIG_PACKAGE_kmod-usb-net-huawei-cdc-ncm=m
+CONFIG_PACKAGE_kmod-usb-net-ipheth=m
 # CONFIG_PACKAGE_kmod-usb-net-kalmia is not set
 # CONFIG_PACKAGE_kmod-usb-net-kaweth is not set
 # CONFIG_PACKAGE_kmod-usb-net-lan78xx is not set
 # CONFIG_PACKAGE_kmod-usb-net-mcs7830 is not set
 # CONFIG_PACKAGE_kmod-usb-net-pegasus is not set
 # CONFIG_PACKAGE_kmod-usb-net-pl is not set
-CONFIG_PACKAGE_kmod-usb-net-qmi-wwan=y
-CONFIG_PACKAGE_kmod-usb-net-rndis=y
+CONFIG_PACKAGE_kmod-usb-net-qmi-wwan=m
+CONFIG_PACKAGE_kmod-usb-net-rndis=m
 # CONFIG_PACKAGE_kmod-usb-net-rtl8150 is not set
 # CONFIG_PACKAGE_kmod-usb-net-rtl8152 is not set
-CONFIG_PACKAGE_kmod-usb-net-sierrawireless=y
+CONFIG_PACKAGE_kmod-usb-net-sierrawireless=m
 # CONFIG_PACKAGE_kmod-usb-net-smsc75xx is not set
 # CONFIG_PACKAGE_kmod-usb-net-smsc95xx is not set
 # CONFIG_PACKAGE_kmod-usb-net-sr9700 is not set
-CONFIG_PACKAGE_kmod-usb-ohci=y
+# CONFIG_PACKAGE_kmod-usb-ohci is not set
 # CONFIG_PACKAGE_kmod-usb-ohci-pci is not set
-CONFIG_PACKAGE_kmod-usb-printer=y
-CONFIG_PACKAGE_kmod-usb-serial=y
+CONFIG_PACKAGE_kmod-usb-printer=m
+CONFIG_PACKAGE_kmod-usb-serial=m
 # CONFIG_PACKAGE_kmod-usb-serial-ark3116 is not set
 # CONFIG_PACKAGE_kmod-usb-serial-belkin is not set
 # CONFIG_PACKAGE_kmod-usb-serial-ch341 is not set
@@ -3556,25 +3557,25 @@ CONFIG_PACKAGE_kmod-usb-serial=y
 # CONFIG_PACKAGE_kmod-usb-serial-mct is not set
 # CONFIG_PACKAGE_kmod-usb-serial-mos7720 is not set
 # CONFIG_PACKAGE_kmod-usb-serial-mos7840 is not set
-CONFIG_PACKAGE_kmod-usb-serial-option=y
+CONFIG_PACKAGE_kmod-usb-serial-option=m
 # CONFIG_PACKAGE_kmod-usb-serial-oti6858 is not set
 # CONFIG_PACKAGE_kmod-usb-serial-pl2303 is not set
-CONFIG_PACKAGE_kmod-usb-serial-qualcomm=y
-CONFIG_PACKAGE_kmod-usb-serial-sierrawireless=y
+CONFIG_PACKAGE_kmod-usb-serial-qualcomm=m
+CONFIG_PACKAGE_kmod-usb-serial-sierrawireless=m
 # CONFIG_PACKAGE_kmod-usb-serial-simple is not set
 # CONFIG_PACKAGE_kmod-usb-serial-ti-usb is not set
 # CONFIG_PACKAGE_kmod-usb-serial-visor is not set
-CONFIG_PACKAGE_kmod-usb-serial-wwan=y
-CONFIG_PACKAGE_kmod-usb-storage=y
-CONFIG_PACKAGE_kmod-usb-storage-extras=y
-CONFIG_PACKAGE_kmod-usb-storage-uas=y
+CONFIG_PACKAGE_kmod-usb-serial-wwan=m
+CONFIG_PACKAGE_kmod-usb-storage=m
+CONFIG_PACKAGE_kmod-usb-storage-extras=m
+CONFIG_PACKAGE_kmod-usb-storage-uas=m
 # CONFIG_PACKAGE_kmod-usb-uhci is not set
-CONFIG_PACKAGE_kmod-usb-wdm=y
-CONFIG_PACKAGE_kmod-usb-xhci-hcd=y
+CONFIG_PACKAGE_kmod-usb-wdm=m
+CONFIG_PACKAGE_kmod-usb-xhci-hcd=m
 # CONFIG_PACKAGE_kmod-usb-yealink is not set
-CONFIG_PACKAGE_kmod-usb2=y
+CONFIG_PACKAGE_kmod-usb2=m
 # CONFIG_PACKAGE_kmod-usb2-pci is not set
-CONFIG_PACKAGE_kmod-usb3=y
+CONFIG_PACKAGE_kmod-usb3=m
 # CONFIG_PACKAGE_kmod-usbip is not set
 # CONFIG_PACKAGE_kmod-usbip-client is not set
 # CONFIG_PACKAGE_kmod-usbip-server is not set
@@ -3584,9 +3585,9 @@ CONFIG_PACKAGE_kmod-usb3=y
 #
 # Video Support
 #
-CONFIG_PACKAGE_kmod-video-core=y
+CONFIG_PACKAGE_kmod-video-core=m
 # CONFIG_PACKAGE_kmod-video-cpia2 is not set
-CONFIG_PACKAGE_kmod-video-gspca-core=y
+CONFIG_PACKAGE_kmod-video-gspca-core=m
 # CONFIG_PACKAGE_kmod-video-gspca-conex is not set
 # CONFIG_PACKAGE_kmod-video-gspca-etoms is not set
 # CONFIG_PACKAGE_kmod-video-gspca-finepix is not set
@@ -3597,7 +3598,7 @@ CONFIG_PACKAGE_kmod-video-gspca-core=y
 # CONFIG_PACKAGE_kmod-video-gspca-mars is not set
 # CONFIG_PACKAGE_kmod-video-gspca-mr97310a is not set
 # CONFIG_PACKAGE_kmod-video-gspca-ov519 is not set
-CONFIG_PACKAGE_kmod-video-gspca-ov534=y
+CONFIG_PACKAGE_kmod-video-gspca-ov534=m
 # CONFIG_PACKAGE_kmod-video-gspca-ov534-9 is not set
 # CONFIG_PACKAGE_kmod-video-gspca-pac207 is not set
 # CONFIG_PACKAGE_kmod-video-gspca-pac7311 is not set
@@ -3620,10 +3621,10 @@ CONFIG_PACKAGE_kmod-video-gspca-ov534=y
 # CONFIG_PACKAGE_kmod-video-gspca-t613 is not set
 # CONFIG_PACKAGE_kmod-video-gspca-tv8532 is not set
 # CONFIG_PACKAGE_kmod-video-gspca-vc032x is not set
-CONFIG_PACKAGE_kmod-video-gspca-zc3xx=y
+CONFIG_PACKAGE_kmod-video-gspca-zc3xx=m
 # CONFIG_PACKAGE_kmod-video-pwc is not set
-CONFIG_PACKAGE_kmod-video-uvc=y
-CONFIG_PACKAGE_kmod-video-videobuf2=y
+CONFIG_PACKAGE_kmod-video-uvc=m
+CONFIG_PACKAGE_kmod-video-videobuf2=m
 # end of Video Support
 
 #
@@ -3760,7 +3761,7 @@ CONFIG_PACKAGE_MAC80211_MESH=y
 # CONFIG_PACKAGE_kmod-zd1211rw is not set
 # end of Wireless Drivers
 
-CONFIG_PACKAGE_kmod-cdrom=y
+CONFIG_PACKAGE_kmod-cdrom=m
 # end of Kernel modules
 
 #
@@ -3785,13 +3786,13 @@ CONFIG_PACKAGE_kmod-cdrom=y
 #
 # Compression
 #
-CONFIG_PACKAGE_libbz2=y
+CONFIG_PACKAGE_libbz2=m
 # end of Compression
 
 #
 # Database
 #
-CONFIG_PACKAGE_libsqlite3=y
+CONFIG_PACKAGE_libsqlite3=m
 
 #
 # Configuration
@@ -3876,7 +3877,7 @@ CONFIG_OPENSSL_WITH_PSK=y
 #
 CONFIG_OPENSSL_ENGINE=y
 # CONFIG_OPENSSL_ENGINE_BUILTIN is not set
-CONFIG_PACKAGE_libopenssl-conf=y
+CONFIG_PACKAGE_libopenssl-conf=m
 # CONFIG_PACKAGE_libopenssl-devcrypto is not set
 CONFIG_PACKAGE_libwolfssl=m
 CONFIG_WOLFSSL_HAS_AES_CCM=y
@@ -3890,7 +3891,7 @@ CONFIG_WOLFSSL_HAS_SESSION_TICKET=y
 # CONFIG_WOLFSSL_HAS_DTLS is not set
 CONFIG_WOLFSSL_HAS_OCSP=y
 CONFIG_WOLFSSL_HAS_WPAS=y
-# CONFIG_WOLFSSL_HAS_ECC25519 is not set
+CONFIG_WOLFSSL_HAS_ECC25519=y
 CONFIG_WOLFSSL_HAS_OPENVPN=y
 CONFIG_WOLFSSL_ALT_NAMES=y
 # CONFIG_WOLFSSL_ASM_CAPABLE is not set
@@ -3905,10 +3906,10 @@ CONFIG_WOLFSSL_HAS_NO_HW=y
 #
 # libimobiledevice
 #
-CONFIG_PACKAGE_libimobiledevice=y
-CONFIG_PACKAGE_libplist=y
+CONFIG_PACKAGE_libimobiledevice=m
+CONFIG_PACKAGE_libplist=m
 # CONFIG_PACKAGE_libplistcxx is not set
-CONFIG_PACKAGE_libusbmuxd=y
+CONFIG_PACKAGE_libusbmuxd=m
 # end of libimobiledevice
 
 # CONFIG_PACKAGE_alsa-lib is not set
@@ -3920,16 +3921,16 @@ CONFIG_PACKAGE_libusbmuxd=y
 # CONFIG_PACKAGE_libaudit is not set
 CONFIG_PACKAGE_libbbtargz=y
 # CONFIG_PACKAGE_libbfd is not set
-CONFIG_PACKAGE_libblkid=y
+CONFIG_PACKAGE_libblkid=m
 CONFIG_PACKAGE_libblobmsg-json=y
-CONFIG_PACKAGE_libbpf=y
+# CONFIG_PACKAGE_libbpf is not set
 # CONFIG_PACKAGE_libbsd is not set
-CONFIG_PACKAGE_libcap=y
+CONFIG_PACKAGE_libcap=m
 # CONFIG_PACKAGE_libcap-bin is not set
-CONFIG_PACKAGE_libcap-ng=y
+CONFIG_PACKAGE_libcap-ng=m
 # CONFIG_PACKAGE_libcap-ng-bin is not set
 # CONFIG_PACKAGE_libcharset is not set
-CONFIG_PACKAGE_libcomerr=y
+CONFIG_PACKAGE_libcomerr=m
 # CONFIG_PACKAGE_libctf is not set
 CONFIG_PACKAGE_libcurl=m
 
@@ -3937,8 +3938,8 @@ CONFIG_PACKAGE_libcurl=m
 # SSL support
 #
 # CONFIG_LIBCURL_MBEDTLS is not set
-CONFIG_LIBCURL_WOLFSSL=y
-# CONFIG_LIBCURL_OPENSSL is not set
+# CONFIG_LIBCURL_WOLFSSL is not set
+CONFIG_LIBCURL_OPENSSL=y
 # CONFIG_LIBCURL_GNUTLS is not set
 # CONFIG_LIBCURL_NOSSL is not set
 
@@ -3975,61 +3976,61 @@ CONFIG_LIBCURL_PROXY=y
 # CONFIG_LIBCURL_UNIX_SOCKETS is not set
 # CONFIG_LIBCURL_LIBCURL_OPTION is not set
 # CONFIG_LIBCURL_VERBOSE is not set
-CONFIG_PACKAGE_libdevmapper=y
+CONFIG_PACKAGE_libdevmapper=m
 # CONFIG_PACKAGE_libdevmapper-selinux is not set
 # CONFIG_PACKAGE_libdw is not set
-CONFIG_PACKAGE_libelf=y
+# CONFIG_PACKAGE_libelf is not set
 CONFIG_PACKAGE_libericstools=y
-CONFIG_PACKAGE_libevent2=y
+CONFIG_PACKAGE_libevent2=m
 # CONFIG_PACKAGE_libevent2-core is not set
 # CONFIG_PACKAGE_libevent2-extra is not set
 # CONFIG_PACKAGE_libevent2-openssl is not set
 # CONFIG_PACKAGE_libevent2-pthreads is not set
-CONFIG_PACKAGE_libexif=y
-CONFIG_PACKAGE_libext2fs=y
-# CONFIG_PACKAGE_libf2fs is not set
+CONFIG_PACKAGE_libexif=m
+CONFIG_PACKAGE_libext2fs=m
+CONFIG_PACKAGE_libf2fs=m
 # CONFIG_PACKAGE_libf2fs-selinux is not set
-CONFIG_PACKAGE_libfdisk=y
+CONFIG_PACKAGE_libfdisk=m
 # CONFIG_PACKAGE_libfdt is not set
 # CONFIG_PACKAGE_libffi is not set
-CONFIG_PACKAGE_libffmpeg-audio-dec=y
+CONFIG_PACKAGE_libffmpeg-audio-dec=m
 # CONFIG_PACKAGE_libffmpeg-custom is not set
 # CONFIG_PACKAGE_libffmpeg-full is not set
 # CONFIG_PACKAGE_libffmpeg-mini is not set
-CONFIG_PACKAGE_libflac=y
+CONFIG_PACKAGE_libflac=m
 # CONFIG_PACKAGE_libgcrypt is not set
 # CONFIG_PACKAGE_libgmp is not set
 # CONFIG_PACKAGE_libgpg-error is not set
 # CONFIG_PACKAGE_libiconv is not set
 # CONFIG_PACKAGE_libiconv-full is not set
-CONFIG_PACKAGE_libid3tag=y
+CONFIG_PACKAGE_libid3tag=m
 # CONFIG_PACKAGE_libidn is not set
 # CONFIG_PACKAGE_libintl-full is not set
 # CONFIG_PACKAGE_libiw is not set
 CONFIG_PACKAGE_libiwinfo=y
-CONFIG_PACKAGE_libjpeg-turbo=y
+CONFIG_PACKAGE_libjpeg-turbo=m
 CONFIG_PACKAGE_libjson-c=y
-CONFIG_PACKAGE_libkeyutils=y
+CONFIG_PACKAGE_libkeyutils=m
 # CONFIG_PACKAGE_libltdl is not set
 # CONFIG_PACKAGE_liblua is not set
 # CONFIG_PACKAGE_liblua5.3 is not set
-CONFIG_PACKAGE_liblzo=y
+CONFIG_PACKAGE_liblzo=m
 # CONFIG_PACKAGE_libmatrixssl-nothread is not set
 CONFIG_PACKAGE_libmnl=y
 # CONFIG_PACKAGE_libmount is not set
-CONFIG_PACKAGE_libncurses=y
+CONFIG_PACKAGE_libncurses=m
 # CONFIG_PACKAGE_libnetfilter-conntrack is not set
 # CONFIG_PACKAGE_libnettle is not set
 # CONFIG_PACKAGE_libnfnetlink is not set
 # CONFIG_PACKAGE_libnftnl is not set
 CONFIG_PACKAGE_libnghttp2=m
 # CONFIG_PACKAGE_libnl is not set
-CONFIG_PACKAGE_libnl-core=y
-CONFIG_PACKAGE_libnl-genl=y
+CONFIG_PACKAGE_libnl-core=m
+CONFIG_PACKAGE_libnl-genl=m
 # CONFIG_PACKAGE_libnl-nf is not set
 # CONFIG_PACKAGE_libnl-route is not set
 CONFIG_PACKAGE_libnl-tiny=y
-CONFIG_PACKAGE_libogg=y
+CONFIG_PACKAGE_libogg=m
 # CONFIG_PACKAGE_libopcodes is not set
 # CONFIG_PACKAGE_libopus is not set
 # CONFIG_PACKAGE_libpcap is not set
@@ -4042,31 +4043,31 @@ CONFIG_PACKAGE_libogg=y
 # CONFIG_PACKAGE_libselinux is not set
 # CONFIG_PACKAGE_libsemanage is not set
 # CONFIG_PACKAGE_libsepol is not set
-CONFIG_PACKAGE_libsmartcols=y
-CONFIG_PACKAGE_libss=y
+CONFIG_PACKAGE_libsmartcols=m
+CONFIG_PACKAGE_libss=m
 # CONFIG_PACKAGE_libtasn1 is not set
-CONFIG_PACKAGE_libtirpc=y
+CONFIG_PACKAGE_libtirpc=m
 CONFIG_PACKAGE_libubox=y
 # CONFIG_PACKAGE_libubox-lua is not set
 CONFIG_PACKAGE_libubus=y
 # CONFIG_PACKAGE_libubus-lua is not set
 CONFIG_PACKAGE_libuci=y
 # CONFIG_PACKAGE_libuci-lua is not set
-CONFIG_PACKAGE_libuclient=y
+CONFIG_PACKAGE_libuclient=m
 # CONFIG_PACKAGE_libunwind is not set
-CONFIG_PACKAGE_libusb-1.0=y
+CONFIG_PACKAGE_libusb-1.0=m
 # CONFIG_PACKAGE_libustream-mbedtls is not set
 CONFIG_PACKAGE_libustream-openssl=y
 CONFIG_PACKAGE_libustream-wolfssl=m
 CONFIG_PACKAGE_libuuid=y
 # CONFIG_PACKAGE_libv4l is not set
-CONFIG_PACKAGE_libvorbis=y
-CONFIG_PACKAGE_libwrap=y
-CONFIG_PACKAGE_libxml2=y
+CONFIG_PACKAGE_libvorbis=m
+CONFIG_PACKAGE_libwrap=m
+CONFIG_PACKAGE_libxml2=m
 # CONFIG_PACKAGE_linux-atm is not set
 # CONFIG_PACKAGE_musl-fts is not set
 # CONFIG_PACKAGE_p11-kit is not set
-CONFIG_PACKAGE_terminfo=y
+CONFIG_PACKAGE_terminfo=m
 CONFIG_PACKAGE_zlib=y
 
 #
@@ -4090,18 +4091,18 @@ CONFIG_PACKAGE_msmtp-nossl=m
 #
 # CONFIG_PACKAGE_ffmpeg is not set
 # CONFIG_PACKAGE_ffprobe is not set
-CONFIG_PACKAGE_gargoyle-mjpg-streamer=y
+CONFIG_PACKAGE_gargoyle-mjpg-streamer=m
 # CONFIG_MJPG_STREAMER_V4L2 is not set
 # CONFIG_PACKAGE_gargoyle-mjpg-streamer-input-file is not set
 # CONFIG_PACKAGE_gargoyle-mjpg-streamer-input-http is not set
-CONFIG_PACKAGE_gargoyle-mjpg-streamer-input-uvc=y
+CONFIG_PACKAGE_gargoyle-mjpg-streamer-input-uvc=m
 # CONFIG_PACKAGE_gargoyle-mjpg-streamer-output-file is not set
-CONFIG_PACKAGE_gargoyle-mjpg-streamer-output-http=y
+CONFIG_PACKAGE_gargoyle-mjpg-streamer-output-http=m
 # CONFIG_PACKAGE_gargoyle-mjpg-streamer-output-rtsp is not set
 # CONFIG_PACKAGE_gargoyle-mjpg-streamer-output-zmq is not set
 # CONFIG_PACKAGE_gargoyle-mjpg-streamer-www is not set
 # CONFIG_PACKAGE_gargoyle-mjpg-streamer-www-simple is not set
-CONFIG_PACKAGE_minidlna=y
+CONFIG_PACKAGE_minidlna=m
 # end of Multimedia
 
 #
@@ -4112,17 +4113,17 @@ CONFIG_PACKAGE_minidlna=y
 # File Transfer
 #
 CONFIG_PACKAGE_curl=m
-CONFIG_PACKAGE_vsftpd=y
+CONFIG_PACKAGE_vsftpd=m
 # end of File Transfer
 
 #
 # Filesystem
 #
 # CONFIG_PACKAGE_ksmbd-avahi-service is not set
-CONFIG_PACKAGE_ksmbd-server=y
-CONFIG_PACKAGE_ksmbd-utils=y
+CONFIG_PACKAGE_ksmbd-server=m
+CONFIG_PACKAGE_ksmbd-utils=m
 # CONFIG_KSMBD_UTILS_SHAREADD is not set
-CONFIG_PACKAGE_nfs-kernel-server=y
+CONFIG_PACKAGE_nfs-kernel-server=m
 
 #
 # Select nfs-kernel-server configuration options
@@ -4130,7 +4131,7 @@ CONFIG_PACKAGE_nfs-kernel-server=y
 CONFIG_NFS_KERNEL_SERVER_V4=y
 # end of Select nfs-kernel-server configuration options
 
-CONFIG_PACKAGE_nfs-kernel-server-utils=y
+CONFIG_PACKAGE_nfs-kernel-server-utils=m
 # end of Filesystem
 
 #
@@ -4172,7 +4173,7 @@ CONFIG_PACKAGE_iptables-mod-webmon=y
 CONFIG_PACKAGE_iptables-mod-weburl=y
 # CONFIG_PACKAGE_iptables-nft is not set
 CONFIG_PACKAGE_iptables-zz-legacy=y
-CONFIG_PACKAGE_miniupnpd=y
+CONFIG_PACKAGE_miniupnpd=m
 # CONFIG_PACKAGE_nftables-json is not set
 # CONFIG_PACKAGE_nftables-nojson is not set
 CONFIG_PACKAGE_xtables-legacy=y
@@ -4219,7 +4220,7 @@ CONFIG_PACKAGE_xtables-legacy=y
 #
 # Printing
 #
-CONFIG_PACKAGE_p910nd=y
+CONFIG_PACKAGE_p910nd=m
 # end of Printing
 
 #
@@ -4237,7 +4238,7 @@ CONFIG_PACKAGE_relayd=y
 # CONFIG_PACKAGE_ss is not set
 # CONFIG_PACKAGE_tc-bpf is not set
 # CONFIG_PACKAGE_tc-full is not set
-CONFIG_PACKAGE_tc-mod-iptables=y
+# CONFIG_PACKAGE_tc-mod-iptables is not set
 CONFIG_PACKAGE_tc-tiny=y
 # end of Routing and Redirection
 
@@ -4301,9 +4302,9 @@ CONFIG_PACKAGE_tc-tiny=y
 #
 # VPN
 #
-CONFIG_PACKAGE_openvpn-gargoyle-easy-rsa=y
+CONFIG_PACKAGE_openvpn-gargoyle-easy-rsa=m
 # CONFIG_PACKAGE_openvpn-gargoyle-mbedtls is not set
-CONFIG_PACKAGE_openvpn-gargoyle-openssl=y
+CONFIG_PACKAGE_openvpn-gargoyle-openssl=m
 CONFIG_OPENVPN_gargoyle_openssl_ENABLE_LZO=y
 CONFIG_OPENVPN_gargoyle_openssl_ENABLE_LZ4=y
 # CONFIG_OPENVPN_gargoyle_openssl_ENABLE_X509_ALT_USERNAME is not set
@@ -4315,18 +4316,18 @@ CONFIG_OPENVPN_gargoyle_openssl_ENABLE_DEF_AUTH=y
 CONFIG_OPENVPN_gargoyle_openssl_ENABLE_PF=y
 # CONFIG_OPENVPN_gargoyle_openssl_ENABLE_IPROUTE2 is not set
 CONFIG_OPENVPN_gargoyle_openssl_ENABLE_SMALL=y
-CONFIG_PACKAGE_wireguard-tools=y
+CONFIG_PACKAGE_wireguard-tools=m
 # end of VPN
 
 #
 # WWAN
 #
 # CONFIG_PACKAGE_adb-enablemodem is not set
-CONFIG_PACKAGE_comgt=y
+CONFIG_PACKAGE_comgt=m
 # CONFIG_PACKAGE_comgt-directip is not set
-CONFIG_PACKAGE_comgt-ncm=y
-CONFIG_PACKAGE_umbim=y
-CONFIG_PACKAGE_uqmi=y
+CONFIG_PACKAGE_comgt-ncm=m
+CONFIG_PACKAGE_umbim=m
+CONFIG_PACKAGE_uqmi=m
 # end of WWAN
 
 #
@@ -4377,7 +4378,7 @@ CONFIG_DRIVER_11AC_SUPPORT=y
 # CONFIG_PACKAGE_wpa-supplicant-p2p is not set
 # CONFIG_PACKAGE_wpa-supplicant-wolfssl is not set
 # CONFIG_PACKAGE_wpad is not set
-CONFIG_PACKAGE_wpad-basic=m
+# CONFIG_PACKAGE_wpad-basic is not set
 # CONFIG_PACKAGE_wpad-basic-openssl is not set
 CONFIG_PACKAGE_wpad-basic-wolfssl=m
 # CONFIG_PACKAGE_wpad-mesh-openssl is not set
@@ -4394,16 +4395,16 @@ CONFIG_PACKAGE_wpad-openssl=y
 # CONFIG_PACKAGE_bpftool-full is not set
 # CONFIG_PACKAGE_bpftool-minimal is not set
 CONFIG_PACKAGE_bwmon-gargoyle=y
-CONFIG_PACKAGE_chat=y
-CONFIG_PACKAGE_ddns-gargoyle=y
+CONFIG_PACKAGE_chat=m
+CONFIG_PACKAGE_ddns-gargoyle=m
 # CONFIG_PACKAGE_ds-lite is not set
-CONFIG_PACKAGE_etherwake=y
+CONFIG_PACKAGE_etherwake=m
 # CONFIG_PACKAGE_ethtool is not set
 # CONFIG_PACKAGE_ethtool-full is not set
 CONFIG_PACKAGE_ewget=y
 CONFIG_PACKAGE_gargoyle-firewall-util=y
 CONFIG_PACKAGE_gargoyle-ip-query=y
-CONFIG_PACKAGE_gargoyle-tor=y
+CONFIG_PACKAGE_gargoyle-tor=m
 # CONFIG_PACKAGE_gargoyle-tor-geoip is not set
 # CONFIG_PACKAGE_gre is not set
 # CONFIG_PACKAGE_ipip is not set
@@ -4414,7 +4415,7 @@ CONFIG_PACKAGE_iw=y
 CONFIG_PACKAGE_libipset=y
 CONFIG_PACKAGE_libiptbwctl=y
 # CONFIG_PACKAGE_map is not set
-CONFIG_PACKAGE_obfsproxy-legacy=y
+CONFIG_PACKAGE_obfsproxy-legacy=m
 CONFIG_PACKAGE_odhcp6c=y
 CONFIG_PACKAGE_odhcp6c_ext_cer_id=0
 # CONFIG_PACKAGE_odhcpd is not set
@@ -4441,7 +4442,7 @@ CONFIG_PACKAGE_ppp-mod-pptp=m
 # CONFIG_PACKAGE_pppstats is not set
 CONFIG_PACKAGE_qos-gargoyle=y
 # CONFIG_PACKAGE_rpcapd is not set
-CONFIG_PACKAGE_rpcbind=y
+CONFIG_PACKAGE_rpcbind=m
 CONFIG_RPCBIND_LIBWRAP=y
 CONFIG_RPCBIND_RMTCALLS=y
 # CONFIG_PACKAGE_rssileds is not set
@@ -4453,7 +4454,7 @@ CONFIG_PACKAGE_SAMBA_MAX_DEBUG_LEVEL=-1
 # CONFIG_PACKAGE_soloscli is not set
 # CONFIG_PACKAGE_tcpdump is not set
 # CONFIG_PACKAGE_tcpdump-mini is not set
-CONFIG_PACKAGE_uclient-fetch=y
+CONFIG_PACKAGE_uclient-fetch=m
 # CONFIG_PACKAGE_umdns is not set
 CONFIG_PACKAGE_usteer=y
 # CONFIG_PACKAGE_ustp is not set
@@ -4480,14 +4481,14 @@ CONFIG_PACKAGE_wwan=y
 # Boot Loaders
 #
 # CONFIG_PACKAGE_fconfig is not set
-CONFIG_PACKAGE_uboot-envtools=y
+CONFIG_PACKAGE_uboot-envtools=m
 # end of Boot Loaders
 
 #
 # Compression
 #
 # CONFIG_PACKAGE_bzip2 is not set
-CONFIG_PACKAGE_zip=y
+CONFIG_PACKAGE_zip=m
 # end of Compression
 
 #
@@ -4500,11 +4501,11 @@ CONFIG_PACKAGE_zip=y
 # Disc
 #
 # CONFIG_PACKAGE_blkdiscard is not set
-CONFIG_PACKAGE_blkid=y
+CONFIG_PACKAGE_blkid=m
 # CONFIG_PACKAGE_blockdev is not set
 # CONFIG_PACKAGE_cfdisk is not set
 # CONFIG_PACKAGE_eject is not set
-CONFIG_PACKAGE_fdisk=y
+CONFIG_PACKAGE_fdisk=m
 # CONFIG_PACKAGE_findfs is not set
 # CONFIG_PACKAGE_lsblk is not set
 # CONFIG_PACKAGE_lvm2 is not set
@@ -4529,14 +4530,14 @@ CONFIG_PACKAGE_fdisk=y
 # Filesystem
 #
 # CONFIG_PACKAGE_attr is not set
-CONFIG_PACKAGE_badblocks=y
+CONFIG_PACKAGE_badblocks=m
 # CONFIG_PACKAGE_chattr is not set
 # CONFIG_PACKAGE_debugfs is not set
-CONFIG_PACKAGE_disktype=y
+CONFIG_PACKAGE_disktype=m
 # CONFIG_PACKAGE_dosfstools is not set
 # CONFIG_PACKAGE_dumpe2fs is not set
 # CONFIG_PACKAGE_e2freefrag is not set
-CONFIG_PACKAGE_e2fsprogs=y
+CONFIG_PACKAGE_e2fsprogs=m
 # CONFIG_PACKAGE_e4crypt is not set
 # CONFIG_PACKAGE_exfat-fsck is not set
 # CONFIG_PACKAGE_exfat-mkfs is not set
@@ -4547,11 +4548,11 @@ CONFIG_PACKAGE_e2fsprogs=y
 # CONFIG_PACKAGE_filefrag is not set
 # CONFIG_PACKAGE_fstrim is not set
 # CONFIG_PACKAGE_lsattr is not set
-# CONFIG_PACKAGE_mkf2fs is not set
+CONFIG_PACKAGE_mkf2fs=m
 # CONFIG_PACKAGE_mkf2fs-selinux is not set
-CONFIG_PACKAGE_nfs-utils=y
-CONFIG_PACKAGE_nfs-utils-libs=y
-CONFIG_PACKAGE_ntfs-3g=y
+CONFIG_PACKAGE_nfs-utils=m
+CONFIG_PACKAGE_nfs-utils-libs=m
+CONFIG_PACKAGE_ntfs-3g=m
 # CONFIG_PACKAGE_NTFS-3G_USE_LIBFUSE is not set
 CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
@@ -4589,7 +4590,7 @@ CONFIG_PACKAGE_swap-utils=y
 # CONFIG_PACKAGE_libimobiledevice-utils is not set
 # CONFIG_PACKAGE_libusbmuxd-utils is not set
 # CONFIG_PACKAGE_plistutil is not set
-CONFIG_PACKAGE_usbmuxd=y
+CONFIG_PACKAGE_usbmuxd=m
 # end of libimobiledevice
 
 #
@@ -4667,14 +4668,14 @@ CONFIG_PACKAGE_losetup=m
 # CONFIG_PACKAGE_namei is not set
 # CONFIG_PACKAGE_nand-utils is not set
 # CONFIG_PACKAGE_nsenter is not set
-CONFIG_PACKAGE_openssl-util=y
+CONFIG_PACKAGE_openssl-util=m
 # CONFIG_PACKAGE_opkg-more is not set
 # CONFIG_PACKAGE_policycoreutils is not set
 # CONFIG_PACKAGE_prlimit is not set
 # CONFIG_PACKAGE_ravpower-mcu is not set
 # CONFIG_PACKAGE_rename is not set
 # CONFIG_PACKAGE_secilc is not set
-CONFIG_PACKAGE_share-users=y
+CONFIG_PACKAGE_share-users=m
 # CONFIG_PACKAGE_spidev-test is not set
 # CONFIG_PACKAGE_strace is not set
 CONFIG_STRACE_NONE=y
@@ -4685,7 +4686,7 @@ CONFIG_PACKAGE_ubi-utils=y
 # CONFIG_PACKAGE_ucode is not set
 # CONFIG_PACKAGE_ugps is not set
 # CONFIG_PACKAGE_unshare is not set
-CONFIG_PACKAGE_usb-modeswitch=y
+CONFIG_PACKAGE_usb-modeswitch=m
 # CONFIG_PACKAGE_uuidd is not set
 # CONFIG_PACKAGE_uuidgen is not set
 # CONFIG_PACKAGE_v4l-utils is not set

--- a/targets/ipq806x/profiles/default/profile_images
+++ b/targets/ipq806x/profiles/default/profile_images
@@ -3,5 +3,6 @@ linksys_ea8500-squashfs-
 netgear_d7800-squashfs-
 netgear_r7500v2-squashfs-
 netgear_r7800-squashfs-
+netgear_xr500-squashfs-
 tplink_c2600-squashfs-
 zyxel_nbg6817-squashfs-

--- a/targets/mediatek/profiles/default/config
+++ b/targets/mediatek/profiles/default/config
@@ -4513,7 +4513,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem

--- a/targets/ramips/profiles/default/config
+++ b/targets/ramips/profiles/default/config
@@ -181,23 +181,23 @@ CONFIG_TARGET_MULTI_PROFILE=y
 # CONFIG_TARGET_ALL_PROFILES is not set
 CONFIG_TARGET_PER_DEVICE_ROOTFS=y
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_aigale_ai-br100=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_aigale_ai-br100="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_aigale_ai-br100="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_alfa-network_ac1200rm=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_alfa-network_ac1200rm="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_alfa-network_ac1200rm="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_alfa-network_r36m-e4g is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_alfa-network_tube-e4g is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_asus_rp-n53=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_asus_rp-n53="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_asus_rt-ac51u=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_asus_rt-ac51u="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_asus_rt-ac51u="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_asus_rt-ac54u is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_asus_rt-n12p=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_asus_rt-n12p="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_asus_rt-n14u=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_asus_rt-n14u="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_asus_rt-n14u="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_bdcom_wap2100-sk is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_buffalo_whr-1166d=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_buffalo_whr-1166d="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_buffalo_whr-1166d="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_buffalo_whr-300hp2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_buffalo_whr-300hp2="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_buffalo_whr-600d=y
@@ -213,13 +213,16 @@ CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dir-810l=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dlink_dir-810l="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-116-a1=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dlink_dwr-116-a1="gargoyle-usb"
-# CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-118-a1 is not set
-# CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-118-a2 is not set
+CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-118-a1=y
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dlink_dwr-118-a1="gargoyle-large"
+CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-118-a2=y
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dlink_dwr-118-a2="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-921-c1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dlink_dwr-921-c1="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dlink_dwr-921-c1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-921-c3=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dlink_dwr-921-c3="gargoyle-usb"
-# CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-922-e2 is not set
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dlink_dwr-921-c3="gargoyle-large"
+CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-922-e2=y
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dlink_dwr-922-e2="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-960 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_dlink_dwr-961-a1 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_domywifi_dm202 is not set
@@ -232,24 +235,24 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_dovado_tiny-ac="gargoyle-basi
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_edimax_ew-7478ac is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_edimax_ew-7478apc is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_elecom_wrh-300cr=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_elecom_wrh-300cr="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_elecom_wrh-300cr="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_engenius_esr600 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_fon_fon2601 is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_glinet_gl-mt300a=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_glinet_gl-mt300a="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_glinet_gl-mt300a="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_glinet_gl-mt300n=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_glinet_gl-mt300n="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_glinet_gl-mt300n="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_glinet_gl-mt750=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_glinet_gl-mt750="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_glinet_gl-mt750="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_head-weblink_hdrm200 is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_hiwifi_hc5661=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_hiwifi_hc5661="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_hiwifi_hc5661="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_hiwifi_hc5761=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_hiwifi_hc5761="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_hiwifi_hc5761="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_hiwifi_hc5861=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_hiwifi_hc5861="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_hiwifi_hc5861="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_hnet_c108=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_hnet_c108="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_hnet_c108="gargoyle-basic"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_hootoo_ht-tm05 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_humax_e2 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_iodata_wn-ac1167gr is not set
@@ -257,18 +260,18 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_hnet_c108="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_iptime_a1004ns is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_iptime_a104ns is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_kimax_u25awf-h1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_kimax_u25awf-h1="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_kimax_u25awf-h1="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_kimax_u35wf is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_kingston_mlw221=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_kingston_mlw221="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_kingston_mlw221="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_kingston_mlwg2=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_kingston_mlwg2="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_kingston_mlwg2="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_lava_lr-25g001 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_lb-link_bl-w1200 is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_lenovo_newifi-y1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_lenovo_newifi-y1="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_lenovo_newifi-y1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_lenovo_newifi-y1s=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_lenovo_newifi-y1s="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_lenovo_newifi-y1s="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_linksys_e1700=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_linksys_e1700="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_ralink_mt7620a-mt7530-evb=y
@@ -280,7 +283,7 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_ralink_mt7620a-evb="gargoyle-
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_ralink_mt7620a-v22sg-evb=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_ralink_mt7620a-v22sg-evb="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_microduino_microwrt=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_microduino_microwrt="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_microduino_microwrt="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_netgear_ex2700 is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_netgear_ex3700=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_netgear_ex3700="gargoyle-basic"
@@ -293,9 +296,9 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_netgear_wn3000rp-v3="gargoyle
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_netis_wf2770 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_nexx_wt3020-4m is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_nexx_wt3020-8m=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_nexx_wt3020-8m="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_nexx_wt3020-8m="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_ohyeah_oy-0001=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_ohyeah_oy-0001="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_ohyeah_oy-0001="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_phicomm_k2-v22.4 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_phicomm_k2-v22.5 is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_phicomm_k2g=y
@@ -314,23 +317,22 @@ CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_planex_mzk-ex300np=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_planex_mzk-ex300np="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_planex_mzk-ex750np=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_planex_mzk-ex750np="gargoyle-basic"
-CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_ravpower_rp-wd03=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_ravpower_rp-wd03="gargoyle-basic"
+# CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_ravpower_rp-wd03 is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_sanlinking_d240=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_sanlinking_d240="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_sanlinking_d240="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_sercomm_na930=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_sercomm_na930="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_sitecom_wlr-4100-v1-002 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_wavlink_wl-wn535k1 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_tplink_archer-c2-v1 is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_tplink_archer-c20-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_tplink_archer-c20-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_tplink_archer-c20-v1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_tplink_archer-c20i=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_tplink_archer-c20i="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_tplink_archer-c20i="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_tplink_archer-c50-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_tplink_archer-c50-v1="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_tplink_archer-c50-v1="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_tplink_archer-mr200=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_tplink_archer-mr200="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_tplink_archer-mr200="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_tplink_re200-v1 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_tplink_re210-v1 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_trendnet_tew-810dr is not set
@@ -339,23 +341,25 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_tplink_archer-mr200="gargoyle
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_wavlink_wl-wn579x3 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_wevo_air-duo is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_wrtnode_wrtnode=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_wrtnode_wrtnode="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_wrtnode_wrtnode="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_xiaomi_miwifi-mini=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_xiaomi_miwifi-mini="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_xiaomi_miwifi-mini="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_youku_yk-l1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_youku_yk-l1="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_youku_yk-l1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_youku_yk-l1c=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_youku_yk-l1c="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_youku_yk-l1c="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_yukai_bocco=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_yukai_bocco="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-ape522ii=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-ape522ii="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-cpe102=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-cpe102="gargoyle-basic"
-# CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-wa05 is not set
+CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-wa05=y
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-wa05="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-we1026-5g-16m=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-we1026-5g-16m="gargoyle-usb"
-# CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-we1026-h-32m is not set
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-we1026-5g-16m="gargoyle-large"
+CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-we1026-h-32m=y
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-we1026-h-32m="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-we2026=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-we2026="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-we826-16m=y
@@ -364,9 +368,9 @@ CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-we826-32m=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-we826-32m="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-we826-e is not set
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zbtlink_zbt-wr8305rt=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-wr8305rt="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zbtlink_zbt-wr8305rt="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zte_q7=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zte_q7="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7620_DEVICE_zte_q7="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zyxel_keenetic-omni is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zyxel_keenetic-omni-ii is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7620_DEVICE_zyxel_keenetic-viva is not set
@@ -505,7 +509,7 @@ CONFIG_EXTERNAL_CPIO=""
 #
 # CONFIG_TARGET_ROOTFS_EXT4FS is not set
 CONFIG_TARGET_ROOTFS_SQUASHFS=y
-CONFIG_TARGET_SQUASHFS_BLOCK_SIZE=256
+CONFIG_TARGET_SQUASHFS_BLOCK_SIZE=1024
 CONFIG_TARGET_UBIFS_FREE_SPACE_FIXUP=y
 CONFIG_TARGET_UBIFS_JOURNAL_SIZE=""
 
@@ -550,23 +554,23 @@ CONFIG_KERNEL_BUILD_USER=""
 CONFIG_KERNEL_BUILD_DOMAIN=""
 CONFIG_KERNEL_PRINTK=y
 CONFIG_KERNEL_SWAP=y
-# CONFIG_KERNEL_PROC_STRIPPED is not set
+CONFIG_KERNEL_PROC_STRIPPED=y
 CONFIG_KERNEL_DEBUG_FS=y
 # CONFIG_KERNEL_PERF_EVENTS is not set
 # CONFIG_KERNEL_PROFILING is not set
 # CONFIG_KERNEL_UBSAN is not set
 # CONFIG_KERNEL_KCOV is not set
 # CONFIG_KERNEL_TASKSTATS is not set
-CONFIG_KERNEL_KALLSYMS=y
+# CONFIG_KERNEL_KALLSYMS is not set
 # CONFIG_KERNEL_FTRACE is not set
-CONFIG_KERNEL_DEBUG_KERNEL=y
-CONFIG_KERNEL_DEBUG_INFO=y
+# CONFIG_KERNEL_DEBUG_KERNEL is not set
+# CONFIG_KERNEL_DEBUG_INFO is not set
 # CONFIG_KERNEL_DYNAMIC_DEBUG is not set
 # CONFIG_KERNEL_KPROBES is not set
-CONFIG_KERNEL_AIO=y
-CONFIG_KERNEL_IO_URING=y
-CONFIG_KERNEL_FHANDLE=y
-CONFIG_KERNEL_FANOTIFY=y
+# CONFIG_KERNEL_AIO is not set
+# CONFIG_KERNEL_IO_URING is not set
+# CONFIG_KERNEL_FHANDLE is not set
+# CONFIG_KERNEL_FANOTIFY is not set
 # CONFIG_KERNEL_BLK_DEV_BSG is not set
 # CONFIG_KERNEL_HUGETLB_PAGE is not set
 CONFIG_KERNEL_MAGIC_SYSRQ=y
@@ -587,51 +591,13 @@ CONFIG_KERNEL_PRINTK_TIME=y
 # CONFIG_USE_RFKILL is not set
 # CONFIG_USE_SPARSE is not set
 # CONFIG_KERNEL_DEVTMPFS is not set
-CONFIG_KERNEL_KEYS=y
-# CONFIG_KERNEL_PERSISTENT_KEYRINGS is not set
-# CONFIG_KERNEL_KEYS_REQUEST_CACHE is not set
-# CONFIG_KERNEL_BIG_KEYS is not set
-CONFIG_KERNEL_CGROUPS=y
-# CONFIG_KERNEL_CGROUP_DEBUG is not set
-CONFIG_KERNEL_FREEZER=y
-# CONFIG_KERNEL_CGROUP_FREEZER is not set
-# CONFIG_KERNEL_CGROUP_DEVICE is not set
-# CONFIG_KERNEL_CGROUP_HUGETLB is not set
-CONFIG_KERNEL_CGROUP_PIDS=y
-CONFIG_KERNEL_CGROUP_RDMA=y
-CONFIG_KERNEL_CGROUP_BPF=y
-CONFIG_KERNEL_CPUSETS=y
-# CONFIG_KERNEL_PROC_PID_CPUSET is not set
-CONFIG_KERNEL_CGROUP_CPUACCT=y
-CONFIG_KERNEL_RESOURCE_COUNTERS=y
-CONFIG_KERNEL_MM_OWNER=y
-CONFIG_KERNEL_MEMCG=y
-CONFIG_KERNEL_MEMCG_SWAP=y
-# CONFIG_KERNEL_MEMCG_SWAP_ENABLED is not set
-CONFIG_KERNEL_MEMCG_KMEM=y
-# CONFIG_KERNEL_CGROUP_PERF is not set
-CONFIG_KERNEL_CGROUP_SCHED=y
-CONFIG_KERNEL_FAIR_GROUP_SCHED=y
-CONFIG_KERNEL_CFS_BANDWIDTH=y
-CONFIG_KERNEL_RT_GROUP_SCHED=y
-CONFIG_KERNEL_BLK_CGROUP=y
-# CONFIG_KERNEL_CFQ_GROUP_IOSCHED is not set
-CONFIG_KERNEL_BLK_DEV_THROTTLING=y
-# CONFIG_KERNEL_BLK_DEV_THROTTLING_LOW is not set
-# CONFIG_KERNEL_DEBUG_BLK_CGROUP is not set
-# CONFIG_KERNEL_NET_CLS_CGROUP is not set
-# CONFIG_KERNEL_CGROUP_NET_CLASSID is not set
-# CONFIG_KERNEL_CGROUP_NET_PRIO is not set
-CONFIG_KERNEL_NAMESPACES=y
-CONFIG_KERNEL_UTS_NS=y
-CONFIG_KERNEL_IPC_NS=y
-CONFIG_KERNEL_USER_NS=y
-CONFIG_KERNEL_PID_NS=y
-CONFIG_KERNEL_NET_NS=y
-CONFIG_KERNEL_DEVPTS_MULTIPLE_INSTANCES=y
-CONFIG_KERNEL_POSIX_MQUEUE=y
+# CONFIG_KERNEL_KEYS is not set
+# CONFIG_KERNEL_CGROUPS is not set
+# CONFIG_KERNEL_NAMESPACES is not set
+# CONFIG_KERNEL_DEVPTS_MULTIPLE_INSTANCES is not set
+# CONFIG_KERNEL_POSIX_MQUEUE is not set
 CONFIG_KERNEL_SECCOMP_FILTER=y
-CONFIG_KERNEL_SECCOMP=y
+# CONFIG_KERNEL_SECCOMP is not set
 CONFIG_KERNEL_IP_MROUTE=y
 CONFIG_KERNEL_IP_MROUTE_MULTIPLE_TABLES=y
 CONFIG_KERNEL_IP_PIMSM_V1=y
@@ -723,7 +689,7 @@ CONFIG_PKG_FORTIFY_SOURCE_1=y
 # CONFIG_PKG_RELRO_PARTIAL is not set
 CONFIG_PKG_RELRO_FULL=y
 # CONFIG_SELINUX is not set
-CONFIG_SECCOMP=y
+# CONFIG_SECCOMP is not set
 # end of Global build settings
 
 # CONFIG_DEVEL is not set
@@ -747,9 +713,9 @@ CONFIG_USE_GARGOYLE_PROFILE_PKGS=y
 #
 # Standard Gargoyle package sets
 #
-CONFIG_GARGOYLE_BASIC=m
-CONFIG_GARGOYLE_USB=m
-CONFIG_GARGOYLE_LARGE=m
+# CONFIG_GARGOYLE_BASIC is not set
+# CONFIG_GARGOYLE_USB is not set
+# CONFIG_GARGOYLE_LARGE is not set
 # end of Standard Gargoyle package sets
 
 CONFIG_GARGOYLE_LANGUAGE_PKGS=m
@@ -2833,9 +2799,8 @@ CONFIG_PACKAGE_procd=y
 # CONFIG_PROCD_SHOW_BOOT is not set
 # end of Configuration
 
-CONFIG_PACKAGE_procd-seccomp=y
 # CONFIG_PACKAGE_procd-selinux is not set
-CONFIG_PACKAGE_procd-ujail=y
+# CONFIG_PACKAGE_procd-ujail is not set
 # CONFIG_PACKAGE_qos-scripts is not set
 # CONFIG_PACKAGE_refpolicy is not set
 CONFIG_PACKAGE_resolveip=m
@@ -2877,8 +2842,8 @@ CONFIG_PACKAGE_gargoyle=y
 CONFIG_PACKAGE_gargoyle-i18n=y
 CONFIG_PACKAGE_plugin-gargoyle-adblock=m
 CONFIG_PACKAGE_plugin-gargoyle-cron=m
-CONFIG_PACKAGE_plugin-gargoyle-ddns=y
-CONFIG_PACKAGE_plugin-gargoyle-diagnostics=y
+CONFIG_PACKAGE_plugin-gargoyle-ddns=m
+CONFIG_PACKAGE_plugin-gargoyle-diagnostics=m
 
 #
 # Diagnostics Plugin Configuration
@@ -2931,12 +2896,13 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=m
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=m
 CONFIG_PACKAGE_plugin-gargoyle-webcam=m
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
 CONFIG_PACKAGE_plugin-gargoyle-wifi-schedule=m
 CONFIG_PACKAGE_plugin-gargoyle-wireguard=m
-CONFIG_PACKAGE_plugin-gargoyle-wol=y
+CONFIG_PACKAGE_plugin-gargoyle-wol=m
 # end of Gargoyle Web Interface
 # end of Administration
 
@@ -3245,7 +3211,7 @@ CONFIG_PACKAGE_kmod-fs-nfsd=m
 CONFIG_PACKAGE_kmod-fs-vfat=m
 # CONFIG_PACKAGE_kmod-fs-xfs is not set
 CONFIG_PACKAGE_kmod-fuse=m
-CONFIG_PACKAGE_kmod-pstore=y
+CONFIG_PACKAGE_kmod-pstore=m
 # end of Filesystems
 
 #
@@ -3376,7 +3342,7 @@ CONFIG_PACKAGE_kmod-input-core=m
 # LED modules
 #
 # CONFIG_PACKAGE_kmod-input-leds is not set
-CONFIG_PACKAGE_kmod-leds-gpio=y
+CONFIG_PACKAGE_kmod-leds-gpio=m
 # CONFIG_PACKAGE_kmod-leds-pca963x is not set
 # CONFIG_PACKAGE_kmod-leds-tlc591xx is not set
 # CONFIG_PACKAGE_kmod-leds-uleds is not set
@@ -3688,7 +3654,7 @@ CONFIG_PACKAGE_kmod-eeprom-93cx6=m
 # CONFIG_PACKAGE_kmod-eeprom-at24 is not set
 # CONFIG_PACKAGE_kmod-eeprom-at25 is not set
 # CONFIG_PACKAGE_kmod-gpio-beeper is not set
-CONFIG_PACKAGE_kmod-gpio-button-hotplug=y
+CONFIG_PACKAGE_kmod-gpio-button-hotplug=m
 # CONFIG_PACKAGE_kmod-gpio-mcp23s08 is not set
 # CONFIG_PACKAGE_kmod-gpio-nxp-74hc164 is not set
 # CONFIG_PACKAGE_kmod-gpio-pca953x is not set
@@ -3709,9 +3675,9 @@ CONFIG_PACKAGE_kmod-mmc=m
 # CONFIG_PACKAGE_kmod-pps-gpio is not set
 # CONFIG_PACKAGE_kmod-pps-ldisc is not set
 # CONFIG_PACKAGE_kmod-ptp is not set
-CONFIG_PACKAGE_kmod-ramoops=y
+CONFIG_PACKAGE_kmod-ramoops=m
 CONFIG_PACKAGE_kmod-random-core=m
-CONFIG_PACKAGE_kmod-reed-solomon=y
+CONFIG_PACKAGE_kmod-reed-solomon=m
 CONFIG_PACKAGE_kmod-regmap-core=m
 CONFIG_PACKAGE_kmod-regmap-i2c=m
 # CONFIG_PACKAGE_kmod-rtc-ds1307 is not set
@@ -4008,15 +3974,15 @@ CONFIG_PACKAGE_kmod-mt76x2-common=m
 # CONFIG_PACKAGE_kmod-rt2400-pci is not set
 # CONFIG_PACKAGE_kmod-rt2500-pci is not set
 # CONFIG_PACKAGE_kmod-rt2500-usb is not set
-CONFIG_PACKAGE_kmod-rt2800-lib=y
-CONFIG_PACKAGE_kmod-rt2800-mmio=y
+CONFIG_PACKAGE_kmod-rt2800-lib=m
+CONFIG_PACKAGE_kmod-rt2800-mmio=m
 CONFIG_PACKAGE_kmod-rt2800-pci=m
-CONFIG_PACKAGE_kmod-rt2800-soc=y
+CONFIG_PACKAGE_kmod-rt2800-soc=m
 # CONFIG_PACKAGE_kmod-rt2800-usb is not set
-CONFIG_PACKAGE_kmod-rt2x00-lib=y
+CONFIG_PACKAGE_kmod-rt2x00-lib=m
 # CONFIG_PACKAGE_RT2X00_LIB_DEBUGFS is not set
 # CONFIG_PACKAGE_RT2X00_DEBUG is not set
-CONFIG_PACKAGE_kmod-rt2x00-mmio=y
+CONFIG_PACKAGE_kmod-rt2x00-mmio=m
 CONFIG_PACKAGE_kmod-rt2x00-pci=m
 # CONFIG_PACKAGE_kmod-rt61-pci is not set
 # CONFIG_PACKAGE_kmod-rt73-usb is not set
@@ -4331,7 +4297,7 @@ CONFIG_PACKAGE_libubus=y
 # CONFIG_PACKAGE_libubus-lua is not set
 CONFIG_PACKAGE_libuci=y
 # CONFIG_PACKAGE_libuci-lua is not set
-CONFIG_PACKAGE_libuclient=y
+CONFIG_PACKAGE_libuclient=m
 # CONFIG_PACKAGE_libunwind is not set
 CONFIG_PACKAGE_libusb-1.0=m
 # CONFIG_PACKAGE_libustream-mbedtls is not set
@@ -4657,13 +4623,13 @@ CONFIG_DRIVER_11AC_SUPPORT=y
 # CONFIG_PACKAGE_wpa-supplicant-wolfssl is not set
 # CONFIG_PACKAGE_wpad is not set
 # CONFIG_PACKAGE_wpad-basic is not set
-CONFIG_PACKAGE_wpad-basic-openssl=m
+# CONFIG_PACKAGE_wpad-basic-openssl is not set
 CONFIG_PACKAGE_wpad-basic-wolfssl=m
 # CONFIG_PACKAGE_wpad-mesh-openssl is not set
 # CONFIG_PACKAGE_wpad-mesh-wolfssl is not set
 # CONFIG_PACKAGE_wpad-mini is not set
 CONFIG_PACKAGE_wpad-openssl=y
-CONFIG_PACKAGE_wpad-wolfssl=m
+# CONFIG_PACKAGE_wpad-wolfssl is not set
 # end of WirelessAPD
 
 # CONFIG_PACKAGE_464xlat is not set
@@ -4674,9 +4640,9 @@ CONFIG_PACKAGE_wpad-wolfssl=m
 # CONFIG_PACKAGE_bpftool-minimal is not set
 CONFIG_PACKAGE_bwmon-gargoyle=y
 CONFIG_PACKAGE_chat=m
-CONFIG_PACKAGE_ddns-gargoyle=y
+CONFIG_PACKAGE_ddns-gargoyle=m
 # CONFIG_PACKAGE_ds-lite is not set
-CONFIG_PACKAGE_etherwake=y
+CONFIG_PACKAGE_etherwake=m
 # CONFIG_PACKAGE_ethtool is not set
 # CONFIG_PACKAGE_ethtool-full is not set
 CONFIG_PACKAGE_ewget=y
@@ -4732,7 +4698,7 @@ CONFIG_PACKAGE_SAMBA_MAX_DEBUG_LEVEL=-1
 # CONFIG_PACKAGE_soloscli is not set
 # CONFIG_PACKAGE_tcpdump is not set
 # CONFIG_PACKAGE_tcpdump-mini is not set
-CONFIG_PACKAGE_uclient-fetch=y
+CONFIG_PACKAGE_uclient-fetch=m
 # CONFIG_PACKAGE_umdns is not set
 CONFIG_PACKAGE_usteer=m
 # CONFIG_PACKAGE_ustp is not set
@@ -4922,7 +4888,6 @@ CONFIG_PACKAGE_adb=m
 # CONFIG_PACKAGE_getopt is not set
 CONFIG_PACKAGE_gpkg=y
 # CONFIG_PACKAGE_haserl is not set
-CONFIG_PACKAGE_haserl-i18n=y
 CONFIG_PACKAGE_haserl-i18n=y
 # CONFIG_PACKAGE_hwclock is not set
 # CONFIG_PACKAGE_iconv is not set

--- a/targets/ramips/profiles/default/profile_images
+++ b/targets/ramips/profiles/default/profile_images
@@ -12,8 +12,11 @@ comfast_cf-wr800n-
 dlink_dch-m225-
 dlink_dir-810l-
 dlink_dwr-116-a1-squashfs-
+dlink_dwr-118-a1-squashfs-
+dlink_dwr-118-a2-squashfs-
 dlink_dwr-921-c1-squashfs-
 dlink_dwr-921-c3-squashfs-
+dlink_dwr-922-e2-squashfs-
 dovado_tiny-ac-
 elecom_wrh-300cr-squashfs-
 glinet_gl-mt300a-
@@ -46,7 +49,6 @@ ralink_mt7620a-evb-
 ralink_mt7620a-mt7530-evb-
 ralink_mt7620a-mt7610e-evb-
 ralink_mt7620a-v22sg-evb-
-ravpower_rp-wd03-
 sanlinking_d240-
 sercomm_na930-
 tplink_archer-c20-v1-squashfs-
@@ -62,8 +64,9 @@ zbtlink_zbt-ape522ii-
 zbtlink_zbt-cpe102-
 zbtlink_zbt-wa05-
 zbtlink_zbt-we1026-5g-16m-
+zbtlink_zbt-we1026-h-32m-
 zbtlink_zbt-we2026-
 zbtlink_zbt-we826-16m-
 zbtlink_zbt-we826-32m-
 zbtlink_zbt-wr8305rt-
-zbtlink_zte-q7-
+zte_q7-

--- a/targets/ramips/profiles/mt7621/config
+++ b/targets/ramips/profiles/mt7621/config
@@ -293,17 +293,17 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_edimax_re23s="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-1167ghbk2-s=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1167ghbk2-s="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-1167gs2-b=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1167gs2-b="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1167gs2-b="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-1167gst2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1167gst2="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-1750gs=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1750gs="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1750gs="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-1750gst2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1750gst2="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-1750gsv=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1750gsv="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1750gsv="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-1900gst=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1900gst="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-1900gst="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-2533ghbk-i=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-2533ghbk-i="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-2533gs2=y
@@ -311,7 +311,7 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-2533gs2="gargoyle-
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-2533gst=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-2533gst="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_elecom_wrc-2533gst2=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-2533gst2="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_elecom_wrc-2533gst2="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_firefly_firewrt is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_gehua_ghl-r-001 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_winstars_ws-wn583a6 is not set
@@ -371,7 +371,7 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_mikrotik_routerboard-750gr3="
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_netgear_r6700-v2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_netgear_r6700-v2="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_netgear_r6220=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_netgear_r6220="gargoyle-usb"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_netgear_r6220="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_netgear_r6260=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_netgear_r6260="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_netgear_r6350=y
@@ -421,19 +421,17 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_archer-c6-v3="gargoyle
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_archer-c6u-v1=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_archer-c6u-v1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_eap235-wall-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_eap235-wall-v1="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_eap235-wall-v1="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_eap615-wall-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_eap615-wall-v1="gargoyle-large"
-CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_re350-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_re350-v1="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_eap615-wall-v1="gargoyle-basic"
+# CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_re350-v1 is not set
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_re500-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_re500-v1="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_re500-v1="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_re650-v1=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_re650-v1="gargoyle-large"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_re650-v1="gargoyle-basic"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_re650-v2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_re650-v2="gargoyle-basic"
-CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_tl-wpa8631p-v3=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_tl-wpa8631p-v3="gargoyle-basic"
+# CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_tl-wpa8631p-v3 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_ubnt_edgerouter-x-sfp is not set
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_ubnt_edgerouter-x=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_ubnt_edgerouter-x="gargoyle-large"
@@ -615,7 +613,7 @@ CONFIG_EXTERNAL_CPIO=""
 #
 # CONFIG_TARGET_ROOTFS_EXT4FS is not set
 CONFIG_TARGET_ROOTFS_SQUASHFS=y
-CONFIG_TARGET_SQUASHFS_BLOCK_SIZE=256
+CONFIG_TARGET_SQUASHFS_BLOCK_SIZE=1024
 CONFIG_TARGET_UBIFS_FREE_SPACE_FIXUP=y
 CONFIG_TARGET_UBIFS_JOURNAL_SIZE=""
 
@@ -660,23 +658,23 @@ CONFIG_KERNEL_BUILD_USER=""
 CONFIG_KERNEL_BUILD_DOMAIN=""
 CONFIG_KERNEL_PRINTK=y
 CONFIG_KERNEL_SWAP=y
-# CONFIG_KERNEL_PROC_STRIPPED is not set
+CONFIG_KERNEL_PROC_STRIPPED=y
 CONFIG_KERNEL_DEBUG_FS=y
 # CONFIG_KERNEL_PERF_EVENTS is not set
 # CONFIG_KERNEL_PROFILING is not set
 # CONFIG_KERNEL_UBSAN is not set
 # CONFIG_KERNEL_KCOV is not set
 # CONFIG_KERNEL_TASKSTATS is not set
-CONFIG_KERNEL_KALLSYMS=y
+# CONFIG_KERNEL_KALLSYMS is not set
 # CONFIG_KERNEL_FTRACE is not set
-CONFIG_KERNEL_DEBUG_KERNEL=y
-CONFIG_KERNEL_DEBUG_INFO=y
+# CONFIG_KERNEL_DEBUG_KERNEL is not set
+# CONFIG_KERNEL_DEBUG_INFO is not set
 # CONFIG_KERNEL_DYNAMIC_DEBUG is not set
 # CONFIG_KERNEL_KPROBES is not set
-CONFIG_KERNEL_AIO=y
-CONFIG_KERNEL_IO_URING=y
-CONFIG_KERNEL_FHANDLE=y
-CONFIG_KERNEL_FANOTIFY=y
+# CONFIG_KERNEL_AIO is not set
+# CONFIG_KERNEL_IO_URING is not set
+# CONFIG_KERNEL_FHANDLE is not set
+# CONFIG_KERNEL_FANOTIFY is not set
 # CONFIG_KERNEL_BLK_DEV_BSG is not set
 # CONFIG_KERNEL_HUGETLB_PAGE is not set
 CONFIG_KERNEL_MAGIC_SYSRQ=y
@@ -698,51 +696,13 @@ CONFIG_KERNEL_RELAY=y
 # CONFIG_USE_RFKILL is not set
 # CONFIG_USE_SPARSE is not set
 # CONFIG_KERNEL_DEVTMPFS is not set
-CONFIG_KERNEL_KEYS=y
-# CONFIG_KERNEL_PERSISTENT_KEYRINGS is not set
-# CONFIG_KERNEL_KEYS_REQUEST_CACHE is not set
-# CONFIG_KERNEL_BIG_KEYS is not set
-CONFIG_KERNEL_CGROUPS=y
-# CONFIG_KERNEL_CGROUP_DEBUG is not set
-CONFIG_KERNEL_FREEZER=y
-# CONFIG_KERNEL_CGROUP_FREEZER is not set
-# CONFIG_KERNEL_CGROUP_DEVICE is not set
-# CONFIG_KERNEL_CGROUP_HUGETLB is not set
-CONFIG_KERNEL_CGROUP_PIDS=y
-CONFIG_KERNEL_CGROUP_RDMA=y
-CONFIG_KERNEL_CGROUP_BPF=y
-CONFIG_KERNEL_CPUSETS=y
-# CONFIG_KERNEL_PROC_PID_CPUSET is not set
-CONFIG_KERNEL_CGROUP_CPUACCT=y
-CONFIG_KERNEL_RESOURCE_COUNTERS=y
-CONFIG_KERNEL_MM_OWNER=y
-CONFIG_KERNEL_MEMCG=y
-CONFIG_KERNEL_MEMCG_SWAP=y
-# CONFIG_KERNEL_MEMCG_SWAP_ENABLED is not set
-CONFIG_KERNEL_MEMCG_KMEM=y
-# CONFIG_KERNEL_CGROUP_PERF is not set
-CONFIG_KERNEL_CGROUP_SCHED=y
-CONFIG_KERNEL_FAIR_GROUP_SCHED=y
-CONFIG_KERNEL_CFS_BANDWIDTH=y
-CONFIG_KERNEL_RT_GROUP_SCHED=y
-CONFIG_KERNEL_BLK_CGROUP=y
-# CONFIG_KERNEL_CFQ_GROUP_IOSCHED is not set
-CONFIG_KERNEL_BLK_DEV_THROTTLING=y
-# CONFIG_KERNEL_BLK_DEV_THROTTLING_LOW is not set
-# CONFIG_KERNEL_DEBUG_BLK_CGROUP is not set
-# CONFIG_KERNEL_NET_CLS_CGROUP is not set
-# CONFIG_KERNEL_CGROUP_NET_CLASSID is not set
-# CONFIG_KERNEL_CGROUP_NET_PRIO is not set
-CONFIG_KERNEL_NAMESPACES=y
-CONFIG_KERNEL_UTS_NS=y
-CONFIG_KERNEL_IPC_NS=y
-CONFIG_KERNEL_USER_NS=y
-CONFIG_KERNEL_PID_NS=y
-CONFIG_KERNEL_NET_NS=y
-CONFIG_KERNEL_DEVPTS_MULTIPLE_INSTANCES=y
-CONFIG_KERNEL_POSIX_MQUEUE=y
+# CONFIG_KERNEL_KEYS is not set
+# CONFIG_KERNEL_CGROUPS is not set
+# CONFIG_KERNEL_NAMESPACES is not set
+# CONFIG_KERNEL_DEVPTS_MULTIPLE_INSTANCES is not set
+# CONFIG_KERNEL_POSIX_MQUEUE is not set
 CONFIG_KERNEL_SECCOMP_FILTER=y
-CONFIG_KERNEL_SECCOMP=y
+# CONFIG_KERNEL_SECCOMP is not set
 CONFIG_KERNEL_IP_MROUTE=y
 CONFIG_KERNEL_IP_MROUTE_MULTIPLE_TABLES=y
 CONFIG_KERNEL_IP_PIMSM_V1=y
@@ -834,7 +794,7 @@ CONFIG_PKG_FORTIFY_SOURCE_1=y
 # CONFIG_PKG_RELRO_PARTIAL is not set
 CONFIG_PKG_RELRO_FULL=y
 # CONFIG_SELINUX is not set
-CONFIG_SECCOMP=y
+# CONFIG_SECCOMP is not set
 # end of Global build settings
 
 # CONFIG_DEVEL is not set
@@ -858,9 +818,9 @@ CONFIG_USE_GARGOYLE_PROFILE_PKGS=y
 #
 # Standard Gargoyle package sets
 #
-CONFIG_GARGOYLE_BASIC=m
-CONFIG_GARGOYLE_USB=m
-CONFIG_GARGOYLE_LARGE=m
+# CONFIG_GARGOYLE_BASIC is not set
+# CONFIG_GARGOYLE_USB is not set
+# CONFIG_GARGOYLE_LARGE is not set
 # end of Standard Gargoyle package sets
 
 CONFIG_GARGOYLE_LANGUAGE_PKGS=m
@@ -2945,9 +2905,8 @@ CONFIG_PACKAGE_procd=y
 # CONFIG_PROCD_SHOW_BOOT is not set
 # end of Configuration
 
-CONFIG_PACKAGE_procd-seccomp=y
 # CONFIG_PACKAGE_procd-selinux is not set
-CONFIG_PACKAGE_procd-ujail=y
+# CONFIG_PACKAGE_procd-ujail is not set
 # CONFIG_PACKAGE_qos-scripts is not set
 # CONFIG_PACKAGE_refpolicy is not set
 CONFIG_PACKAGE_resolveip=m
@@ -3044,6 +3003,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=m
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=m
 CONFIG_PACKAGE_plugin-gargoyle-webcam=m
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -3488,7 +3448,7 @@ CONFIG_PACKAGE_kmod-input-core=m
 # LED modules
 #
 # CONFIG_PACKAGE_kmod-input-leds is not set
-CONFIG_PACKAGE_kmod-leds-gpio=y
+CONFIG_PACKAGE_kmod-leds-gpio=m
 # CONFIG_PACKAGE_kmod-leds-pca963x is not set
 # CONFIG_PACKAGE_kmod-leds-tlc591xx is not set
 # CONFIG_PACKAGE_kmod-leds-uleds is not set
@@ -3800,7 +3760,7 @@ CONFIG_PACKAGE_kmod-eeprom-93cx6=m
 # CONFIG_PACKAGE_kmod-eeprom-at24 is not set
 # CONFIG_PACKAGE_kmod-eeprom-at25 is not set
 # CONFIG_PACKAGE_kmod-gpio-beeper is not set
-CONFIG_PACKAGE_kmod-gpio-button-hotplug=y
+CONFIG_PACKAGE_kmod-gpio-button-hotplug=m
 # CONFIG_PACKAGE_kmod-gpio-mcp23s08 is not set
 # CONFIG_PACKAGE_kmod-gpio-nxp-74hc164 is not set
 # CONFIG_PACKAGE_kmod-gpio-pca953x is not set
@@ -4432,7 +4392,7 @@ CONFIG_PACKAGE_libubus=y
 # CONFIG_PACKAGE_libubus-lua is not set
 CONFIG_PACKAGE_libuci=y
 # CONFIG_PACKAGE_libuci-lua is not set
-CONFIG_PACKAGE_libuclient=y
+CONFIG_PACKAGE_libuclient=m
 # CONFIG_PACKAGE_libunwind is not set
 CONFIG_PACKAGE_libusb-1.0=m
 # CONFIG_PACKAGE_libustream-mbedtls is not set
@@ -4758,13 +4718,13 @@ CONFIG_DRIVER_11AX_SUPPORT=y
 # CONFIG_PACKAGE_wpa-supplicant-wolfssl is not set
 # CONFIG_PACKAGE_wpad is not set
 # CONFIG_PACKAGE_wpad-basic is not set
-CONFIG_PACKAGE_wpad-basic-openssl=m
+# CONFIG_PACKAGE_wpad-basic-openssl is not set
 CONFIG_PACKAGE_wpad-basic-wolfssl=m
 # CONFIG_PACKAGE_wpad-mesh-openssl is not set
 # CONFIG_PACKAGE_wpad-mesh-wolfssl is not set
 # CONFIG_PACKAGE_wpad-mini is not set
 CONFIG_PACKAGE_wpad-openssl=y
-CONFIG_PACKAGE_wpad-wolfssl=m
+# CONFIG_PACKAGE_wpad-wolfssl is not set
 # end of WirelessAPD
 
 # CONFIG_PACKAGE_464xlat is not set
@@ -4833,7 +4793,7 @@ CONFIG_PACKAGE_SAMBA_MAX_DEBUG_LEVEL=-1
 # CONFIG_PACKAGE_soloscli is not set
 # CONFIG_PACKAGE_tcpdump is not set
 # CONFIG_PACKAGE_tcpdump-mini is not set
-CONFIG_PACKAGE_uclient-fetch=y
+CONFIG_PACKAGE_uclient-fetch=m
 # CONFIG_PACKAGE_umdns is not set
 CONFIG_PACKAGE_usteer=m
 # CONFIG_PACKAGE_ustp is not set

--- a/targets/ramips/profiles/mt7621/profile_images
+++ b/targets/ramips/profiles/mt7621/profile_images
@@ -61,11 +61,9 @@ tplink_archer-c6-v3
 tplink_archer-c6u-v1
 tplink_eap235-wall-v1
 tplink_eap615-wall-v1
-tplink_re350-v1
 tplink_re500-v1
 tplink_re650-v1
 tplink_re650-v2
-tplink_tl-wpa8631p-v3
 ubnt_edgerouter-x
 ubnt_unifi-6-lite
 ubnt_unifi-nanohd

--- a/targets/ramips/profiles/mt76x8/config
+++ b/targets/ramips/profiles/mt76x8/config
@@ -212,9 +212,9 @@ CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_archer-c50-v4="gargoyl
 # CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_re305-v1 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_re305-v3 is not set
 CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-mr3020-v3=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_tl-mr3020-v3="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_tl-mr3020-v3="gargoyle-usb"
 CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-mr3420-v5=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_tl-mr3420-v5="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_tl-mr3420-v5="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-mr6400-v4 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-mr6400-v5 is not set
 CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-wa801nd-v5=y
@@ -228,10 +228,10 @@ CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-wr841n-v13=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_tl-wr841n-v13="gargoyle-basic"
 # CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-wr841n-v14 is not set
 CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-wr842n-v5=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_tl-wr842n-v5="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_tl-wr842n-v5="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-wr850n-v2 is not set
 CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_tplink_tl-wr902ac-v3=y
-CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_tl-wr902ac-v3="gargoyle-basic"
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt76x8_DEVICE_tplink_tl-wr902ac-v3="gargoyle-usb"
 # CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_unielec_u7628-01-16m is not set
 # CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_vocore_vocore2 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt76x8_DEVICE_vocore_vocore2-lite is not set
@@ -2753,6 +2753,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=m
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=m
 CONFIG_PACKAGE_plugin-gargoyle-webcam=m
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -4635,7 +4636,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem

--- a/targets/ramips/profiles/rt305x/config
+++ b/targets/ramips/profiles/rt305x/config
@@ -441,7 +441,7 @@ CONFIG_CLEAN_IPKG_PARTIAL=y
 CONFIG_KERNEL_BUILD_USER=""
 CONFIG_KERNEL_BUILD_DOMAIN=""
 CONFIG_KERNEL_PRINTK=y
-# CONFIG_KERNEL_SWAP is not set
+CONFIG_KERNEL_SWAP=y
 CONFIG_KERNEL_PROC_STRIPPED=y
 CONFIG_KERNEL_DEBUG_FS=y
 # CONFIG_KERNEL_PERF_EVENTS is not set
@@ -479,7 +479,7 @@ CONFIG_KERNEL_PRINTK_TIME=y
 # CONFIG_KERNEL_DEVPTS_MULTIPLE_INSTANCES is not set
 # CONFIG_KERNEL_POSIX_MQUEUE is not set
 CONFIG_KERNEL_SECCOMP_FILTER=y
-CONFIG_KERNEL_SECCOMP=y
+# CONFIG_KERNEL_SECCOMP is not set
 CONFIG_KERNEL_IP_MROUTE=y
 CONFIG_KERNEL_IP_MROUTE_MULTIPLE_TABLES=y
 CONFIG_KERNEL_IP_PIMSM_V1=y
@@ -490,7 +490,7 @@ CONFIG_KERNEL_IPV6_SUBTREES=y
 CONFIG_KERNEL_IPV6_MROUTE=y
 CONFIG_KERNEL_IPV6_MROUTE_MULTIPLE_TABLES=y
 CONFIG_KERNEL_IPV6_PIMSM_V2=y
-# CONFIG_KERNEL_IPV6_SEG6_LWTUNNEL is not set
+CONFIG_KERNEL_IPV6_SEG6_LWTUNNEL=y
 # CONFIG_KERNEL_LWTUNNEL_BPF is not set
 # CONFIG_KERNEL_NET_L3_MASTER_DEV is not set
 # CONFIG_KERNEL_IP_PNP is not set
@@ -571,7 +571,7 @@ CONFIG_PKG_FORTIFY_SOURCE_1=y
 # CONFIG_PKG_RELRO_PARTIAL is not set
 CONFIG_PKG_RELRO_FULL=y
 # CONFIG_SELINUX is not set
-CONFIG_SECCOMP=y
+# CONFIG_SECCOMP is not set
 # end of Global build settings
 
 # CONFIG_DEVEL is not set
@@ -595,9 +595,9 @@ CONFIG_USE_GARGOYLE_PROFILE_PKGS=y
 #
 # Standard Gargoyle package sets
 #
-CONFIG_GARGOYLE_BASIC=m
-CONFIG_GARGOYLE_USB=m
-CONFIG_GARGOYLE_LARGE=m
+# CONFIG_GARGOYLE_BASIC is not set
+# CONFIG_GARGOYLE_USB is not set
+# CONFIG_GARGOYLE_LARGE is not set
 # end of Standard Gargoyle package sets
 
 CONFIG_GARGOYLE_LANGUAGE_PKGS=m
@@ -2642,7 +2642,7 @@ CONFIG_PACKAGE_dropbear=y
 #
 CONFIG_DROPBEAR_CURVE25519=y
 # CONFIG_DROPBEAR_ECC is not set
-# CONFIG_DROPBEAR_ED25519 is not set
+CONFIG_DROPBEAR_ED25519=y
 CONFIG_DROPBEAR_CHACHA20POLY1305=y
 # CONFIG_DROPBEAR_ZLIB is not set
 CONFIG_DROPBEAR_DBCLIENT=y
@@ -2681,7 +2681,6 @@ CONFIG_PACKAGE_procd=y
 # CONFIG_PROCD_SHOW_BOOT is not set
 # end of Configuration
 
-CONFIG_PACKAGE_procd-seccomp=y
 # CONFIG_PACKAGE_procd-selinux is not set
 # CONFIG_PACKAGE_procd-ujail is not set
 # CONFIG_PACKAGE_qos-scripts is not set
@@ -2724,7 +2723,7 @@ CONFIG_PACKAGE_gargoyle=y
 CONFIG_PACKAGE_gargoyle-i18n=y
 CONFIG_PACKAGE_plugin-gargoyle-adblock=m
 CONFIG_PACKAGE_plugin-gargoyle-cron=m
-CONFIG_PACKAGE_plugin-gargoyle-ddns=y
+CONFIG_PACKAGE_plugin-gargoyle-ddns=m
 CONFIG_PACKAGE_plugin-gargoyle-diagnostics=m
 
 #
@@ -2778,6 +2777,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=m
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=m
 CONFIG_PACKAGE_plugin-gargoyle-webcam=m
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -3199,7 +3199,7 @@ CONFIG_PACKAGE_kmod-input-core=m
 # LED modules
 #
 # CONFIG_PACKAGE_kmod-input-leds is not set
-CONFIG_PACKAGE_kmod-leds-gpio=y
+CONFIG_PACKAGE_kmod-leds-gpio=m
 # CONFIG_PACKAGE_kmod-leds-pca963x is not set
 # CONFIG_PACKAGE_kmod-leds-tlc591xx is not set
 # CONFIG_PACKAGE_kmod-leds-uleds is not set
@@ -3468,7 +3468,7 @@ CONFIG_PACKAGE_kmod-dma-buf=m
 # CONFIG_PACKAGE_kmod-eeprom-at24 is not set
 # CONFIG_PACKAGE_kmod-eeprom-at25 is not set
 # CONFIG_PACKAGE_kmod-gpio-beeper is not set
-CONFIG_PACKAGE_kmod-gpio-button-hotplug=y
+CONFIG_PACKAGE_kmod-gpio-button-hotplug=m
 # CONFIG_PACKAGE_kmod-gpio-mcp23s08 is not set
 # CONFIG_PACKAGE_kmod-gpio-nxp-74hc164 is not set
 # CONFIG_PACKAGE_kmod-gpio-pca953x is not set
@@ -3488,7 +3488,7 @@ CONFIG_PACKAGE_kmod-gpio-button-hotplug=y
 # CONFIG_PACKAGE_kmod-pps-ldisc is not set
 # CONFIG_PACKAGE_kmod-ptp is not set
 CONFIG_PACKAGE_kmod-ramoops=m
-# CONFIG_PACKAGE_kmod-random-core is not set
+CONFIG_PACKAGE_kmod-random-core=m
 CONFIG_PACKAGE_kmod-reed-solomon=m
 # CONFIG_PACKAGE_kmod-rtc-ds1307 is not set
 # CONFIG_PACKAGE_kmod-rtc-ds1374 is not set
@@ -3726,14 +3726,14 @@ CONFIG_PACKAGE_MAC80211_MESH=y
 # CONFIG_PACKAGE_kmod-rsi91x-sdio is not set
 # CONFIG_PACKAGE_kmod-rsi91x-usb is not set
 # CONFIG_PACKAGE_kmod-rt2500-usb is not set
-CONFIG_PACKAGE_kmod-rt2800-lib=y
-CONFIG_PACKAGE_kmod-rt2800-mmio=y
-CONFIG_PACKAGE_kmod-rt2800-soc=y
+CONFIG_PACKAGE_kmod-rt2800-lib=m
+CONFIG_PACKAGE_kmod-rt2800-mmio=m
+CONFIG_PACKAGE_kmod-rt2800-soc=m
 # CONFIG_PACKAGE_kmod-rt2800-usb is not set
-CONFIG_PACKAGE_kmod-rt2x00-lib=y
+CONFIG_PACKAGE_kmod-rt2x00-lib=m
 # CONFIG_PACKAGE_RT2X00_LIB_DEBUGFS is not set
 # CONFIG_PACKAGE_RT2X00_DEBUG is not set
-CONFIG_PACKAGE_kmod-rt2x00-mmio=y
+CONFIG_PACKAGE_kmod-rt2x00-mmio=m
 # CONFIG_PACKAGE_kmod-rt73-usb is not set
 # CONFIG_PACKAGE_kmod-rtl8187 is not set
 # CONFIG_PACKAGE_kmod-rtl8192cu is not set
@@ -4038,7 +4038,7 @@ CONFIG_PACKAGE_libubus=y
 # CONFIG_PACKAGE_libubus-lua is not set
 CONFIG_PACKAGE_libuci=y
 # CONFIG_PACKAGE_libuci-lua is not set
-CONFIG_PACKAGE_libuclient=y
+CONFIG_PACKAGE_libuclient=m
 # CONFIG_PACKAGE_libunwind is not set
 CONFIG_PACKAGE_libusb-1.0=m
 # CONFIG_PACKAGE_libustream-mbedtls is not set
@@ -4364,13 +4364,13 @@ CONFIG_DRIVER_11N_SUPPORT=y
 # CONFIG_PACKAGE_wpa-supplicant-wolfssl is not set
 # CONFIG_PACKAGE_wpad is not set
 # CONFIG_PACKAGE_wpad-basic is not set
-CONFIG_PACKAGE_wpad-basic-openssl=m
+# CONFIG_PACKAGE_wpad-basic-openssl is not set
 CONFIG_PACKAGE_wpad-basic-wolfssl=m
 # CONFIG_PACKAGE_wpad-mesh-openssl is not set
 # CONFIG_PACKAGE_wpad-mesh-wolfssl is not set
 # CONFIG_PACKAGE_wpad-mini is not set
-CONFIG_PACKAGE_wpad-openssl=m
-CONFIG_PACKAGE_wpad-wolfssl=m
+CONFIG_PACKAGE_wpad-openssl=y
+# CONFIG_PACKAGE_wpad-wolfssl is not set
 # end of WirelessAPD
 
 # CONFIG_PACKAGE_464xlat is not set
@@ -4381,7 +4381,7 @@ CONFIG_PACKAGE_wpad-wolfssl=m
 # CONFIG_PACKAGE_bpftool-minimal is not set
 CONFIG_PACKAGE_bwmon-gargoyle=y
 CONFIG_PACKAGE_chat=m
-CONFIG_PACKAGE_ddns-gargoyle=y
+CONFIG_PACKAGE_ddns-gargoyle=m
 # CONFIG_PACKAGE_ds-lite is not set
 CONFIG_PACKAGE_etherwake=m
 # CONFIG_PACKAGE_ethtool is not set
@@ -4438,7 +4438,7 @@ CONFIG_PACKAGE_samba36-server=m
 CONFIG_PACKAGE_SAMBA_MAX_DEBUG_LEVEL=-1
 # CONFIG_PACKAGE_tcpdump is not set
 # CONFIG_PACKAGE_tcpdump-mini is not set
-CONFIG_PACKAGE_uclient-fetch=y
+CONFIG_PACKAGE_uclient-fetch=m
 # CONFIG_PACKAGE_umdns is not set
 CONFIG_PACKAGE_usteer=m
 # CONFIG_PACKAGE_ustp is not set

--- a/targets/x86/profiles/alix/config
+++ b/targets/x86/profiles/alix/config
@@ -2536,6 +2536,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=y
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=y
 CONFIG_PACKAGE_plugin-gargoyle-webcam=y
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -4437,7 +4438,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem

--- a/targets/x86/profiles/default/config
+++ b/targets/x86/profiles/default/config
@@ -2547,6 +2547,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=y
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=y
 CONFIG_PACKAGE_plugin-gargoyle-webcam=y
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -4454,7 +4455,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem

--- a/targets/x86/profiles/x64/config
+++ b/targets/x86/profiles/x64/config
@@ -2548,6 +2548,7 @@ CONFIG_PACKAGE_plugin-gargoyle-usb-storage-full=y
 #
 CONFIG_GARGOYLE_SMB_KSMBD=y
 # CONFIG_GARGOYLE_SMB_SAMBA is not set
+CONFIG_PACKAGE_plugin-gargoyle-usb-storage-extroot=m
 CONFIG_PACKAGE_plugin-gargoyle-usb-storage-noshare=y
 CONFIG_PACKAGE_plugin-gargoyle-webcam=y
 CONFIG_PACKAGE_plugin-gargoyle-webshell=m
@@ -4459,7 +4460,7 @@ CONFIG_PACKAGE_NTFS-3G_HAS_PROBE=y
 # CONFIG_PACKAGE_ntfs-3g-low is not set
 # CONFIG_PACKAGE_ntfs-3g-utils is not set
 # CONFIG_PACKAGE_resize2fs is not set
-CONFIG_PACKAGE_swap-utils=y
+CONFIG_PACKAGE_swap-utils=m
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
 # end of Filesystem


### PR DESCRIPTION
Update the plugin-gargoyle-usb-storage-noshare package to add an "extroot" package without the HFS+ and NTFS filesystems and some NLS kmods; these items are left in the "noshare" package which becomes a meta-package dependent on the "extroot" package.  The gargoyle-usb profile meta-package is set to use the "extroot" package, which still allows users to configure extroot on 8MB flash USB devices; with extroot configured users can then install other packages.

More packages are set to =m to minimise the chance of unnecessary inclusion in -basic profile images; -usb and -large profile images will include the packages they need as dependencies.  `swap-utils` should be unnecessary if the Busybox swap related applets are built but is retained as an installable package for now.

mt7620 (ramips.default) and mt7620 have the kernel and image slimming options used in ath79 and mt76x8 to keep as many 8MB device images buildable as possible.  Several devices have to be abandoned as unbuildable even with a -basic profile in spite of these changes :-(, but many 8MB devices remain viable (though users may not be able to add many - if any - optional packages).

The ath79 and ipq806x cleanup changes haven't been built by me just yet - will do that tonight.  The sweep through the targets to add the extroot USB storage package entry and change of swap-utils to =m also hasn't been built however these changes should be very low risk of causing a build failure. I don't at the moment have storage to do a full build of all targets, but will run through as I can.