### PR TITLE
Update wifi settings

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/cache_basic_vars.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/cache_basic_vars.sh
@@ -95,7 +95,7 @@ print_mac80211_channels_for_wifi_dev()
 	# however, as far as I can tell there is no other way to get max txpower for each channel
 	# so... here it goes.
 	# If stuff gets FUBAR, take a look at iw output, and see if this god-awful expression still works
-	iw "$phyname" info 2>&1 | sed -e '/MHz/!d; /GI/d; /disabled/d; /radar detect /d; /Supported Channel Width/d; /STBC/d; /PPDU/d; /MCS/d; s/[:blank:]*\*[:blank:]*//g; s:[]()[]::g; s/\..*$//g' | awk ' { print "nextCh.push("$3"); nextChFreq["$3"] = \""$1"MHz\"; nextChPwr["$3"] = "$4";"   ; } ' >> "$out"
+	iw "$phyname" info 2>&1 | sed -e '/MHz/!d; /GI/d; /disabled/d; /radar detect /d; /Supported Channel Width/d; /STBC/d; /PPDU/d; /MCS/d; s/[:blank:]*\*[:blank:]*//g; s:[]()[]::g; s/\..*$//g' | grep  -v 'MHz -' | awk ' { print "nextCh.push("$3"); nextChFreq["$3"] = \""$1"MHz\"; nextChPwr["$3"] = "$4";"   ; } ' >> "$out"
 
 	echo "mac80211Channels[\"$chId\"] = nextCh ;"     >> "$out"
 	echo "mac80211ChFreqs[\"$chId\"]  = nextChFreq ;" >> "$out"
@@ -146,8 +146,10 @@ echo "var wifiDevA=\"\";" >> "$out_file"
 if [ -e /lib/wifi/broadcom.sh ] ; then
 	echo "var wirelessDriver=\"broadcom\";" >> "$out_file"
 	echo "var GwifiN = false;" >> "$out_file"
+	echo "var GwifiAX = false;" >> "$out_file"
 	echo "var AwifiN = false;" >> "$out_file"
 	echo "var AwifiAC = false;" >> "$out_file"
+	echo "var AwifiAX = false;" >> "$out_file"
 	echo "var dualBandWireless=false;" >> "$out_file"
 elif [ -e /lib/wifi/mac80211.sh ] && [ -e "/sys/class/ieee80211/phy0" ] ; then
 	echo 'var wirelessDriver="mac80211";' >> "$out_file"

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -762,7 +762,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="ap+wds">AP+WDS</option>
 							<option value="sta"><%~ Clnt %></option>
 							<option value="ap+sta"><%~ Clnt %>+AP</option>
-							<option value="adhoc">Ad Hoc</option>
 							<option value="disabled"><%~ Disabled %></option>
 						</select>
 					</span>

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -208,8 +208,9 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<label class="col-xs-5" for="bridge_hwmode" id="bridge_hwmode_label"><%~ BrOpr %>:</label>
 					<span class="col-xs-7">
 						<select id="bridge_hwmode" class="form-control" onchange="setHwMode(this)">
-							<option value="11gn">B+G+N</option>
-							<option value="11g">B+G</option>
+							<option value="11gnax">G+N+AX</option>
+							<option value="11gn">G+N</option>
+							<option value="11g">G</option>
 							<option value="11anacax">A+N+AC+AX</option>
 							<option value="11anac">A+N+AC</option>
 							<option value="11an">A+N</option>
@@ -226,6 +227,8 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="HT20">20MHz</option>
 							<option value="HT40+">40MHz (<%~ ChAbv %>)</option>
 							<option value="HT40-">40Mhz (<%~ ChBlw %>)</option>
+							<option value="HE20">20MHz</option>
+							<option value="HE40">40MHz</option>
 						</select>
 					</span>
 				</div>
@@ -328,7 +331,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="11">11</option>
 							<option value="12">12</option>
 							<option value="13">13</option>
-							<option value="14">14</option>
 						</select>
 					</span>
 				</div>
@@ -771,8 +773,9 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<span class="col-xs-7">
 						<select id="wifi_hwmode" class="form-control" onchange="setHwMode(this)">
 							<option value="disabled">Disabled</option>
-							<option value="11gn">B+G+N</option>
-							<option value="11g">B+G</option>
+							<option value="11gnax">G+N+AX</option>
+							<option value="11gn">G+N</option>
+							<option value="11g">G</option>
 						</select>
 					</span>
 				</div>
@@ -784,6 +787,8 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="HT20">20MHz</option>
 							<option value="HT40+">40MHz (<%~ ChAbv %>)</option>
 							<option value="HT40-">40MHz (<%~ ChBlw %>)</option>
+							<option value="HE20">20MHz</option>
+							<option value="HE40">40MHz</option>
 						</select>
 					</span>
 				</div>
@@ -928,7 +933,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="11">11</option>
 							<option value="12">12</option>
 							<option value="13">13</option>
-							<option value="14">14</option>
 						</select>
 					</span>
 				</div>
@@ -1011,7 +1015,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="11">11</option>
 							<option value="12">12</option>
 							<option value="13">13</option>
-							<option value="14">14</option>
 						</select>
 					</span>
 				</div>

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -361,7 +361,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<span class="col-xs-7">
 						<select id="bridge_encryption" class="form-control" onchange="setBridgeVisibility(); proofreadPass('bridge_pass', this)">
 							<option value="none"><%~ None %></option>
-							<option value="sae-mixed">WPA3/WPA2 SAE/PSK</option>
 							<option value="sae">WPA3 SAE</option>
 							<option value="psk2">WPA2 PSK</option>
 							<option value="psk">WPA PSK</option>
@@ -944,8 +943,12 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<span class="col-xs-7">
 						<select class="form-control" id="wifi_encryption2" onchange="setWifiVisibility(); proofreadPass('wifi_pass2', this)">
 							<option value="none"><%~ None %></option>
+							<option value="sae-mixed">WPA3/WPA2 SAE/PSK</option>
+							<option value="sae">WPA3 SAE</option>
 							<option value="psk2">WPA2 PSK</option>
 							<option value="psk">WPA PSK</option>
+							<option value="owe">OWE</option>
+							<option value="wpa2">WPA2 RADIUS</option>
 						</select>
 					</span>
 				</div>
@@ -1153,8 +1156,11 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						<span class="col-xs-7">
 							<select class="form-control" id="wifi_guest_encryption1" onchange="setWifiVisibility(); proofreadPass('wifi_guest_pass1', this)">
 								<option value="none"><%~ None %></option>
+								<option value="sae-mixed">WPA3/WPA2 SAE/PSK</option>
+								<option value="sae">WPA3 SAE</option>
 								<option value="psk2">WPA2 PSK</option>
 								<option value="psk">WPA PSK</option>
+								<option value="owe">OWE</option>
 							</select>
 						</span>
 					</div>

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -365,7 +365,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="sae">WPA3 SAE</option>
 							<option value="psk2">WPA2 PSK</option>
 							<option value="psk">WPA PSK</option>
-							<option value="wep">WEP</option>
 							<option value="owe">OWE</option>
 						</select>
 					</span>
@@ -382,13 +381,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						<input type="password" id="bridge_pass" class="form-control" size="20" oninput="proofreadPass(this, 'bridge_encryption')" autocomplete="new-password"/>
 						<input type="checkbox" id="show_bridge_pass" onclick="togglePass('bridge_pass')" autocomplete="off"/>
 						<label for="show_bridge_pass" id="show_bridge_pass_label"><%~ rvel %></label>
