### PR TITLE
ramips: add build support for US/CA/TW variants of Archer AX23v1

### DIFF
--- a/targets/ramips/patches/001-tplink-safeloader-add-Archer-AX23-US_CA_TW.patch
+++ b/targets/ramips/patches/001-tplink-safeloader-add-Archer-AX23-US_CA_TW.patch
@@ -1,0 +1,47 @@
+--- a/tools/firmware-utils/patches/001-tplink-safeloader-add-Archer-AX23.patch
++++ b/tools/firmware-utils/patches/001-tplink-safeloader-add-Archer-AX23.patch
+@@ -62,7 +62,7 @@
+ 
+ --- a/src/tplink-safeloader.c
+ +++ b/src/tplink-safeloader.c
+-@@ -874,6 +874,49 @@ static struct device_info boards[] = {
++@@ -874,6 +874,53 @@ static struct device_info boards[] = {
+  		.last_sysupgrade_partition = "file-system",
+  	},
+  
+@@ -78,7 +78,11 @@
+ +			"{product_name:Archer AX23,product_ver:1.20,special_id:4A500000}\n"
+ +			"{product_name:Archer AX23,product_ver:1.0,special_id:4B520000}\n"
+ +			"{product_name:Archer AX23,product_ver:1.0,special_id:52550000}\n"
+-+			"{product_name:Archer AX1800,product_ver:1.20,special_id:52550000}\n",
+++			"{product_name:Archer AX1800,product_ver:1.20,special_id:52550000}\n"
+++			"{product_name:Archer AX23,product_ver:1.0.0,special_id:55530000}\n"
+++			"{product_name:Archer AX23,product_ver:1.20,special_id:55530000}\n"
+++			"{product_name:Archer AX23,product_ver:1.0.0,special_id:43410000}\n"
+++			"{product_name:Archer AX23,product_ver:1.0.0,special_id:54570000}\n",
+ +		.part_trail = 0x00,
+ +		.soft_ver = SOFT_VER_TEXT("soft_ver:3.0.3\n"),
+ +
+@@ -100,9 +104,9 @@
+ +			{"logo", 0xfde000, 0x02000},
+ +			{"partition-table", 0xfe0000, 0x00800},
+ +			{"soft-version", 0xfe0800, 0x00100},
+-+			{"support-list", 0xfe0900, 0x00200},
+-+			{"profile", 0xfe0b00, 0x03000},
+-+			{"extra-para", 0xfe3b00, 0x00100},
+++			{"support-list", 0xfe0900, 0x00400},
+++			{"profile", 0xfe0d00, 0x03000},
+++			{"extra-para", 0xfe3d00, 0x00100},
+ +			{"radio", 0xff0000, 0x10000},
+ +			{NULL, 0, 0}
+ +		},
+@@ -112,7 +116,7 @@
+  	/** Firmware layout for the C2v3 */
+  	{
+  		.id     = "ARCHER-C2-V3",
+-@@ -3353,6 +3396,7 @@ static void build_image(const char *outp
++@@ -3353,6 +3400,7 @@ static void build_image(const char *outp
+  	if (strcasecmp(info->id, "ARCHER-A6-V3") == 0 ||
+  	    strcasecmp(info->id, "ARCHER-A7-V5") == 0 ||
+  	    strcasecmp(info->id, "ARCHER-A9-V6") == 0 ||
+


### PR DESCRIPTION
Discussion: https://forum.openwrt.org/t/add-support-for-tp-link-ax23-v1/130746/25

The patch added with this commit will need to be removed if OpenWrt backports these changes to 22.03 or Gargoyle moves to a newer OpenWrt branch.

Backported commits:
* https://github.com/openwrt/firmware-utils/commit/6a58f456109008620dd15267a7ff0594095e0d77
* https://github.com/openwrt/firmware-utils/commit/e8191eb7efc2804d33feb18573c96e632a6c1086