### PR TITLE
Fixed empty temperature display

### DIFF
--- a/package/gargoyle/files/usr/lib/gargoyle/tempinfo.sh
+++ b/package/gargoyle/files/usr/lib/gargoyle/tempinfo.sh
@@ -31,8 +31,8 @@ case "$tmodel" in
 	TEMPWIFI="-";
 	show_temp=0;
 	# Try to load whatever info we can find from hwmon or thermal_zone
-	[ -e /sys/class/thermal/thermal_zone0/temp ] && { TEMPCPU=$(cut -c1-2 /sys/class/thermal/thermal_zone0/temp); show_temp=1; };
-	[ -e /sys/class/hwmon/hwmon0/temp1_input ] && { TEMPCPU=$(cut -c1-2 /sys/class/hwmon/hwmon0/temp1_input); show_temp=1; };;
+	[ -e /sys/class/thermal/thermal_zone0/temp ] && { TEMPCPU=$(cut -c1-2 /sys/class/thermal/thermal_zone0/temp); [ -n "$TEMPCPU" ] && show_temp=1; };
+	[ -e /sys/class/hwmon/hwmon0/temp1_input ] && { TEMPCPU=$(cut -c1-2 /sys/class/hwmon/hwmon0/temp1_input); [ -n "$TEMPCPU" ] && show_temp=1; };;
 esac
 
 echo "temps.push(\"$show_temp\",\"$TEMPCPU\",\"$TEMPMEM\",\"$TEMPWIFI\");"


### PR DESCRIPTION
In some cases (ipq40xx), it fails to read the temperature and returns an empty value:
```
root@Gargoyle:~# /usr/lib/gargoyle/tempinfo.sh
temps.push("1","","-","-");
```
because:
```
root@Gargoyle:~# sh -x /usr/lib/gargoyle/tempinfo.sh
+ '[' -e /tmp/sysinfo/model ]
+ cat /tmp/sysinfo/model
+ tmodel='Cell C RTL30VW'
+ show_temp=1
+ TEMPCPU=-
+ TEMPMEM=-
+ TEMPWIFI=-
+ show_temp=0
+ '[' -e /sys/class/thermal/thermal_zone0/temp ]
+ '[' -e /sys/class/hwmon/hwmon0/temp1_input ]
+ cut -c1-2 /sys/class/hwmon/hwmon0/temp1_input
+ TEMPCPU=
+ show_temp=1
+ echo 'temps.push("1","","-","-");'
temps.push("1","","-","-");
+ exit 0
```
Fix this.