-					</span>
-				</div>
-
-				<div id="bridge_wep_container" class="row form-group">
-					<label class="col-xs-5" for="bridge_wep" id="bridge_wep_label" ><%~ HexK %>:</label>
-					<span class="col-xs-7">
-						<input type="text" id="bridge_wep" class="form-control" size="30" maxLength="26" oninput="proofreadWep(this)"/>
 					</span>
 				</div>
 
@@ -954,7 +946,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="none"><%~ None %></option>
 							<option value="psk2">WPA2 PSK</option>
 							<option value="psk">WPA PSK</option>
-							<option value="wep">WEP</option>
 						</select>
 					</span>
 				</div>
@@ -970,13 +961,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						<input type="password" id="wifi_pass2" class="form-control" size="20" oninput="proofreadPass(this, 'wifi_encryption2')" autocomplete="new-password"/>&nbsp;&nbsp;
 						<input type="checkbox" id="show_pass2" onclick="togglePass('wifi_pass2')" autocomplete="off"/>
 						<label for="show_pass2" id="show_pass2_label"><%~ rvel %></label><br/>
-					</span>
-				</div>
-
-				<div id="wifi_wep2_container" class="row indent">
-					<label class="col-xs-5" for="wifi_wep2" id="wifi_wep2_label"><%~ HexK %>:</label>
-					<span class="col-xs-7">
-						<input type="text" id="wifi_wep2" class="form-control" size="30" maxLength="26" oninput="proofreadWep(this)"/>
 					</span>
 				</div>
 
@@ -1048,7 +1032,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<option value="sae">WPA3 SAE</option>
 							<option value="psk2">WPA2 PSK</option>
 							<option value="psk">WPA PSK</option>
-							<option value="wep">WEP</option>
 							<option value="owe">OWE</option>
 							<option value="wpa">WPA RADIUS</option>
 							<option value="wpa2">WPA2 RADIUS</option>
@@ -1062,17 +1045,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 						<input type="password" id="wifi_pass1" class="form-control" size="20" oninput="proofreadPass(this, 'wifi_encryption1')" autocomplete="new-password"/>&nbsp;&nbsp;
 						<input type="checkbox" id="show_pass1" onclick="togglePass('wifi_pass1')" autocomplete="off"/>
 						<label for="show_pass1" id="show_pass1_label"><%~ rvel %></label><br/>
-					</span>
-				</div>
-
-				<div id="wifi_wep1_container" class="row indent">
-					<label class="col-xs-5" for="wifi_wep1" id="wifi_wep1_label"><%~ HexK %>:</label>
-					<span class="col-xs-7" >
-						<input type="text" id="wifi_wep1" class="form-control" size="30" maxLength="26" oninput="proofreadWep(this)"/>
-						<div class="second_row_right_column">	
-							<button class="btn btn-default" id="wep1gen40" onclick="setToWepKey('wifi_wep1',10)"><%~ Rndm %> 40/64 Bit WEP Key</button>
-							<button class="btn btn-default" id="wep1gen104" onclick="setToWepKey('wifi_wep1',26)"><%~ Rndm %> 104/128 Bit WEP Key</button>
-						</div>
 					</span>
 				</div>
 
@@ -1183,7 +1155,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 								<option value="none"><%~ None %></option>
 								<option value="psk2">WPA2 PSK</option>
 								<option value="psk">WPA PSK</option>
-								<option value="wep">WEP</option>
 							</select>
 						</span>
 					</div>
@@ -1194,17 +1165,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 							<input type="password" id="wifi_guest_pass1" class="form-control" size="20" oninput="proofreadPass(this, 'wifi_guest_encryption1')" autocomplete="new-password"/>&nbsp;&nbsp;
 							<input type="checkbox" id="show_guest_pass1" onclick="togglePass('wifi_guest_pass1')" autocomplete="off"/>
 							<label for="show_guest_pass1" id="show_guest_pass1_label"><%~ rvel %></label><br/>
-						</span>
-					</div>
-
-					<div id="wifi_guest_wep1_container" class="row indent">
-						<label class="col-xs-5" for="wifi_guest_wep1" id="wifi_guest_wep1_label"><%~ HexK %>:</label>
-						<span class="col-xs-7">
-							<input type="text" id="wifi_guest_wep1" class="form-control" size="30" maxLength="26" oninput="proofreadWep(this)"/>
-							<div class="second_row_right_column form-group">
-								<button class="btn btn-default" id="guestwep1gen40" onclick="setToWepKey('wifi_guest_wep1',10)"><%~ Rndm %> 40/64 Bit WEP Key</button>
-								<button class="btn btn-default" id="guestwep1gen104" onclick="setToWepKey('wifi_guest_wep1',26)"><%~ Rndm %> 104/128 Bit WEP Key</button>
-							</div>
 						</span>
 					</div>
 

--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -943,7 +943,6 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					<span class="col-xs-7">
 						<select class="form-control" id="wifi_encryption2" onchange="setWifiVisibility(); proofreadPass('wifi_pass2', this)">
 							<option value="none"><%~ None %></option>
