### PR TITLE
packet steering: update for OpenWrt 24.10

### DIFF
--- a/package/gargoyle/files/www/advanced.sh
+++ b/package/gargoyle/files/www/advanced.sh
@@ -106,6 +106,7 @@
 						<select class="form-control" id="pktsteer_opt">
 							<option value="0"><%~ Disabled %></option>
 							<option value="1"><%~ Enabled %></option>
+							<option value="2"><%~ Enabled (All CPUs) %></option>
 						</select>
 					</div>
 				</div>

--- a/package/gargoyle/files/www/js/advanced.js
+++ b/package/gargoyle/files/www/js/advanced.js
@@ -249,7 +249,7 @@ function setNetOptContainerVisibility()
 
 function setPktSteeringVisibility()
 {
-	loadSelectedValueFromVariable(['pktsteer_opt',uciOriginal,'network','globals','packet_steering','0']);
+	loadSelectedValueFromVariable(['pktsteer_opt',uciOriginal,'network','globals','packet_steering','1']);
 }
 
 function parseCountry(countryLines)


### PR DESCRIPTION
add additional option value (`Enabled (All CPUs)`) and set `Enabled` as default