### PR TITLE
fon-flash: fix aarch64 where char can be unsigned

### DIFF
--- a/fon-flash/fon-flash.cpp
+++ b/fon-flash/fon-flash.cpp
@@ -1231,7 +1231,7 @@ int main(int argc, char* argv[])
 	int num_files_expected = 0;
 	int num_files_found = 0;
 	
-	char c;	
+	int c;
 	while((c = getopt(argc, argv, "C:c:I:i:")) != -1)
 	{	
 		switch(c)
@@ -1341,7 +1341,7 @@ int main(int argc, char* argv[])
 {
 	char* iface = NULL;
 
-	char c;	
+	int c;
 	while((c = getopt(argc, argv, "I:i:")) != -1)
 	{	
 		switch(c)


### PR DESCRIPTION
In Homebrew, we are currently building binaries for aarch64 (armv8-a) on GitHub's `ubuntu-22.04-arm` runner using the system GCC 11. The resulting `fon-flash` binary ended up never exited.

This seems like common issue of porting to ARM where `char` can be unsigned - https://developer.arm.com/documentation/den0013/d/Porting/Miscellaneous-C-porting-issues/unsigned-char-and-signed-char

I think the type can just be made into `int` like official documentation for `getopt()`