### PR TITLE
ipq806x: stability mitigation for Netgear XR500, network performance improvement for all devices

### DIFF
--- a/targets/ipq806x/files/files/etc/init.d/pin_interrupts
+++ b/targets/ipq806x/files/files/etc/init.d/pin_interrupts
@@ -1,0 +1,9 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+boot() {
+	# pin ethernet interface interrupts
+	awk '/eth0/ { gsub(/:/,""); print $1 }' /proc/interrupts | while read irq; do echo "1" > /proc/irq/$irq/smp_affinity; done
+	awk '/eth1/ { gsub(/:/,""); print $1 }' /proc/interrupts | while read irq; do echo "2" > /proc/irq/$irq/smp_affinity; done
+}

--- a/targets/ipq806x/patches/002-r7800_stability.patch
+++ b/targets/ipq806x/patches/002-r7800_stability.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/package/base-files/files/etc/init.d/r7800stability
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,12 @@
 +#!/bin/sh /etc/rc.common
 +
 +START=99
@@ -8,6 +8,9 @@
 +boot()
 +{
 +	dev=$(cat /tmp/sysinfo/board_name | grep "netgear,r7800")
++	if [ -z "$dev" ] ; then
++		dev=$(cat /tmp/sysinfo/board_name | grep "netgear,xr500")
++	fi
 +	[ -n "$dev" ] && { echo "performance" > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor; echo "performance" > /sys/devices/system/cpu/cpufreq/policy1/scaling_governor; }
 +}
 --- a/package/base-files/Makefile


### PR DESCRIPTION
Commit 537fdc6 adds the Netgear XR500 to the existing stability mitigation script (same base hardware as R7800).

Commit 662c384 improves network throughput, especially when QOS is enabled, by pinning ethernet interface interrupts to different CPUs.