-							<option value="sae-mixed">WPA3/WPA2 SAE/PSK</option>
 							<option value="sae">WPA3 SAE</option>
 							<option value="psk2">WPA2 PSK</option>
 							<option value="psk">WPA PSK</option>

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -1322,12 +1322,11 @@ function setGlobalVisibility()
 	else
 	{
 		currentMode=getSelectedValue('wifi_mode');
-		setAllowableSelections('wifi_mode', ['ap', 'ap+wds', 'adhoc', 'disabled'], [basicS.AcPt+' (AP)', 'AP+WDS', 'Ad Hoc', UI.Disabled]);
+		setAllowableSelections('wifi_mode', ['ap', 'ap+wds', 'disabled'], [basicS.AcPt+' (AP)', 'AP+WDS', UI.Disabled]);
 		if(wirelessDriver == "")
 		{
 			removeOptionFromSelectElementByValue("wifi_mode", "ap", document);
 			removeOptionFromSelectElementByValue("wifi_mode", "ap+wds", document);
-			removeOptionFromSelectElementByValue("wifi_mode", "adhoc", document);
 		}
 		if(currentMode == 'ap+sta' || currentMode == 'sta')
 		{
@@ -1490,40 +1489,25 @@ function setWifiVisibility()
 		setAllowableSelections('wifi_encryption1', values, names);
 	}
 
-	if(wifiMode == 'adhoc')
+	document.getElementById("wifi_ssid2_label").firstChild.data = basicS.Join+":";
+	var values = ['none', 'psk2', 'psk'];
+	var names = [basicS.None, 'WPA2 PSK', 'WPA PSK'];
+	if(wpad_wep)
 	{
-		var values = ['none'];
-		var names = [basicS.None];
-		if(wpad_wep)
-		{
-			values.push('wep');
-			names.push('WEP');
-		}
-		setAllowableSelections('wifi_encryption2', values, names);
-		document.getElementById("wifi_ssid2_label").firstChild.data = "SSID:";
+		values.push('wep');
+		names.push('WEP');
 	}
-	else
+	if(wpad_sae)
 	{
-		document.getElementById("wifi_ssid2_label").firstChild.data = basicS.Join+":";
-		var values = ['none', 'psk2', 'psk'];
-		var names = [basicS.None, 'WPA2 PSK', 'WPA PSK'];
-		if(wpad_wep)
-		{
-			values.push('wep');
-			names.push('WEP');
-		}
-		if(wpad_sae)
-		{
-			values.splice(values.indexOf('psk2'),0,'sae-mixed','sae');
-			names.splice(names.indexOf('WPA2 PSK'),0,'WPA3/WPA2 SAE/PSK','WPA3 SAE');
-		}
-		if(wpad_owe)
-		{
-			values.push('owe');
-			names.push('OWE');
-		}
-		setAllowableSelections('wifi_encryption2', values, names);
+		values.splice(values.indexOf('psk2'),0,'sae-mixed','sae');
+		names.splice(names.indexOf('WPA2 PSK'),0,'WPA3/WPA2 SAE/PSK','WPA3 SAE');
 	}
+	if(wpad_owe)
+	{
+		values.push('owe');
+		names.push('OWE');
+	}
+	setAllowableSelections('wifi_encryption2', values, names);
 
 	var Gwifi_vals = ['disabled'];
 	var Gwifi_names = [UI.Disabled];
@@ -1656,7 +1640,6 @@ function setWifiVisibility()
 	wifiVisibilities['ap+wds']   = [1,1,gw,g,ae,aw,a,1,mf,   1,0,1,0,0,0,p1,k1,1,1,1,p1,w1,r1,r1,   gns,gng,gna,gp1,gn,gn,gn,gp1,gw1,gns,   b,b,  0,0,0,0,0,0,0,0,0,0,0,0 ];
 	wifiVisibilities['sta']      = [1,1,gw,g,ae,aw,a,1,mf,   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,1,g,0,a,0,1,0,p2,w2];
 	wifiVisibilities['ap+sta']   = [1,1,gw,g,ae,aw,a,1,mf,   1,a,1,0,a,as2,p1,k1,1,1,1,p1,w1,r1,r1,   gns,gng,gna,gp1,gn,gn,gn,gp1,gw1,gns,   0,0,  1,0,0,1,g,0,a,a,1,0,p2,w2];
-	wifiVisibilities['adhoc']    = [1,1,gw,g,ae,aw,a,1,mf,   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,1,g,0,a,0,1,0,p2,w2];
 	wifiVisibilities['disabled'] = [0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,0,0,0,0,0,0,0,0,0 ];
 
 	var wifiVisibility = wifiVisibilities[ wifiMode ];

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -1527,13 +1527,18 @@ function setWifiVisibility()
 
 	var Gwifi_vals = ['disabled'];
 	var Gwifi_names = [UI.Disabled];
+	if(GwifiAX)
+	{
+		Gwifi_vals.push('11gnax');
+		Gwifi_names.push('G+N+AX');
+	}
 	if(GwifiN)
 	{
 		Gwifi_vals.push('11gn');
-		Gwifi_names.push('B+G+N');
+		Gwifi_names.push('G+N');
 	}
 	Gwifi_vals.push('11g');
-	Gwifi_names.push('B+G');
+	Gwifi_names.push('G');
 	setAllowableSelections('wifi_hwmode', Gwifi_vals, Gwifi_names);
 
 	var Awifi_vals = ['disabled'];
@@ -1752,12 +1757,17 @@ function setBridgeVisibility()
 	var allowedbridgemodes2 = [];
 	if(dualBandWireless)
 	{
+		if(GwifiAX)
+		{
+			allowedbridgemodes.push('G+N+AX')
+			allowedbridgemodes2.push('11gnax');
+		}
 		if(GwifiN)
 		{
-			allowedbridgemodes.push('B+G+N')
+			allowedbridgemodes.push('G+N')
 			allowedbridgemodes2.push('11gn');
 		}
-		allowedbridgemodes.push('B+G');
+		allowedbridgemodes.push('G');
 		allowedbridgemodes2.push('11g');
 		if(AwifiAX)
 		{
@@ -1774,7 +1784,6 @@ function setBridgeVisibility()
 			allowedbridgemodes.push('A+N')
 			allowedbridgemodes2.push('11an');
 		}
-
 		allowedbridgemodes.push('A');
 		allowedbridgemodes2.push('11a');
 	}
@@ -1782,12 +1791,11 @@ function setBridgeVisibility()
 	{
 		if(GwifiN)
 		{
-			allowedbridgemodes.push('B+G+N')
+			allowedbridgemodes.push('G+N')
 			allowedbridgemodes2.push('11gn');
 		}
-		allowedbridgemodes.push('B+G');
+		allowedbridgemodes.push('G');
 		allowedbridgemodes2.push('11g');
-
 	}
 
 
@@ -2272,11 +2280,25 @@ function resetData()
 	}
 
 	//wireless N + AC + AX variables
