### PR TITLE
Gargoyle UI: add packet steering option to Connection/Advanced page

### DIFF
--- a/package/gargoyle/files/www/advanced.sh
+++ b/package/gargoyle/files/www/advanced.sh
@@ -23,6 +23,8 @@
 	if [ -e ./data/countrylist.txt ] ; then
 		awk '{gsub(/"/, "\\\""); print "countryLines.push(\""$0"\");"}' ./data/countrylist.txt	
 	fi
+
+	echo "var num_cpus=$(grep -c processor /proc/cpuinfo);"
 %>
 //-->
 </script>
@@ -83,6 +85,25 @@
 					<label class="col-xs-5" for="usteer_comms"><%~ ShrAPClnts %>:</label>
 					<div class="col-xs-7">
 						<select class="form-control" id="usteer_comms">
+							<option value="0"><%~ Disabled %></option>
+							<option value="1"><%~ Enabled %></option>
+						</select>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col-lg-6" id="netopt_container" style="display:none">
+		<div class="panel panel-default">
+			<div class="panel-heading">
+				<h3 class="panel-title"><%~ NetOptTitle %></h3>
+			</div>
+			<div class="panel-body">
+				<div id="pktsteer_opt_container" class="row form-group">
+					<label class="col-xs-5" for="pktsteer_opt"><%~ PktSteer %>:</label>
+					<div class="col-xs-7">
+						<select class="form-control" id="pktsteer_opt">
 							<option value="0"><%~ Disabled %></option>
 							<option value="1"><%~ Enabled %></option>
 						</select>

--- a/package/gargoyle/files/www/js/advanced.js
+++ b/package/gargoyle/files/www/js/advanced.js
@@ -22,6 +22,8 @@ function resetData()
 	setUSteerCommsVisibility();
 	// WAN
 	setModemNetworkVisibility();
+	// NetworkOpts
+	setPktSteeringVisibility();
 
 	setGlobalVisibility();
 }
@@ -77,6 +79,13 @@ function saveChanges()
 		uci.removeSection('network','modem');
 	}
 
+	// NetworkOpts
+	if(num_cpus > 1)
+	{
+		var selPktSteerOpt = getSelectedValue('pktsteer_opt');
+		uci.set('network', 'globals', 'packet_steering', selPktSteerOpt);
+	}
+
 	var restartNetworkCommand = "\nsh /usr/lib/gargoyle/restart_network.sh;\n";
 	var regenerateCacheCommand = "\nrm -rf /tmp/cached_basic_vars ;\n/usr/lib/gargoyle/cache_basic_vars.sh >/dev/null 2>/dev/null\n";
 	var commands = uci.getScriptCommands(uciCompare);
@@ -96,6 +105,11 @@ function saveChanges()
 	if(commands.match(/network\.modem/))
 	{
 		// Modem network is being created/destroyed
+		shouldRestartNetwork = true;
+	}
+	if(commands.match(/packet_steering/))
+	{
+		// Packet steering option is being changed
 		shouldRestartNetwork = true;
 	}
 
@@ -125,6 +139,7 @@ function arrayMoveIdx(arr, fromIdx, toIdx)
 function setGlobalVisibility()
 {
 	var anyVis = 0;
+	anyVis += setNetOptContainerVisibility();
 	anyVis += setWirelessContainerVisibility();
 	anyVis += setLANContainerVisibility();
 	anyVis += setWANContainerVisibility();
@@ -216,6 +231,25 @@ function setWirelessCountryVisibility()
 	// If we already had a selection, set it again
 	selCountry = currentSel == "" ? selCountry : currentSel;
 	setSelectedValue('wireless_country',selCountry);
+}
+
+function setNetOptContainerVisibility()
+{
+	var retVal = 0;
+	var vis = 'none';
+
+	if(num_cpus > 1)
+	{
+		retVal = 1;
+		vis = 'block';
+	}
+	byId('netopt_container').style.display = vis;
+	return retVal;
+}
+
+function setPktSteeringVisibility()
+{
+	loadSelectedValueFromVariable(['pktsteer_opt',uciOriginal,'network','globals','packet_steering','0']);
 }
 
 function parseCountry(countryLines)

--- a/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/advanced.js
+++ b/package/plugin-gargoyle-i18n-English-EN/files/www/i18n/English-EN/advanced.js
@@ -13,4 +13,6 @@ advancedStr.ShrAPClnts="Share connected Wireless Client information to other Gar
 advancedStr.ModemNet="Create network interface to access upstream modem?";
 advancedStr.ModemSMsk="(same as modem subnet)";
 advancedStr.ModemIP="(IP must be in modem subnet)";
-
+// Network options
+advancedStr.NetOptTitle="Global network options";
+advancedStr.PktSteer="Activate packet steering?";

--- a/package/plugin-gargoyle-i18n-Polish-PL/files/www/i18n/Polish-PL/advanced.js
+++ b/package/plugin-gargoyle-i18n-Polish-PL/files/www/i18n/Polish-PL/advanced.js
@@ -13,3 +13,6 @@ advancedStr.ShrAPClnts="Udostępnianie informacji o podłączonych klientach bez
 advancedStr.ModemNet="Tworzenie interfejsu sieciowego, aby uzyskać dostęp do modemu nadrzędnego";
 advancedStr.ModemSMsk="(taka jak maska modemu)";
 advancedStr.ModemIP="(IP musi być z tej samej klasy co ma modem)";
+// Network options
+advancedStr.NetOptTitle="Opcje sieci globalnej";
+advancedStr.PktSteer="Aktywować sterowanie pakietami?";


### PR DESCRIPTION
Add the ability to enable/disable Packet Steering as in OpenWrt's
Interfaces/Global Network Options page.

Packet steering is only useful for multi-cpu devices so don't show
the option if the device has only 1 cpu.

Polish is the only language plugin with translations for the Advanced options
page so update it (translations produced using Google Translate) for packet
steering.