### PR TITLE
additional devices, qosmon patch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ set_version_variables()
 	# set precise commit in repo to use 
 	# you can set this to an alternate commit 
 	# or empty to checkout latest
-	openwrt_commit="f7541aecdc0658051f492016733a64a1de4904bd"
+	openwrt_commit="94adc23fa693d1b129ce1718573dfb12594f20f8"
 	openwrt_abbrev_commit=$( echo "$openwrt_commit" | cut -b 1-7 )
 	
 

--- a/package/qos-gargoyle/src/qosmon.c
+++ b/package/qos-gargoyle/src/qosmon.c
@@ -764,6 +764,9 @@ void update_status( FILE* fd )
               cptr->cbw_flt/1000);
         cptr++;
     }
+    time_t now;
+    time(&now);
+    printw("Print time: %s\n",ctime(&now));
 
     refresh();
 #endif
@@ -1012,7 +1015,12 @@ int main(int argc, char *argv[])
         //select() returns 1 if there is data to read.
         //                 0 if the time has expired.
         //                -1 if a signal arrived. 
-        while  (sel_err=select(s+1, &fdmask, NULL, NULL, &timeout)) {
+        while  (sel_err=select(s+1, &fdmask, NULL, NULL, &timeout))
+        {
+              //Reset timeout value which may have been overwritten by select()
+              //Also halve it so that the loop is tighter
+              timeout.tv_sec = 0;
+              timeout.tv_usec = period*0.5*1000;
 
               //Signal arrived, just loop and keep waiting.
               if (sel_err == -1) continue;

--- a/targets/ath79/profiles/default/config
+++ b/targets/ath79/profiles/default/config
@@ -402,7 +402,8 @@ CONFIG_TARGET_PER_DEVICE_ROOTFS=y
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_avm_fritz300e is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_avm_fritz450e is not set
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_avm_fritzdvbc is not set
-# CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_belkin_f9j1108-v2 is not set
+CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_belkin_f9j1108-v2=y
+CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_belkin_f9j1108-v2="gargoyle-large"
 CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_belkin_f9k1115-v2=y
 CONFIG_TARGET_DEVICE_PACKAGES_ath79_generic_DEVICE_belkin_f9k1115-v2="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ath79_generic_DEVICE_buffalo_bhr-4grv is not set

--- a/targets/ath79/profiles/default/profile_images
+++ b/targets/ath79/profiles/default/profile_images
@@ -1,3 +1,4 @@
+belkin_f9j1108-v2-squashfs-
 belkin_f9k1115-v2-squashfs-
 buffalo_wzr-600dhp-squashfs-
 buffalo_wzr-hp-ag300h-squashfs-

--- a/targets/ramips/profiles/mt7621/config
+++ b/targets/ramips/profiles/mt7621/config
@@ -138,6 +138,7 @@ CONFIG_TARGET_MULTI_PROFILE=y
 # CONFIG_TARGET_ramips_mt7621_DEVICE_linksys_re6500 is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_mediatek_ap-mt7621a-v60 is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_mediatek_mt7621-eval-board is not set
+# CONFIG_TARGET_ramips_mt7621_DEVICE_mercusys_mr70x-v1 is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_mikrotik_routerboard-750gr3 is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_mikrotik_routerboard-760igs is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_mikrotik_routerboard-m11g is not set
@@ -174,6 +175,7 @@ CONFIG_TARGET_MULTI_PROFILE=y
 # CONFIG_TARGET_ramips_mt7621_DEVICE_thunder_timecloud is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_totolink_a7000r is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_totolink_x5000r is not set
+# CONFIG_TARGET_ramips_mt7621_DEVICE_tplink_archer-ax23-v1 is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_tplink_archer-a6-v3 is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_tplink_archer-c6-v3 is not set
 # CONFIG_TARGET_ramips_mt7621_DEVICE_tplink_archer-c6u-v1 is not set
@@ -359,6 +361,8 @@ CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_linksys_re6500=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_linksys_re6500="gargoyle-basic"
 # CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_mediatek_ap-mt7621a-v60 is not set
 # CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_mediatek_mt7621-eval-board is not set
+CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_mercusys_mr70x-v1=y
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_mercusys_mr70x-v1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_mikrotik_routerboard-750gr3=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_mikrotik_routerboard-750gr3="gargoyle-large"
 # CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_mikrotik_routerboard-760igs is not set
@@ -416,6 +420,8 @@ CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_totolink_x5000r=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_totolink_x5000r="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_archer-a6-v3=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_archer-a6-v3="gargoyle-large"
+CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_archer-ax23-v1=y
+CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_archer-ax23-v1="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_archer-c6-v3=y
 CONFIG_TARGET_DEVICE_PACKAGES_ramips_mt7621_DEVICE_tplink_archer-c6-v3="gargoyle-large"
 CONFIG_TARGET_DEVICE_ramips_mt7621_DEVICE_tplink_archer-c6u-v1=y

--- a/targets/ramips/profiles/mt7621/profile_images
+++ b/targets/ramips/profiles/mt7621/profile_images
@@ -40,6 +40,7 @@ linksys_ea7500-v2
 linksys_ea8100-v1
 linksys_ea8100-v2
 linksys_re6500
+mercusys_mr70x-v1
 mikrotik_routerboard-750gr3
 netgear_r6700-v2
 netgear_r6220
@@ -57,6 +58,7 @@ netgear_wndr3700-v5
 totolink_a7000r
 totolink_x5000r
 tplink_archer-a6-v3
+tplink_archer-ax23-v1
 tplink_archer-c6-v3
 tplink_archer-c6u-v1
 tplink_eap235-wall-v1


### PR DESCRIPTION
Add devices:
- mt7621: Mercusys MR70X v1 and TP-Link Archer AX23 v1
- ath79: Belkin F9J1108 v2

Bump OpenWrt to 22.03.4 (required to be able to add mt7621 devices above).

Patch by Lantis1008 to improve behaviour of qosmon.