-	if( GwifiN || AwifiN || AwifiAC || AwifiAX )
+	if( GwifiN || GwifiAX || AwifiN || AwifiAC || AwifiAX )
 	{
-		var hwGmode = uciOriginal.get("wireless", wifiDevG, "band");
+		var Gwifi_vals = ['disabled'];
+		var Gwifi_names = [UI.Disabled];
+		if (GwifiAX)
+		{
+			Gwifi_vals.push('11gnax');
+			Gwifi_names.push('G+N+AX');
+		}
+		if (GwifiN)
+		{
+			Gwifi_vals.push('11gn');
+			Gwifi_names.push('G+N');
+		}
+		Gwifi_vals.push('11g');
+		Gwifi_names.push('G');
+		setAllowableSelections('wifi_hwmode', Gwifi_vals, Gwifi_names);
+		hwGmode = uciOriginal.get("wireless", wifiDevG, "band");
 		hwGmode = hwGmode == "" || hwGmode == "2g" ? "11g" : hwGmode;
-		setAllowableSelections( "wifi_hwmode", [ 'disabled', '11gn', '11g' ], [UI.Disabled, 'B+G+N', 'B+G' ] );
 		setSelectedValue("wifi_hwmode", hwGmode);
 		if(dualBandWireless)
 		{
@@ -2335,6 +2357,11 @@ function resetData()
 		{
 			setSelectedValue("wifi_hwmode", "11gn");
 			setSelectedValue("bridge_hwmode", "11gn");
+			if(/HE/i.test(htGMode))
+			{
+				setSelectedValue("wifi_hwmode", "11gnax");
+				setSelectedValue("bridge_hwmode", "11gnax");
+			}
 		}
 		else if(((htGMode == "") || (htGMode == "NONE")) && (otherdev == "" || otherdev == wifiDevG))
 		{
@@ -2832,7 +2859,7 @@ function scanWifi(ssidField)
 					var qual = scannedSsids[3][ssidIndex];
 
 					enc = enc =="none" ? "Open" :  enc.replace(/psk/g, "wpa").toUpperCase();
-					if((GwifiN || AwifiN || AwifiAC || AwifiAX) && dualBandWireless)
+					if((GwifiN || GwifiAX || AwifiN || AwifiAC || AwifiAX) && dualBandWireless)
 					{
 						var ghz = scannedSsids[4][ssidIndex] == "A" ? "5GHz" : "2.4GHz";
 						ssidDisplay.push( ssid + " (" + enc + ", " + qual +"% Signal, " + ghz +  ")");
@@ -2919,15 +2946,20 @@ function setSsidVisibility(selectId)
 			var chan = scannedSsids[2][scannedIndex];
 			var band = scannedSsids[4][scannedIndex];
 
-			if(GwifiN)
+			if(GwifiAX)
+			{
+				var modes = ['11gnax','11gn', '11g'];
+				var mnames = ['G+N+AX','G+N', 'G'];
+			}
+			else if(GwifiN)
 			{
 				var modes = ['11gn','11g'];
-				var mnames = ['B+G+N','B+G'];
+				var mnames = ['G+N','G'];
 			}
 			else
 			{
 				var modes = ['11g'];
-				var mnames = ['B+G'];
+				var mnames = ['G'];
 			}
 			if(band == "A")
 			{
@@ -3068,12 +3100,17 @@ function setSsidVisibility(selectId)
 		var allowedbridgemodes2 = [];
 		if(dualBandWireless)
 		{
+			if(GwifiAX)
+			{
+				allowedbridgemodes.push('G+N+AX')
+				allowedbridgemodes2.push('11gnax');
+			}
 			if(GwifiN)
 			{
-				allowedbridgemodes.push('B+G+N')
+				allowedbridgemodes.push('G+N')
 				allowedbridgemodes2.push('11gn');
 			}
-			allowedbridgemodes.push('B+G');
+			allowedbridgemodes.push('G');
 			allowedbridgemodes2.push('11g');
 			if(AwifiAX)
 			{
@@ -3097,10 +3134,10 @@ function setSsidVisibility(selectId)
 		{
 			if(GwifiN)
 			{
-				allowedbridgemodes.push('B+G+N')
+				allowedbridgemodes.push('G+N')
 				allowedbridgemodes2.push('11gn');
 			}
-			allowedbridgemodes.push('B+G');
+			allowedbridgemodes.push('G');
 			allowedbridgemodes2.push('11g');
 		}
 		setAllowableSelections("bridge_hwmode",allowedbridgemodes2,allowedbridgemodes)
@@ -3487,6 +3524,7 @@ function setHwMode(selectCtl)
 					if(HWMODE == "2g")
 					{
 						hwGmode = uciOriginal.get("wireless", secdev, "htmode").match(/HT/) ? "11gn" : "11g";
+						hwGmode = uciOriginal.get("wireless", secdev, "htmode").match(/HE/) ? "11gnax" : hwGmode;
 						for(x = 0; x<document.getElementById("wifi_hwmode").length;x++)
 						{
 							if(hwGmode == document.getElementById("wifi_hwmode")[x].value)
@@ -3587,9 +3625,13 @@ function setHwMode(selectCtl)
 	{
 		setAllowableSelections('wifi_channel_width', ['NONE'], ['20MHz']);
 	}
-	else
+	else if (hwGmode == "11gn")
 	{
 		setAllowableSelections('wifi_channel_width', ['HT20', 'HT40+', 'HT40-'], ['20MHz', '40MHz ' + basicS.ChAbv, '40MHz ' + basicS.ChBlw]);
+	}
+	else if (hwGmode == "11gnax")
+	{
+		setAllowableSelections('wifi_channel_width', ['HE20', 'HE40'], ['20MHz', '40MHz']);
 	}
 
 	if(hwAmode == "disabled")
@@ -3649,6 +3691,10 @@ function setHwMode(selectCtl)
 	else if(bridgehwmode == "11gn")
 	{
 		setAllowableSelections('bridge_channel_width', ['HT20', 'HT40+', 'HT40-'], ['20MHz', '40MHz ' + basicS.ChAbv, '40MHz ' + basicS.ChBlw]);
+	}
+	else if(bridgehwmode == "11gnax")
+	{
+		setAllowableSelections('bridge_channel_width', ['HE20', 'HE40'], ['20MHz', '40MHz']);
 	}
 	else if(bridgehwmode == "11a")
 	{
@@ -3711,7 +3757,7 @@ function setHwMode(selectCtl)
 			setChannel(document.getElementById("wifi_channel1_seg2_5ghz"), "A")
 		}
 	}
-	var displayWidth = GwifiN;
+	var displayWidth = (GwifiN || GwifiAX);
 	if(!displayWidth)
 	{
 		setSelectedValue("wifi_channel_width", "NONE");
@@ -3725,7 +3771,7 @@ function setHwMode(selectCtl)
 		setChannelWidth(document.getElementById("wifi_channel_width_5ghz"), "A")
 	}
 
-	displayWidth = (GwifiN || AwifiN || AwifiAC || AwifiAX);
+	displayWidth = (GwifiN || GwifiAX || AwifiN || AwifiAC || AwifiAX);
 
 	var containers = [
 				"wifi_channel_width_container",
@@ -3867,6 +3913,7 @@ function setHwMode(selectCtl)
 
 		//atempt to set to higher bandwidth values if they are available as these should be the defautls
 		setSelectedValue('wifi_hwmode',"11gn");
+		setSelectedValue('wifi_hwmode',"11gnax");
 		setSelectedValue('wifi_hwmode_5ghz',"11an");
 		setSelectedValue('wifi_hwmode_5ghz',"11anac");
 		setSelectedValue('wifi_hwmode_5ghz',"11anacax");

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -377,7 +377,7 @@ function saveChanges()
 					{
 						//add one section for each bssid
 						var encryption = getSelectedValue("wifi_encryption1");
-						var key = encryption == "none" ? "" : ( encryption == "wep" ? document.getElementById("wifi_wep1").value : document.getElementById("wifi_pass1").value );
+						var key = encryption == "none" ? "" : document.getElementById("wifi_pass1").value;
 						var ssid = document.getElementById("wifi_ssid1").value;
 						var wIndex=0;
 						for(wIndex=0; wIndex < wdsList.length; wIndex++)
@@ -550,14 +550,14 @@ function saveChanges()
 			inputIds = [
 					'wan_protocol', 'wan6_protocol', 'wan_pppoe_user', 'wan_pppoe_pass', 'wan_pppoe_max_idle', ppoeReconnectIds, 'wan_static_ip', 'wan_static_mask', 'wan_static_gateway', 'wan_static_ip6', 'wan_static_gateway6', 'wan_mac', 'wan_mtu', 
 					'lan_ip', 'lan_mask', 'lan_gateway', 'lan_ip6assign', 'lan_ip6hint', 'lan_ip6ifaceid', 'lan_ip6gw',
-					wifiSsidId, 'wifi_ft', 'wifi_hidden', 'wifi_isolate', 'wifi_encryption1', 'wifi_pass1', 'wifi_wep1', wifiGuestSsidId, 'wifi_guest_ft', 'wifi_guest_hidden', 'wifi_guest_isolate', 'wifi_guest_encryption1', 'wifi_guest_pass1', 'wifi_guest_wep1', 'wifi_server1', 'wifi_port1', 'wifi_pass2', 'wifi_wep2', 
+					wifiSsidId, 'wifi_ft', 'wifi_hidden', 'wifi_isolate', 'wifi_encryption1', 'wifi_pass1', wifiGuestSsidId, 'wifi_guest_ft', 'wifi_guest_hidden', 'wifi_guest_isolate', 'wifi_guest_encryption1', 'wifi_guest_pass1', 'wifi_server1', 'wifi_port1', 'wifi_pass2',
 					'wan_3g_device', 'wan_3g_user', 'wan_3g_pass', 'wan_3g_apn', 'wan_3g_pincode', 'wan_3g_service', 'wan_3g_isp'
 					];
 
 			options = [
 					'proto', 'proto', 'username', 'password', 'demand', 'keepalive', 'ipaddr', 'netmask', 'gateway', 'ip6addr', 'ip6gw', 'macaddr', 'mtu', 
 					'ipaddr', 'netmask', 'gateway', 'ip6assign', 'ip6hint', 'ip6ifaceid', 'ip6gw',
-					'ssid', 'ieee80211r', 'hidden', 'isolate', 'encryption', 'key', 'key', 'ssid', 'ieee80211r', 'hidden', 'isolate', 'encryption', 'key', 'key', 'auth_server', 'auth_port', 'key', 'key',
+					'ssid', 'ieee80211r', 'hidden', 'isolate', 'encryption', 'key', 'ssid', 'ieee80211r', 'hidden', 'isolate', 'encryption', 'key', 'auth_server', 'auth_port', 'key',
 					'device', 'username', 'password', 'apn', 'pincode', 'service', 'mobile_isp'
 					];
 
@@ -568,8 +568,8 @@ function saveChanges()
 			setFunctions = [
 					sv,sv,sv,sv,svm,svcat,sv,sv,sv,svm,svm,/*svcond*/svm,svcond,	// 0-12
 					sv,sv,sv,sv,sv,sv,svm,	// 13-19
-					sv,svcond,svcond,svcond,sv,sv,sv,sv,svcond,svcond,svcond,sv,sv,sv,sv,sv,sv,sv,	// 20-37
-					sv,sv,sv,sv,sv,sv,sv	// 38-44
+					sv,svcond,svcond,svcond,sv,sv,sv,svcond,svcond,svcond,sv,sv,sv,sv,sv,	// 20-34
+					sv,sv,sv,sv,sv,sv,sv	// 35-41
 					];
 			var f=false;
 			var t=true;
@@ -598,13 +598,13 @@ function saveChanges()
 			additionalParams = [
 						f,f,f,f, demandParams,f,f,f,f,ip6Params,ip6Params,macParams,mtuParams,	// 0-12
 						f,f,f,f,f,f,ip6Params,	// 13-19
-						f,ftParams,hiddenParams,isolateParams,f,f,f,f,guestFtParams,guestHiddenParams,guestIsolateParams,f,f,f,f,f,f,f,	// 20-37
-						f,f,f,f,f,f,f	// 38-44
+						f,ftParams,hiddenParams,isolateParams,f,f,f,guestFtParams,guestHiddenParams,guestIsolateParams,f,f,f,f,f,	// 20-34
+						f,f,f,f,f,f,f	// 35-41
 					];
 
 			pppoeReconnectVisibilityIds = ['wan_pppoe_reconnect_pings_container', 'wan_pppoe_interval_container'];
 			multipleVisibilityIds= [pppoeReconnectVisibilityIds];
-			wirelessSections=[apcfg, apcfg, apcfg, apcfg, apcfg, apcfg, apcfg, apgncfg, apgncfg, apgncfg, apgncfg, apgncfg, apgncfg, apgncfg, apcfg, apcfg, othercfg, othercfg];
+			wirelessSections=[apcfg, apcfg, apcfg, apcfg, apcfg, apcfg, apgncfg, apgncfg, apgncfg, apgncfg, apgncfg, apgncfg, apcfg, apcfg, othercfg];
 			visibilityIds = [];
 			pkgs = [];
 			sections = [];
@@ -612,8 +612,8 @@ function saveChanges()
 			inputIds = [
 					'wan_protocol', 'wan6_protocol', 'wan_pppoe_user', 'wan_pppoe_pass', 'wan_pppoe_max_idle', ppoeReconnectIds, 'wan_static_ip', 'wan_static_mask', 'wan_static_gateway', 'wan_static_ip6', 'wan_static_gateway6', 'wan_mac', 'wan_mtu',	// 0-12
 					'lan_ip', 'lan_mask', 'lan_gateway', 'lan_ip6assign', 'lan_ip6hint', 'lan_ip6ifaceid', 'lan_ip6gw',	// 13-19
-					wifiSsidId, 'wifi_ft', 'wifi_hidden', 'wifi_isolate', 'wifi_encryption1', 'wifi_pass1', 'wifi_wep1', wifiGuestSsidId, 'wifi_guest_ft', 'wifi_guest_hidden', 'wifi_guest_isolate', 'wifi_guest_encryption1', 'wifi_guest_pass1', 'wifi_guest_wep1', 'wifi_server1', 'wifi_port1', 'wifi_pass2', 'wifi_wep2',	// 20-37
-					'wan_3g_device', 'wan_3g_user', 'wan_3g_pass', 'wan_3g_apn', 'wan_3g_pincode', 'wan_3g_service', 'wan_3g_isp'	// 38-44
+					wifiSsidId, 'wifi_ft', 'wifi_hidden', 'wifi_isolate', 'wifi_encryption1', 'wifi_pass1', wifiGuestSsidId, 'wifi_guest_ft', 'wifi_guest_hidden', 'wifi_guest_isolate', 'wifi_guest_encryption1', 'wifi_guest_pass1', 'wifi_server1', 'wifi_port1', 'wifi_pass2',	// 20-34
+					'wan_3g_device', 'wan_3g_user', 'wan_3g_pass', 'wan_3g_apn', 'wan_3g_pincode', 'wan_3g_service', 'wan_3g_isp'	// 35-41
 					];
 			for(idIndex=0; idIndex < inputIds.length; idIndex++)
 			{
@@ -638,11 +638,11 @@ function saveChanges()
 					sections.push(wanMacLoc);
 					//uci.remove('network', wanMacLoc, options[idIndex]);
 				}
-				else if(idIndex < 13 || idIndex > 37)
+				else if(idIndex < 13 || idIndex > 34)
 				{
 					pkgs.push('network');
 					sections.push('wan');
-					if(idIndex != 38)
+					if(idIndex != 35)
 					{
 						uci.remove('network', 'wan', options[idIndex]);
 					}
@@ -894,7 +894,7 @@ function saveChanges()
 				ssid = scannedSsids[0][ parseInt(getSelectedValue("bridge_list_ssid")) ];
 				encryption  = scannedSsids[1][ parseInt(getSelectedValue("bridge_list_ssid")) ];
 			}
-			var key = encryption == "none" ? "" : ( encryption == "wep" ? document.getElementById("bridge_wep").value : document.getElementById("bridge_pass").value );
+			var key = encryption == "none" ? "" : document.getElementById("bridge_pass").value;
 
 			if( getSelectedValue("bridge_mode") == "client_bridge")
 			{
@@ -1172,12 +1172,6 @@ function generateHexKey(length)
 	return key;
 }
 
-function setToWepKey(id, length)
-{
-	document.getElementById(id).value = generateHexKey(length);
-	proofreadWep(document.getElementById(id));
-}
-
 function setToFtKey(id)
 {
 	document.getElementById(id).value = generateHexKey(64);
@@ -1192,7 +1186,6 @@ function proofreadAll()
 	var vnm = validateNetMask;
 	var vm = validateMac;
 	var vn = validateNumeric;
-	var vw = validateWep;
 	var vid = validateSsid;
 	var vp = function(text){ return validatePass(text, 'wifi_encryption1'); }
 	var vpg = function(text){ return validatePass(text, 'wifi_guest_encryption1'); }
@@ -1224,14 +1217,14 @@ function proofreadAll()
 		var inputIds = [
 				'wan_pppoe_user', 'wan_pppoe_pass', 'wan_pppoe_max_idle', 'wan_pppoe_reconnect_pings', 'wan_pppoe_interval', 'wan_static_ip', 'wan_static_mask', 'wan_static_gateway', 'wan_mac', 'wan_mtu', 'wan_static_ip6', 'wan_static_gateway6',
 				'lan_ip', 'lan_mask', 'lan_gateway', 'lan_ip6assign', 'lan_ip6hint', 'lan_ip6ifaceid', 'lan_ip6gw',
-				'wifi_txpower', 'wifi_txpower_5ghz', 'wifi_ssid1', 'wifi_pass1', 'wifi_wep1', 'wifi_ft_key', 'wifi_guest_pass1', 'wifi_guest_wep1', 'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_pass2', 'wifi_wep2', 
+				'wifi_txpower', 'wifi_txpower_5ghz', 'wifi_ssid1', 'wifi_pass1', 'wifi_ft_key', 'wifi_guest_pass1', 'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_pass2',
 				'wan_3g_device', 'wan_3g_apn'
 		];
 
 		var functions= [
 				vlr1, vlr1, vn, vn, vn, vip, vnm, vip, vm, vn, vip6fr, vip6,
 				vip, vnm, vip, vip6m, vip6h, vip6if, vip6,
-				vtp, vtpa, vid, vp, vw, vfk, vpg, vw, vip, vnp, vid, vp2, vw,
+				vtp, vtpa, vid, vp, vfk, vpg, vip, vnp, vid, vp2,
 				vlr1, vlr1
 		];
 
@@ -1269,8 +1262,8 @@ function proofreadAll()
 	}
 	else
 	{
-		var inputIds = ['bridge_ip', 'bridge_mask', 'bridge_gateway', 'bridge_txpower', 'bridge_ssid', 'bridge_pass', 'bridge_wep', 'bridge_broadcast_ssid'];
-		var functions = [vip, vnm, vip, vtp, vid, vpb, vw, vid];
+		var inputIds = ['bridge_ip', 'bridge_mask', 'bridge_gateway', 'bridge_txpower', 'bridge_ssid', 'bridge_pass', 'bridge_broadcast_ssid'];
+		var functions = [vip, vnm, vip, vtp, vid, vpb, vid];
 		var returnCodes=[];
 		var visibilityIds=[];
 		var labelIds=[];
@@ -1438,11 +1431,6 @@ function setWifiVisibility()
 	{
 		var values = ['none', 'psk2', 'psk'];
 		var names = [basicS.None, 'WPA2 PSK', 'WPA PSK'];
-		if(wpad_wep)
-		{
-			values.push('wep');
-			names.push('WEP');
-		}
 		if(wpad_sae)
 		{
 			values.splice(values.indexOf('psk2'),0,'sae-mixed','sae');
@@ -1459,11 +1447,6 @@ function setWifiVisibility()
 	{
 		var values = ['none', 'psk2', 'psk'];
 		var names = [basicS.None, 'WPA2 PSK', 'WPA PSK'];
-		if(wpad_wep)
-		{
-			values.push('wep');
-			names.push('WEP');
-		}
 		if(wpad_sae)
 		{
 			values.splice(values.indexOf('psk2'),0,'sae-mixed','sae');
@@ -1492,11 +1475,6 @@ function setWifiVisibility()
 	document.getElementById("wifi_ssid2_label").firstChild.data = basicS.Join+":";
 	var values = ['none', 'psk2', 'psk'];
 	var names = [basicS.None, 'WPA2 PSK', 'WPA PSK'];
-	if(wpad_wep)
-	{
-		values.push('wep');
-		names.push('WEP');
-	}
 	if(wpad_sae)
 	{
 		values.splice(values.indexOf('psk2'),0,'sae-mixed','sae');
@@ -1573,7 +1551,6 @@ function setWifiVisibility()
 			'wifi_isolate_container',
 			'wifi_encryption1_container',
 			'wifi_pass1_container',
-			'wifi_wep1_container',
 			'wifi_server1_container',
 			'wifi_port1_container',
 
@@ -1586,7 +1563,6 @@ function setWifiVisibility()
 			'wifi_guest_isolate_container',
 			'wifi_guest_encryption1_container',
 			'wifi_guest_pass1_container',
-			'wifi_guest_wep1_container',
 			'wifi_guest_mode_container',
 
 
@@ -1605,7 +1581,6 @@ function setWifiVisibility()
 			'wifi_encryption2_container',
 			'wifi_fixed_encryption2_container',
 			'wifi_pass2_container',
-			'wifi_wep2_container'
 			];
 
 	var ae = wifiDevA != "" ? 1 : 0; //A band exists
@@ -1617,8 +1592,7 @@ function setWifiVisibility()
 
 	var mf = getSelectedValue("mac_filter_enabled") == "enabled" ? 1 : 0;
 	var e1 = document.getElementById('wifi_encryption1').value;
-	var p1 = (e1 != 'none' && e1 != 'wep' && e1 != 'owe') ? 1 : 0;
-	var w1 = (e1 == 'wep') ? 1 : 0;
+	var p1 = (e1 != 'none' && e1 != 'owe') ? 1 : 0;
 	var r1 = (e1 == 'wpa' || e1 == 'wpa2') ? 1 : 0;
 	var k1 = r1 && (getSelectedValue('wifi_ft') == "enabled" ? 1 : 0);
 	var gns = (wirelessDriver == "mac80211" && !isb43); //drivers that support guest networks
@@ -1626,21 +1600,19 @@ function setWifiVisibility()
 	var gng = getSelectedValue("wifi_guest_mode") == "24ghz" || getSelectedValue("wifi_guest_mode") == 'dual'  ? 1 : 0;
 	var gna = getSelectedValue("wifi_guest_mode") == "5ghz" || getSelectedValue("wifi_guest_mode") == 'dual' ? 1 : 0;
 	var ge1 = document.getElementById('wifi_guest_encryption1').value;
-	var gp1 = gn && (ge1 != 'none' && ge1 != 'wep') ? 1 : 0;
-	var gw1 = gn && (ge1 == 'wep') ? 1 : 0;
+	var gp1 = gn && (ge1 != 'none') ? 1 : 0;
 	var gr1 = gn && (ge1 == 'wpa' || ge1 == 'wpa2') ? 1 : 0;
 	var e2 = document.getElementById('wifi_fixed_encryption2').style.display != 'none' ? document.getElementById('wifi_fixed_encryption2').firstChild.data : getSelectedValue('wifi_encryption2');
 	var b = (GwifiN ? 0 : 1) && (AwifiN ? 0 : 1); //we shouldnt have to look for AC here
 
 	var p2 = e2.match(/sae/) || e2.match(/psk/) || e2.match(/WPA/) ? 1 : 0;
-	var w2 = e2.match(/wep/) || e2.match(/WEP/) ? 1 : 0;
 
 	var wifiVisibilities = new Array();
-	wifiVisibilities['ap']       = [1,1,gw,g,ae,aw,a,1,mf,   1,a,1,0,a,as2,p1,k1,1,1,1,p1,w1,r1,r1,   gns,gng,gna,gp1,gn,gn,gn,gp1,gw1,gns,   0,0,  0,0,0,0,0,0,0,0,0,0,0,0 ];
-	wifiVisibilities['ap+wds']   = [1,1,gw,g,ae,aw,a,1,mf,   1,0,1,0,0,0,p1,k1,1,1,1,p1,w1,r1,r1,   gns,gng,gna,gp1,gn,gn,gn,gp1,gw1,gns,   b,b,  0,0,0,0,0,0,0,0,0,0,0,0 ];
-	wifiVisibilities['sta']      = [1,1,gw,g,ae,aw,a,1,mf,   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,1,g,0,a,0,1,0,p2,w2];
-	wifiVisibilities['ap+sta']   = [1,1,gw,g,ae,aw,a,1,mf,   1,a,1,0,a,as2,p1,k1,1,1,1,p1,w1,r1,r1,   gns,gng,gna,gp1,gn,gn,gn,gp1,gw1,gns,   0,0,  1,0,0,1,g,0,a,a,1,0,p2,w2];
-	wifiVisibilities['disabled'] = [0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,0,0,0,0,0,0,0,0,0 ];
+	wifiVisibilities['ap']       = [1,1,gw,g,ae,aw,a,1,mf,   1,a,1,0,a,as2,p1,k1,1,1,1,p1,r1,r1, gns,gng,gna,gp1,gn,gn,gn,gp1,gns,   0,0,  0,0,0,0,0,0,0,0,0,0,0 ];
+	wifiVisibilities['ap+wds']   = [1,1,gw,g,ae,aw,a,1,mf,   1,0,1,0,0,0,p1,k1,1,1,1,p1,r1,r1,   gns,gng,gna,gp1,gn,gn,gn,gp1,gns,   b,b,  0,0,0,0,0,0,0,0,0,0,0 ];
+	wifiVisibilities['sta']      = [1,1,gw,g,ae,aw,a,1,mf,   0,0,0,0,0,0,0,0,0,0,0,0,0,0,        0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,1,g,0,a,0,1,0,p2];
+	wifiVisibilities['ap+sta']   = [1,1,gw,g,ae,aw,a,1,mf,   1,a,1,0,a,as2,p1,k1,1,1,1,p1,r1,r1, gns,gng,gna,gp1,gn,gn,gn,gp1,gns,   0,0,  1,0,0,1,g,0,a,a,1,0,p2];
+	wifiVisibilities['disabled'] = [0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,0,0,0,0,        0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,0,0,0,0,0,0,0,0 ];
 
 	var wifiVisibility = wifiVisibilities[ wifiMode ];
 	setVisibility(wifiIds, wifiVisibility);
@@ -1684,11 +1656,6 @@ function setBridgeVisibility()
 	{
 		var values = ['none', 'psk2', 'psk'];
 		var names = [basicS.None, 'WPA2 PSK', 'WPA PSK'];
-		if(wpad_wep)
-		{
-			values.push('wep');
-			names.push('WEP');
-		}
 		if(wpad_sae)
 		{
 			values.splice(values.indexOf('psk2'),0,'sae-mixed','sae');
@@ -1702,7 +1669,6 @@ function setBridgeVisibility()
 		setAllowableSelections('bridge_encryption', values, names);
 		var brenc = document.getElementById("bridge_fixed_encryption_container").style.display == "none" ? getSelectedValue("bridge_encryption") : document.getElementById("bridge_fixed_encryption").firstChild.data;
 		document.getElementById("bridge_pass_container").style.display = brenc.match(/sae/) || brenc.match(/psk/) || brenc.match(/WPA/) ? "block" : "none";
-		document.getElementById("bridge_wep_container").style.display  = brenc.match(/wep/) || brenc.match(/WEP/) ? "block" : "none";
 
 		var bridgeMode = getSelectedValue("bridge_mode")
 		var repeaterPossible = (bridgeMode == "client_bridge" && (!isb43)) || (bridgeMode=="wds" && wirelessDriver == "mac80211") ;
@@ -1933,8 +1899,7 @@ function resetData()
 		var encryption = uciOriginal.get("wireless", bridgeSection, "encryption");
 		encryption = encryption == "" ? "none" : encryption;
 		setSelectedValue("bridge_encryption", encryption);
-		document.getElementById("bridge_wep").value = encryption == "wep" ? uciOriginal.get("wireless", bridgeSection, "key") : "";
-		document.getElementById("bridge_pass").value = encryption != "wep" && encryption != "none" ? uciOriginal.get("wireless", bridgeSection, "key") : "";
+		document.getElementById("bridge_pass").value = encryption != "none" ? uciOriginal.get("wireless", bridgeSection, "key") : "";
 		document.getElementById("bridge_broadcast_ssid").value = repeaterSection == "" ? uciOriginal.get("wireless", bridgeSection, "ssid") : uciOriginal.get("wireless", repeaterSection, "ssid");
 
 		if(mode == "wds")
@@ -2418,7 +2383,7 @@ function resetData()
 		setSelectedValue("wifi_hwmode_5ghz", hwAmode);
 	}
 
-	var wirelessIds=['wifi_channel1', 'wifi_channel2', 'wifi_channel1_5ghz', 'wifi_channel1_seg2_5ghz', 'wifi_channel2_5ghz', 'wifi_ssid1', 'wifi_ssid1a', 'wifi_encryption1', 'wifi_pass1', 'wifi_wep1',      'wifi_guest_ssid1', 'wifi_guest_mac_g', 'wifi_guest_ssid1a', 'wifi_guest_mac_a', 'wifi_guest_encryption1', 'wifi_guest_pass1', 'wifi_guest_wep1',        'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_encryption2', 'wifi_pass2', 'wifi_wep2'];
+	var wirelessIds=['wifi_channel1', 'wifi_channel2', 'wifi_channel1_5ghz', 'wifi_channel1_seg2_5ghz', 'wifi_channel2_5ghz', 'wifi_ssid1', 'wifi_ssid1a', 'wifi_encryption1', 'wifi_pass1', 'wifi_guest_ssid1', 'wifi_guest_mac_g', 'wifi_guest_ssid1a', 'wifi_guest_mac_a', 'wifi_guest_encryption1', 'wifi_guest_pass1',        'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_encryption2', 'wifi_pass2'];
 	var wirelessPkgs= new Array();
 	var wIndex;
 	for(wIndex=0; wIndex < wirelessIds.length; wIndex++)
@@ -2428,10 +2393,10 @@ function resetData()
 	var default5ID = uciOriginal.get("wireless", apcfg, "ssid") ? uciOriginal.get("wireless", apcfg, "ssid") + " 5GHz" : "Gargoyle 5GHz";
 	var defaultGuest5ID = apgncfg && uciOriginal.get("wireless", apgncfg, "ssid") ? uciOriginal.get("wireless", apgncfg, "ssid") + " 5GHz" : "Guests 5GHz";
 
-	var wirelessSections=[wifiDevG, wifiDevG, wifiDevA, wifiDevA, wifiDevA, apgcfg, apacfg, apcfg, apcfg, apcfg,                                                                apgngcfg, apgngcfg, apgnacfg, apgnacfg, apgncfg, apgncfg, apgncfg,               apcfg, apcfg, othercfg, othercfg, othercfg, othercfg];
-	var wirelessOptions=['channel', 'channel', 'channel', 'channel2', 'channel', 'ssid', 'ssid', 'encryption', 'key', 'key',                                                    'ssid', 'macaddr', 'ssid', 'macaddr', 'encryption', 'key', 'key',                   'auth_server', 'auth_port', 'ssid', 'encryption', 'key','key'];
-	var wirelessParams=["5", "5", "36","36","36", 'Gargoyle', default5ID, 'none','','',        'Guests', '', defaultGuest5ID, '', 'none', '', '',                                  '', '', 'ExistingWireless', 'none', '',''];
-	var wirelessFunctions=[lsv, lsv, lsv,lsv, lsv, lv, lv, lsv, lv, lv,                                                                                                 lv, lv, lv, lv, lsv, lv, lv,                                                        lv, lv, lv, lsv, lv, lv];
+	var wirelessSections=[wifiDevG, wifiDevG, wifiDevA, wifiDevA, wifiDevA, apgcfg, apacfg, apcfg, apcfg,                                                                apgngcfg, apgngcfg, apgnacfg, apgnacfg, apgncfg, apgncfg,               apcfg, apcfg, othercfg, othercfg, othercfg];
+	var wirelessOptions=['channel', 'channel', 'channel', 'channel2', 'channel', 'ssid', 'ssid', 'encryption', 'key',                                                    'ssid', 'macaddr', 'ssid', 'macaddr', 'encryption', 'key',                   'auth_server', 'auth_port', 'ssid', 'encryption', 'key'];
+	var wirelessParams=["5", "5", "36","36","36", 'Gargoyle', default5ID, 'none','',        'Guests', '', defaultGuest5ID, '', 'none', '',                                  '', '', 'ExistingWireless', 'none', ''];
+	var wirelessFunctions=[lsv, lsv, lsv,lsv, lsv, lv, lv, lsv, lv,                                                                                                 lv, lv, lv, lv, lsv, lv,                                                        lv, lv, lv, lsv, lv];
 
 	loadVariables(uciOriginal, wirelessIds, wirelessPkgs, wirelessSections, wirelessOptions, wirelessParams, wirelessFunctions);
 
@@ -2581,18 +2546,9 @@ function resetData()
 	while (encryptNum <= 2)
 	{
 		encMode = document.getElementById('wifi_encryption' + encryptNum).value;
-		if(encMode == 'wep')
+		if(encMode == 'none')
 		{
 			document.getElementById('wifi_pass' + encryptNum).value = '';
-		}
-		else if(encMode != 'none')
-		{
-			document.getElementById('wifi_wep' + encryptNum).value = '';
-		}
-		else
-		{
-			document.getElementById('wifi_pass' + encryptNum).value = '';
-			document.getElementById('wifi_wep' + encryptNum).value = '';
 		}
 		encryptNum++;
 	}
@@ -2709,16 +2665,6 @@ function setChannel(selectElement)
 function resetWirelessMode()
 {
 	setSelectedValue('wifi_mode', getWirelessMode(uciOriginal));
-}
-
-function validateWep(text)
-{
-	return (validateHex(text) == 0 && (text.length == 10 || text.length == 26)) ? 0 : 1;
-}
-
-function proofreadWep(input)
-{
-	proofreadText(input, validateWep, 0);
 }
 
 function validatePass(text, encryption)
@@ -2904,9 +2850,7 @@ function setSsidVisibility(selectId)
 
 
 			'wifi_pass2_container',
-			'wifi_wep2_container',
 			'bridge_pass_container',
-			'bridge_wep_container'
 			];
 
 	var isAp = getSelectedValue("wifi_mode").match(/ap/) && document.getElementById("global_gateway").checked ? 1 : 0;
@@ -3022,20 +2966,16 @@ function setSsidVisibility(selectId)
 		var be = getSelectedValue('bridge_encryption');
 		var we = getSelectedValue('wifi_encryption2');
 		var bp = be.match(/sae/) || be.match(/psk/) || be.match(/WPA/) ? 1 : 0;
-		var bw = be.match(/wep/) || be.match(/WEP/) ? 1 : 0;
 		var wp = we.match(/sae/) || we.match(/psk/) || we.match(/WPA/) ? 1 : 0;
-		var ww = we.match(/wep/) || we.match(/WEP/) ? 1 : 0;
-		setVisibility(visIds , [1,ic,0,ic,inc,ic,inc,  1,ic,0,ic,inc,ic,inc,  ic*isAp,inc*isAp,  wp,ww,bp,bw] );
+		setVisibility(visIds , [1,ic,0,ic,inc,ic,inc,  1,ic,0,ic,inc,ic,inc,  ic*isAp,inc*isAp,  wp,bp] );
 	}
 	else
 	{
 		var be = getSelectedValue('bridge_encryption');
 		var we = getSelectedValue('wifi_encryption2');
 		var bp = be.match(/sae/) || be.match(/psk/) || be.match(/WPA/) ? 1 : 0;
-		var bw = be.match(/wep/) || be.match(/WEP/) ? 1 : 0;
 		var wp = we.match(/sae/) || we.match(/psk/) || we.match(/WPA/) ? 1 : 0;
-		var ww = we.match(/wep/) || we.match(/WEP/) ? 1 : 0;
-		setVisibility(visIds, [0,0,1,1,0,1,0,          0,0,1,1,0,1,0,         isAp,0,    wp,ww,bp,bw] );
+		setVisibility(visIds, [0,0,1,1,0,1,0,          0,0,1,1,0,1,0,         isAp,0,    wp,bp] );
 	}
 
 	if(ic)
@@ -3194,10 +3134,6 @@ function parseWifiScan(rawScanOutput)
 			else if(encStr.match(/WPA PSK/))
 			{
 				enc = "psk"
-			}
-			else if(encStr.match(/WEP/))
-			{
-				enc = "wep"
 			}
 			else if(encStr.match(/none/))
 			{

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -3228,7 +3228,7 @@ function setChannelWidth(selectCtl, band)
 			aChannels = []
 			var valid40 = [36, 44, 52, 60, 100, 108, 116, 124, 132, 140, 149, 157, 165, 173]
 			var valid80 = [36, 52, 100, 116, 132, 149, 165]
-			var valid160 = [36, 100]
+			var valid160 = [36, 100, 149]
 			valid40 = channelBondCheck(origAChan,band,valid40,2,1);
 			valid80 = channelBondCheck(origAChan,band,valid80,4,1);
 			valid160 = channelBondCheck(origAChan,band,valid160,8,1);


### PR DESCRIPTION
I propose quite big set of changes:

The first one is handling Wifi6 on 2.4GHz.

I think that some options should be dropped:
- WiFi 2, because OpenWrt 21.02 and newer disable 802.11b by default
- ad-hoc - I think nobody even test it
- WPA1 - I could not think about any example of WPA1 AES device, which could not handle WPA2 AES;
- WEP - it is very weak and breaks WiFi4 (hostapd will disallow HT)
- WiFi 3 (802.11g and 802.11a) - I think that it is a good time to stop supporting ancient devices.

Some small fixes also attached:
- added channel 149 for 160MHz (in theory it is okay, but it would not probably appear often due to regulations)
- fixed wifi based on broadcom drivers (broken by introducing WiFi6)
- fixed invalid output from iw (when mac80211 supports 802.11ah)

I prepared branch for those all and I am open to discuss.
I also gave a chance to stay at WiFi3, when (and only when) radio does not support WiFi4.

If any special case needs handling, remember that Gargoyle here works as overlay for OpenWrt, you can still tweak these settings by editing /etc/config/wireless by your own.