### PR TITLE
bwmon: fix CSV export on 32bit targets

### DIFF
--- a/package/libiptbwctl/src/ipt_bwctl.c
+++ b/package/libiptbwctl/src/ipt_bwctl.c
@@ -1424,7 +1424,7 @@ void print_histories(FILE* out, char* id, ip_bw_history* histories, unsigned lon
 					}
 					else
 					{
-						fprintf(out, "%s,%s,%ld,%ld,%lld\n", id, ip_str, start, end, (unsigned long long int)bw );
+						fprintf(out, "%s,%s,%lld,%lld,%lld\n", id, ip_str, start, end, (unsigned long long int)bw );
 					}
 				
 	

--- a/package/libnftbwctl/src/nft_bwctl.c
+++ b/package/libnftbwctl/src/nft_bwctl.c
@@ -1424,7 +1424,7 @@ void print_histories(FILE* out, char* id, ip_bw_history* histories, unsigned lon
 					}
 					else
 					{
-						fprintf(out, "%s,%s,%ld,%ld,%lld\n", id, ip_str, start, end, (unsigned long long int)bw );
+						fprintf(out, "%s,%s,%lld,%lld,%lld\n", id, ip_str, start, end, (unsigned long long int)bw );
 					}
 				
 	


### PR DESCRIPTION
OpenWrt 24.10 uses musl 1.2.x which has 64bit time_t on all architechtures requiring "%lld" formatting for time_t values.

Fix applied to old iptables version of bwmon as well as current nftables version, though iptables change is untested.

nftables change tested on the following targets:
- big endian 32bit: ath79
- little endian 32bit: ipq40xx, mt7621
- little endian 64bit: filogic, bcm2711