### PR TITLE
configure_printer: improve service discovery records

### DIFF
--- a/package/plugin-gargoyle-usb-printer/files/usr/lib/gargoyle/configure_printer.sh
+++ b/package/plugin-gargoyle-usb-printer/files/usr/lib/gargoyle/configure_printer.sh
@@ -90,6 +90,8 @@ if [ -n "$printer" ] ; then
 	domain=$(uci get dhcp.@dnsmasq[0].domain)
 	hostname=$(uci get system.@system[0].hostname)
 	revip=$(uci get network.lan.ipaddr | sed 's/\./ /g' | awk ' { print "0."$3"."$2"."$1 ; }')
+	printername="${printer// /_}"
+	manufacturer=$(printf "%s" "$usb_device_lines" | grep "Driver=usblp" | sed 's/^.*Manufacturer=//g' | sed 's/ .:.*$//g'| head -n1)
 	dnsmasqConfLines=""
 	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\nptr-record=b._dns-sd._udp.$revip.in-addr.arpa,$domain\n")
 	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\nptr-record=db._dns-sd._udp.$revip.in-addr.arpa,$domain\n")
@@ -97,9 +99,9 @@ if [ -n "$printer" ] ; then
 	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\nptr-record=dr._dns-sd._udp.$revip.in-addr.arpa,$domain\n")
 	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\nptr-record=lb._dns-sd._udp.$revip.in-addr.arpa,$domain\n")
 	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\nptr-record=_services._dns-sd._udp.$domain,_pdl-datastream._tcp.$domain\n")
-	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\nptr-record=_pdl-datastream._tcp.$domain,$hostname._pdl-datastream._tcp.$domain\n")
-	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\nsrv-host=Gargoyle._pdl-datastream._tcp.$domain,$hostname.$domain,9100\n")
-	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\ntxt-record=$hostname._pdl-datastream._tcp.$domain,ty=$printer,product=($printer),usb_MDL=$printer,txtvers=1,qtotal=1,priority=20\n")
+	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\nptr-record=_pdl-datastream._tcp.$domain,$printername._pdl-datastream._tcp.$domain\n")
+	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\nsrv-host=$printername._pdl-datastream._tcp.$domain,$hostname.$domain,9100\n")
+	dnsmasqConfLines=$(printf "${dnsmasqConfLines}\ntxt-record=$printername._pdl-datastream._tcp.$domain,ty=$printer,product=($printer),usb_MDL=$printer,usb_MFG=$manufacturer,note=$hostname,pdl=raw,txtvers=1,qtotal=1,priority=20\n")
 
 
 	update_dnsmasq_conf "/etc/dnsmasq.conf" "$dnsmasqConfLines"


### PR DESCRIPTION
This PR corrects the service discovery DNS records that are added to the dnsmasq configuration when a printer is detected. 

For static service discovery records being served from a unicast DNS server, the PTR record that associates a service (e.g. _pdl-datastream._tcp) with a hostname needs to have [matching SRV and TXT records](http://pig.made-it.com/cups-dns-sd.html) for that hostname. Currently the SRV is always set to "Gargoyle"; I've changed it and the PTR and TXT records to use the printer name with spaces replaced with underscores.

This also adds some logic that fetches the device manufacturer from the USB device and includes it as the `usb_MFG` attribute, which may help OSes with picking the correct printer driver, along with two more attributes that set the `note` to the router hostname and `pdl` to "raw". 

On macOS with these changes, the printer now shows up in the printer browser with the printer name and the hostname as the Location.
<img width="885" alt="printers3" src="https://github.com/ericpaulbishop/gargoyle/assets/3324775/79d6f392-7014-4a7d-b96e-f410c4cd8b9c">

For reference, here's what a series of DNS queries for successful unicast service discovery could look like (assuming a search domain of "home" is set on a 10.10.1.0/24 network):
```
$ dig +short PTR b._dns-sd._udp.0.1.10.10.in-addr.arpa
home.
$ dig +short PTR _services._dns-sd._udp.home
_pdl-datastream._tcp.home.
$ dig +short PTR _pdl-datastream._tcp.home
HP_LaserJet_1020._pdl-datastream._tcp.home.
$ dig +short SRV HP_LaserJet_1020._pdl-datastream._tcp.home
0 0 9100 ArcherC7v4.home.
$ dig +short TXT HP_LaserJet_1020._pdl-datastream._tcp.home
"ty=HP LaserJet 1020" "product=(HP LaserJet 1020)" "usb_MDL=HP LaserJet 1020" "usb_MFG=Hewlett-Packard" "note=ArcherC7v4" "pdl=raw" "txtvers=1" "qtotal=1" "priority=20"
```
