### PR TITLE
x86.x64: include additional ethernet card drivers

### DIFF
--- a/targets/x86/profiles/x64/config
+++ b/targets/x86/profiles/x64/config
@@ -2655,8 +2655,8 @@ CONFIG_PACKAGE_libiwinfo-data=m
 # CONFIG_PACKAGE_ath6k-firmware is not set
 # CONFIG_PACKAGE_ath9k-htc-firmware is not set
 # CONFIG_PACKAGE_b43legacy-firmware is not set
-# CONFIG_PACKAGE_bnx2-firmware is not set
-# CONFIG_PACKAGE_bnx2x-firmware is not set
+CONFIG_PACKAGE_bnx2-firmware=m
+CONFIG_PACKAGE_bnx2x-firmware=m
 # CONFIG_PACKAGE_brcmfmac-firmware-4329-sdio is not set
 # CONFIG_PACKAGE_brcmfmac-firmware-43430-sdio-rpi-3b is not set
 # CONFIG_PACKAGE_brcmfmac-firmware-43430-sdio-rpi-zero-w is not set
@@ -3178,8 +3178,8 @@ CONFIG_PACKAGE_kmod-amd-xgbe=y
 # CONFIG_PACKAGE_kmod-atl2 is not set
 # CONFIG_PACKAGE_kmod-b44 is not set
 # CONFIG_PACKAGE_kmod-be2net is not set
-# CONFIG_PACKAGE_kmod-bnx2 is not set
-# CONFIG_PACKAGE_kmod-bnx2x is not set
+CONFIG_PACKAGE_kmod-bnx2=m
+CONFIG_PACKAGE_kmod-bnx2x=m
 # CONFIG_PACKAGE_kmod-dm9000 is not set
 # CONFIG_PACKAGE_kmod-dummy is not set
 CONFIG_PACKAGE_kmod-e100=y
@@ -3194,11 +3194,11 @@ CONFIG_PACKAGE_kmod-e1000e=y
 # CONFIG_PACKAGE_kmod-i40e is not set
 # CONFIG_PACKAGE_kmod-iavf is not set
 CONFIG_PACKAGE_kmod-ifb=y
-# CONFIG_PACKAGE_kmod-igb is not set
+CONFIG_PACKAGE_kmod-igb=y
 # CONFIG_PACKAGE_kmod-igbvf is not set
 CONFIG_PACKAGE_kmod-igc=y
 # CONFIG_PACKAGE_kmod-ipvlan is not set
-# CONFIG_PACKAGE_kmod-ixgbe is not set
+CONFIG_PACKAGE_kmod-ixgbe=y
 # CONFIG_PACKAGE_kmod-ixgbevf is not set
 CONFIG_PACKAGE_kmod-libphy=y
 # CONFIG_PACKAGE_kmod-macvlan is not set


### PR DESCRIPTION
igb (intel i350) and ixgbe are both widely used and included as x64 device packages
but need to be explicitly set; bnx2[x] is much less common but readily
available second hand.

Ref [this post](https://www.gargoyle-router.com/phpbb/viewtopic.php?p=65104#p65104), also comments on gitter.
