### PR TITLE
Enable ext4 journaling in images with ext4 filesystems

### DIFF
--- a/patches-generic/140-enable_ext4_rootfs_journalling.patch
+++ b/patches-generic/140-enable_ext4_rootfs_journalling.patch
@@ -1,0 +1,29 @@
+From f9f2426e398cf74d1098ae40317bfba677ac7560 Mon Sep 17 00:00:00 2001
+From: Jordan Woyak <jordan.woyak@gmail.com>
+Date: Mon, 25 Mar 2024 20:56:06 -0500
+Subject: [PATCH] config: Enable ext4 journaling by default.
+
+Not having a journal by default is a major "gotcha".
+
+Because openwrt does not fsck on boot, a power loss without journaling
+can result in a dirty filesystem that openwrt will mount as read-only
+which requires intervention to restore the router to working order.
+
+Signed-off-by: Jordan Woyak <jordan.woyak@gmail.com>
+---
+ config/Config-images.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/config/Config-images.in b/config/Config-images.in
+index c2d7af7a80b10..6f2f92643234d 100644
+--- a/config/Config-images.in
++++ b/config/Config-images.in
+@@ -127,6 +127,7 @@ menu "Target Images"
+ 		config TARGET_EXT4_JOURNAL
+ 			bool "Create a journaling filesystem"
+ 			depends on TARGET_ROOTFS_EXT4FS
++			default y
+ 			help
+ 			  Create an ext4 filesystem with a journal.
+ 
+


### PR DESCRIPTION
Having journaling enabled will reduce problems arising from power loss induced dirty ext4 root filesystems, which would otherwise require intervention to return the router to normal booting.

Journaling can be manually enabled on existing ext4 filesystems with tunefs.

Imported from OpenWrt main branch (commit f9f2426e398cf74d1098ae40317bfba677ac7560)

NB: - this change only affects ext4 filesystems in images that get directly written to
      storage media (e.g. dd'ed to SD cards or disk); currently only the x86 and
      bcm27xx targets build such images.
    - this patch will need to be removed when Gargoyle transitions to a future
      OpenWrt stable branch.